### PR TITLE
Cicle wallpaper and theme

### DIFF
--- a/Configs/.local/lib/hyde/cyclewallpaperandtheme.sh
+++ b/Configs/.local/lib/hyde/cyclewallpaperandtheme.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+
+# Paths to "hyde" scripts
+WALL_SCRIPT="$HOME/.local/share/bin/swwwallpaper.sh"
+THEME_SCRIPT="$HOME/.local/share/bin/themeswitch.sh"
+
+# Log file for debugging
+LOG_FILE="$HOME/.local/share/cyclewallpaperandtheme.log"
+
+# State tracking files
+WALL_CYCLE_FILE="$HOME/.local/share/cyclewallpapercount"
+THEME_CYCLE_FILE="$HOME/.local/share/cyclethemecount"
+THEME_CHANGE_FLAG_FILE="$HOME/.local/share/cyclethemeflag"
+
+# Directory where themes are stored
+THEMES_DIR="$HOME/.config/hyde/themes"
+
+# If it's time to change the theme
+if [ -f "$THEME_CHANGE_FLAG_FILE" ]; then
+    # Get the list of themes and cycle through them (ensure spaces in file names are treated correctly)
+    themes=()
+    while IFS= read -r theme; do
+        themes+=("$theme")
+    done < <(find "$THEMES_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+    themes=("${themes[@]##*/}")  # Strip path to get only names
+
+    # Read or initialize the theme counter
+    if [ ! -f "$THEME_CYCLE_FILE" ]; then
+        echo 0 > "$THEME_CYCLE_FILE"
+    fi
+    theme_count=$(cat "$THEME_CYCLE_FILE")
+
+    # Get the theme in the list and set it
+    next_theme="${themes[$theme_count]}"
+    "$THEME_SCRIPT" -s "$next_theme" >> "$LOG_FILE" 2>&1
+
+    # Update the theme counter
+    echo $((theme_count + 1)) > "$THEME_CYCLE_FILE"
+
+    # Sleep for 3 seconds to ensure theme is totally changed and new variables are set
+    sleep 3
+
+    # Clear the theme change flag
+    rm "$THEME_CHANGE_FLAG_FILE"
+fi
+
+# Extract the current theme from the config file
+current_theme=$(grep -oP '(?<=^hydeTheme=").*(?=")' "$HOME/.config/hyde/hyde.conf")
+
+if [ -z "$current_theme" ] || [ ! -d "$THEMES_DIR/$current_theme" ]; then
+    echo "ERROR: Unable to determine current theme or theme directory does not exist" >> "$LOG_FILE"
+    exit 1
+fi
+
+WALLPAPER_DIR="$THEMES_DIR/$current_theme/wallpapers"
+
+# Check if the wallpaper directory exists
+if [ ! -d "$WALLPAPER_DIR" ]; then
+    echo "ERROR: Wallpaper directory for theme '$current_theme' does not exist: $WALLPAPER_DIR" >> "$LOG_FILE"
+    exit 1
+fi
+
+# Read or initialize the wallpaper counter
+if [ ! -f "$WALL_CYCLE_FILE" ]; then
+    echo 0 > "$WALL_CYCLE_FILE"
+fi
+wall_count=$(cat "$WALL_CYCLE_FILE")
+
+# Get list of wallpapers and set it
+wallpapers=("$WALLPAPER_DIR"/*)
+"$WALL_SCRIPT" -s "${wallpapers[$wall_count]}" >> "$LOG_FILE" 2>&1
+# Call the setsddmwallpaper script to update the login screen wallpaper
+"$HOME/.local/share/bin/setsddmwallpaper.sh" "${wallpapers[$wall_count]}" >> "$LOG_FILE" 2>&1
+
+# If all wallpapers have been cycled, set the flag to change the theme on the next run
+if [ "$wall_count" -ge $(( ${#wallpapers[@]} - 1 )) ]; then
+    echo "theme_change_needed" > "$THEME_CHANGE_FLAG_FILE"
+    # Reset wallpaper counter for the next run
+    echo 0 > "$WALL_CYCLE_FILE"
+else
+    # Increment wallpaper count and update the file
+    wall_count=$((wall_count + 1))
+    echo $wall_count > "$WALL_CYCLE_FILE"
+fi
+
+echo "Wallpaper and theme updated successfully." >> "$LOG_FILE"

--- a/Configs/.local/lib/hyde/setsddmwallpaper.sh
+++ b/Configs/.local/lib/hyde/setsddmwallpaper.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+##################################################
+### This will only work if using Corners theme ###
+##################################################
+
+# Check if the wallpaper path argument is provided
+if [ -z "$1" ]; then
+    echo "ERROR: No wallpaper path provided."
+    exit 1
+fi
+
+WALLPAPER_PATH="$1"
+
+# Ensure the wallpaper path is quoted to handle spaces
+if [ ! -f "$WALLPAPER_PATH" ]; then
+    echo "ERROR: Wallpaper file does not exist: $WALLPAPER_PATH"
+    exit 1
+fi
+
+# Set the path to the theme configuration file
+SDDM_THEME_CONFIG="/usr/share/sddm/themes/Corners/theme.conf"
+
+# Set the background directory for SDDM theme
+BACKGROUND_DIR="/usr/share/sddm/themes/Corners/backgrounds"
+
+# Define the fixed name for the wallpaper
+WALLPAPER_NAME="customwallpaper"
+
+# Copy the wallpaper to the backgrounds directory with the fixed name
+cp -f "$WALLPAPER_PATH" "$BACKGROUND_DIR/$WALLPAPER_NAME"
+
+# Update the theme configuration file to point to the new background
+sed -i "s|^Background=.*|Background=\"backgrounds/$WALLPAPER_NAME\"|" "$SDDM_THEME_CONFIG"
+
+echo "SDDM wallpaper updated successfully to: backgrounds/$WALLPAPER_NAME"

--- a/Configs/.local/lib/hyde/setsddmwallpaper.sh
+++ b/Configs/.local/lib/hyde/setsddmwallpaper.sh
@@ -1,36 +1,29 @@
 #!/usr/bin/env sh
 
-##################################################
-### This will only work if using Corners theme ###
-##################################################
+# Configuration
+SDDM_THEME_CONFIG="/usr/share/sddm/themes/Corners/theme.conf"
+BACKGROUND_DIR="/usr/share/sddm/themes/Corners/backgrounds"
+WALLPAPER_NAME="customwallpaper"
 
-# Check if the wallpaper path argument is provided
+# Log messages
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') $1"
+}
+
+# Validate input
 if [ -z "$1" ]; then
-    echo "ERROR: No wallpaper path provided."
+    log "ERROR: No wallpaper path provided."
     exit 1
 fi
 
 WALLPAPER_PATH="$1"
-
-# Ensure the wallpaper path is quoted to handle spaces
 if [ ! -f "$WALLPAPER_PATH" ]; then
-    echo "ERROR: Wallpaper file does not exist: $WALLPAPER_PATH"
+    log "ERROR: Wallpaper file does not exist: $WALLPAPER_PATH"
     exit 1
 fi
 
-# Set the path to the theme configuration file
-SDDM_THEME_CONFIG="/usr/share/sddm/themes/Corners/theme.conf"
-
-# Set the background directory for SDDM theme
-BACKGROUND_DIR="/usr/share/sddm/themes/Corners/backgrounds"
-
-# Define the fixed name for the wallpaper
-WALLPAPER_NAME="customwallpaper"
-
-# Copy the wallpaper to the backgrounds directory with the fixed name
+# Update SDDM wallpaper
 cp -f "$WALLPAPER_PATH" "$BACKGROUND_DIR/$WALLPAPER_NAME"
-
-# Update the theme configuration file to point to the new background
 sed -i "s|^Background=.*|Background=\"backgrounds/$WALLPAPER_NAME\"|" "$SDDM_THEME_CONFIG"
 
-echo "SDDM wallpaper updated successfully to: backgrounds/$WALLPAPER_NAME"
+log "SDDM wallpaper updated to: $BACKGROUND_DIR/$WALLPAPER_NAME"


### PR DESCRIPTION
# Pull Request

## Description

This pull aims to append two new scripts that can cycle through all installed wallpapers and themes and set them for the desktop and SDDM Corners theme. This is useful for those who want to see all wallpapers and themes they have installed or just is undecided on which one to use; for the latter, the user can set a cronjob to run the script periodically, thus having a new look on its PC from time to time.

(SDDM wallpaper will match the one on the desktop)

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
