### PR TITLE
authorization from wayland

### DIFF
--- a/Scripts/pkg_core.lst
+++ b/Scripts/pkg_core.lst
@@ -48,6 +48,7 @@ qt5-imageformats                                       # for dolphin image thumb
 ffmpegthumbs                                           # for dolphin video thumbnails
 kde-cli-tools                                          # for dolphin file type defaults
 libnotify                                              # for notifications
+xorg-xhost                                             # authorization from wayland
 
 # --------------------------------------------------- // Theming
 nwg-look                                               # gtk configuration tool


### PR DESCRIPTION
run scripts and applications that do not detect resolution, this is very good and recommended. I use auditing tools and that is necessary even for applications 
![241215_13h09m21s_screenshot](https://github.com/user-attachments/assets/ff617dba-ed47-4477-83b1-1d15ddad3301)
xhost +SI:localuser:root
![241215_13h12m04s_screenshot](https://github.com/user-attachments/assets/0be4146f-3ef1-4006-bb56-391dfb19d052)
