### PR TITLE
better suspend command 

### DIFF
--- a/Configs/.config/wlogout/layout_1
+++ b/Configs/.config/wlogout/layout_1
@@ -14,7 +14,7 @@
 
 {
     "label": "suspend",
-    "action": "systemctl suspend",
+    "action": "hyprlock & disown && systemctl suspend",
     "text": "Suspend",
     "keybind": "u"
 }

--- a/Configs/.config/wlogout/layout_1
+++ b/Configs/.config/wlogout/layout_1
@@ -14,7 +14,7 @@
 
 {
     "label": "suspend",
-    "action": "hyprlock & disown && systemctl suspend",
+    "action": "lockscreen.sh & disown && systemctl suspend",
     "text": "Suspend",
     "keybind": "u"
 }


### PR DESCRIPTION
@kRHYME7 could you test it ?

i also have this in userprefs as i use a laptop maybe we could include this in keybindings.conf and comment it so if laptop users want a "sleep mode" more similar to that windows which first calls hyprlock and then suspends so whenever we wake the system it firsts asks for password

`bindl = , XF86PowerOff, exec, hyprlock & disown && systemctl suspend # launch lock screen & suspend`