### PR TITLE
fix typo in the script arguments call

### DIFF
--- a/Configs/.config/waybar/modules/cliphist.jsonc
+++ b/Configs/.config/waybar/modules/cliphist.jsonc
@@ -2,9 +2,9 @@
         "format": "{}",
         "rotate": ${r_deg},
         "exec": "echo ; echo 󰅇 clipboard history",
-        "on-click": "sleep 0.1 && cliphist.sh c",
-        "on-click-right": "sleep 0.1 && cliphist.sh d",
-        "on-click-middle": "sleep 0.1 && cliphist.sh w",
+        "on-click": "sleep 0.1 && cliphist.sh -c",
+        "on-click-right": "sleep 0.1 && cliphist.sh -d",
+        "on-click-middle": "sleep 0.1 && cliphist.sh -w",
         "interval" : 86400, // once every day
         "tooltip": true
     },


### PR DESCRIPTION
Added the missing hyphen “ - ” to the arguments of the cliphist.sh script in the waybar module, as the missing hyphen caused the arguments to never execute when clicked.

# Pull Request

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

