### PR TITLE
breaking (zshrc): Rework for the zshrc implementation

### DIFF
--- a/Configs/.hyde.zshrc
+++ b/Configs/.hyde.zshrc
@@ -1,0 +1,46 @@
+#  Startup 
+# Commands on startup (before the prompt is shown)
+# This is a good place to load graphic/ascii art, display system information, etc.
+
+# pokego --no-title -r 1,3,6
+# fastfetch --logo-type kitty
+# fastfetch.sh
+
+#  Aliases 
+# Override aliases here or in '~/.zshrc' (already set in .zshenv)
+
+# # Helpful aliases
+# alias c='clear'                                                        # clear terminal
+# alias l='eza -lh --icons=auto'                                         # long list
+# alias ls='eza -1 --icons=auto'                                         # short list
+# alias ll='eza -lha --icons=auto --sort=name --group-directories-first' # long list all
+# alias ld='eza -lhD --icons=auto'                                       # long list dirs
+# alias lt='eza --icons=auto --tree'                                     # list folder as tree
+# alias un='$aurhelper -Rns'                                             # uninstall package
+# alias up='$aurhelper -Syu'                                             # update system/package/aur
+# alias pl='$aurhelper -Qs'                                              # list installed package
+# alias pa='$aurhelper -Ss'                                              # list available package
+# alias pc='$aurhelper -Sc'                                              # remove unused cache
+# alias po='$aurhelper -Qtdq | $aurhelper -Rns -'                        # remove unused packages, also try > $aurhelper -Qqd | $aurhelper -Rsu --print -
+# alias vc='code'                                                        # gui code editor
+# alias fastfetch='fastfetch --logo-type kitty'
+
+# # Directory navigation shortcuts
+# alias ..='cd ..'
+# alias ...='cd ../..'
+# alias .3='cd ../../..'
+# alias .4='cd ../../../..'
+# alias .5='cd ../../../../..'
+
+# # Always mkdir a path (this doesn't inhibit functionality to make a single dir)
+# alias mkdir='mkdir -p'
+
+#  Plugins 
+# manually add your oh-my-zsh plugins here
+plugins=(
+    "sudo"
+    # "git"                     # (default)
+    # "zsh-autosuggestions"     # (default)
+    # "zsh-syntax-highlighting" # (default)
+    # "zsh-completions"         # (default)
+)

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -150,13 +150,29 @@ else
     echo "$aurhelper" > "$aur_cache_file"
 fi
 
+
+# Optionally load user configuration // usefull for customizing the shell without modifying the main file
+[[ -f ~/.hyde.zshrc ]] && source ~/.hyde.zshrc
+
+# Load plugins
+load_zsh_plugins
+
+# Warn if the shell is slow to load
+autoload -Uz add-zsh-hook
+add-zsh-hook -Uz precmd slow_load_warning
+# add-zsh-hook zshexit cleanup
+
+
 # Helpful aliases
+if [[ -x /usr/bin/exa ]]; then
+    alias ls='exa' \
+        l='exa -lh --icons=auto' \
+        ll='exa -lha --icons=auto --sort=name --group-directories-first' \
+        ld='exa -lhD --icons=auto' \
+        lt='exa --icons=auto --tree'
+fi
+
 alias c='clear' \
-    l='eza -lh --icons=auto' \
-    ls='eza -1 --icons=auto' \
-    ll='eza -lha --icons=auto --sort=name --group-directories-first' \
-    ld='eza -lhD --icons=auto' \
-    lt='eza --icons=auto --tree' \
     un='$aurhelper -Rns' \
     up='$aurhelper -Syu' \
     pl='$aurhelper -Qs' \
@@ -172,14 +188,3 @@ alias c='clear' \
     .5='cd ../../../../..' \
     mkdir='mkdir -p' # Always mkdir a path (this doesn't inhibit functionality to make a single dir)
 
-
-# Optionally load user configuration // usefull for customizing the shell without modifying the main file
-[[ -f ~/.hyde.zshrc ]] && source ~/.hyde.zshrc
-
-# Load plugins
-load_zsh_plugins
-
-# Warn if the shell is slow to load
-autoload -Uz add-zsh-hook
-add-zsh-hook -Uz precmd slow_load_warning
-add-zsh-hook zshexit cleanup

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -1,0 +1,185 @@
+#!          ░▒▓         
+#!        ░▒▒░▓▓         
+#!      ░▒▒▒░░░▓▓           ___________
+#!    ░░▒▒▒░░░░░▓▓        //___________/
+#!   ░░▒▒▒░░░░░▓▓     _   _ _    _ _____
+#!   ░░▒▒░░░░░▓▓▓▓▓▓ | | | | |  | |  __/
+#!    ░▒▒░░░░▓▓   ▓▓ | |_| | |_/ /| |___
+#!     ░▒▒░░▓▓   ▓▓   \__  |____/ |____/    ▀█ █▀ █░█
+#!       ░▒▓▓   ▓▓  //____/                █▄ ▄█ █▀█
+
+# HyDE's ZSH env configuration
+# This file is sourced by ZSH on startup
+# And ensures that we have an obstruction free ~/.zshrc file
+# This also ensures that the proper HyDE $ENVs are loaded
+
+
+# Command not found handler
+function command_not_found_handler {
+    local purple='\e[1;35m' bright='\e[0;1m' green='\e[1;32m' reset='\e[0m'
+    printf 'zsh: command not found: %s\n' "$1"
+    local entries=( ${(f)"$(/usr/bin/pacman -F --machinereadable -- "/usr/bin/$1")"} )
+    if (( ${#entries[@]} > 0 )); then
+        printf "${bright}$1${reset} may be found in the following packages:\n"
+        local pkg
+        for entry in "${entries[@]}"; do
+            local fields=( ${(0)entry} )
+            if [[ "$pkg" != "${fields[2]}" ]]; then
+                printf "${purple}%s/${bright}%s ${green}%s${reset}\n" "${fields[1]}" "${fields[2]}" "${fields[3]}"
+            fi
+            printf '    /%s\n' "${fields[4]}"
+            pkg="${fields[2]}"
+        done
+    fi
+    return 127
+}
+
+function load_zsh_plugins {
+# Oh-my-zsh installation path
+zsh_paths=(
+    "/usr/share/oh-my-zsh"
+    "/usr/local/share/oh-my-zsh"
+    "$HOME/.oh-my-zsh"
+)
+for zsh_path in "${zsh_paths[@]}"; do [[ -d $zsh_path ]] && export ZSH=$zsh_path && break; done
+# Load Plugins
+hyde_plugins=( git zsh-256color zsh-autosuggestions zsh-syntax-highlighting )
+plugins+=( "${plugins[@]}" "${hyde_plugins[@]}" git zsh-256color zsh-autosuggestions zsh-syntax-highlighting)
+# Deduplicate plugins
+plugins=("${plugins[@]}")
+plugins=($(printf "%s\n" "${plugins[@]}" | sort -u))
+
+# Loads om-my-zsh
+[[ -r $ZSH/oh-my-zsh.sh ]] && source $ZSH/oh-my-zsh.sh
+}
+
+# Install packages from both Arch and AUR
+function in {
+local -a inPkg=("$@")
+local -a arch=()
+local -a aur=()
+
+for pkg in "${inPkg[@]}"; do
+if pacman -Si "${pkg}" &>/dev/null; then
+arch+=("${pkg}")
+else
+aur+=("${pkg}")
+fi
+done
+
+if [[ ${#arch[@]} -gt 0 ]]; then
+sudo pacman -S "${arch[@]}"
+fi
+
+if [[ ${#aur[@]} -gt 0 ]]; then
+${aurhelper} -S "${aur[@]}"
+fi
+}
+
+# Function to display a slow load warning
+function slow_load_warning {
+    local lock_file="/tmp/.hyde_slow_load_warning.lock"
+    local load_time=$SECONDS
+
+    # Check if the lock file exists
+    if [[ ! -f $lock_file ]]; then
+        # Create the lock file
+        touch $lock_file
+
+        # Display the warning if load time exceeds the limit
+        time_limit=3
+        if ((load_time > time_limit)); then
+            cat <<EOF
+    ⚠️ Warning: Shell startup took more than ${time_limit} seconds. Consider optimizing your configuration.
+        1. This might be due to slow plugins, slow initialization scripts.
+        2. Duplicate plugins initialization.
+            - navigate to ~/.zshrc and remove any 'source ZSH/oh-my-zsh.sh' or
+                'source ~/.oh-my-zsh/oh-my-zsh.sh' lines.
+            - HyDE already sources the oh-my-zsh.sh file for you.
+            - It is important to remove all HyDE related
+                configurations from your .zshrc file as HyDE will handle it for you.
+            - Check the '.zshrc' file from the repo for a clean configuration.
+                https://github.com/HyDE-Project/HyDE/blob/master/Configs/.zshrc
+        3. Check the '~/.hyde.zshrc' file for any slow initialization scripts.
+        4. Check the '~/.p10k.zsh' file for any slow initialization scripts.
+
+    For more information, on the possible causes of slow shell startup, see:
+        🌐 https://github.com/HyDE-Project/HyDE/wiki
+
+EOF
+        fi
+    fi
+}
+
+# Function to handle initialization errors
+function handle_init_error {
+    if [[ $? -ne 0 ]]; then
+        echo "Error during initialization. Please check your configuration."
+    fi
+}
+
+# Function to remove the lock file on exit
+function cleanup {
+    rm -f /tmp/.hyde_slow_load_warning.lock
+}
+
+function no_such_file_or_directory_handler {
+    local red='\e[1;31m' reset='\e[0m'
+    printf "${red}zsh: no such file or directory: %s${reset}\n" "$1"
+    return 127
+}
+
+# We are loading the prompt on start so users can see the prompt immediately
+# Powerlevel10k theme path
+P10k_THEME=${P10k_THEME:-/usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme}
+[[ -r $P10k_THEME ]] && source $P10k_THEME
+
+# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh
+[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+
+# Detect AUR wrapper and cache it for faster subsequent loads
+aur_cache_file="/tmp/.aurhelper.zshrc"
+if [[ -f $aur_cache_file ]]; then
+    aurhelper=$(<"$aur_cache_file")
+else
+    if pacman -Qi yay &>/dev/null; then
+        aurhelper="yay"
+    elif pacman -Qi paru &>/dev/null; then
+        aurhelper="paru"
+    fi
+    echo "$aurhelper" > "$aur_cache_file"
+fi
+
+# Helpful aliases
+alias c='clear' \
+    l='eza -lh --icons=auto' \
+    ls='eza -1 --icons=auto' \
+    ll='eza -lha --icons=auto --sort=name --group-directories-first' \
+    ld='eza -lhD --icons=auto' \
+    lt='eza --icons=auto --tree' \
+    un='$aurhelper -Rns' \
+    up='$aurhelper -Syu' \
+    pl='$aurhelper -Qs' \
+    pa='$aurhelper -Ss' \
+    pc='$aurhelper -Sc' \
+    po='$aurhelper -Qtdq | $aurhelper -Rns -' \
+    vc='code' \
+    fastfetch='fastfetch --logo-type kitty' \
+    ..='cd ..' \
+    ...='cd ../..' \
+    .3='cd ../../..' \
+    .4='cd ../../../..' \
+    .5='cd ../../../../..' \
+    mkdir='mkdir -p' # Always mkdir a path (this doesn't inhibit functionality to make a single dir)
+
+
+# Optionally load user configuration // usefull for customizing the shell without modifying the main file
+[[ -f ~/.hyde.zshrc ]] && source ~/.hyde.zshrc
+
+# Load plugins
+load_zsh_plugins
+
+# Warn if the shell is slow to load
+autoload -Uz add-zsh-hook
+add-zsh-hook -Uz precmd slow_load_warning
+add-zsh-hook zshexit cleanup

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -164,12 +164,12 @@ add-zsh-hook -Uz precmd slow_load_warning
 
 
 # Helpful aliases
-if [[ -x /usr/bin/exa ]]; then
-    alias ls='exa' \
-        l='exa -lh --icons=auto' \
-        ll='exa -lha --icons=auto --sort=name --group-directories-first' \
-        ld='exa -lhD --icons=auto' \
-        lt='exa --icons=auto --tree'
+if [[ -x "$(which eza)" ]]; then
+    alias ls='eza' \
+        l='eza -lh --icons=auto' \
+        ll='eza -lha --icons=auto --sort=name --group-directories-first' \
+        ld='eza -lhD --icons=auto' \
+        lt='eza --icons=auto --tree'
 fi
 
 alias c='clear' \

--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -1,90 +1,14 @@
-# Oh-my-zsh installation path
-ZSH=/usr/share/oh-my-zsh/
+# Add user configurations here
+# For HyDE not to touch your beloved configurations,
+# we added 2 files to the project structure:
+# 1. ~/.hyde.zshrc - for customizing the shell related hyde configurations
+# 2. ~/.zshenv - for updating the zsh environment variables handled by HyDE // this will be modified across updates
 
-# Powerlevel10k theme path
-source /usr/share/zsh-theme-powerlevel10k/powerlevel10k.zsh-theme
+#  Plugins 
+# oh-my-zsh plugins are loaded  in ~/.hyde.zshrc file, see the file for more information
 
-# List of plugins used
-plugins=()
-source $ZSH/oh-my-zsh.sh
+#  Aliases 
+# Add aliases here
 
-# In case a command is not found, try to find the package that has it
-function command_not_found_handler {
-    local purple='\e[1;35m' bright='\e[0;1m' green='\e[1;32m' reset='\e[0m'
-    printf 'zsh: command not found: %s\n' "$1"
-    local entries=( ${(f)"$(/usr/bin/pacman -F --machinereadable -- "/usr/bin/$1")"} )
-    if (( ${#entries[@]} )) ; then
-        printf "${bright}$1${reset} may be found in the following packages:\n"
-        local pkg
-        for entry in "${entries[@]}" ; do
-            local fields=( ${(0)entry} )
-            if [[ "$pkg" != "${fields[2]}" ]]; then
-                printf "${purple}%s/${bright}%s ${green}%s${reset}\n" "${fields[1]}" "${fields[2]}" "${fields[3]}"
-            fi
-            printf '    /%s\n' "${fields[4]}"
-            pkg="${fields[2]}"
-        done
-    fi
-    return 127
-}
-
-# Detect AUR wrapper
-if pacman -Qi yay &>/dev/null; then
-   aurhelper="yay"
-elif pacman -Qi paru &>/dev/null; then
-   aurhelper="paru"
-fi
-
-function in {
-    local -a inPkg=("$@")
-    local -a arch=()
-    local -a aur=()
-
-    for pkg in "${inPkg[@]}"; do
-        if pacman -Si "${pkg}" &>/dev/null; then
-            arch+=("${pkg}")
-        else
-            aur+=("${pkg}")
-        fi
-    done
-
-    if [[ ${#arch[@]} -gt 0 ]]; then
-        sudo pacman -S "${arch[@]}"
-    fi
-
-    if [[ ${#aur[@]} -gt 0 ]]; then
-        ${aurhelper} -S "${aur[@]}"
-    fi
-}
-
-# Helpful aliases
-alias c='clear' # clear terminal
-alias l='eza -lh --icons=auto' # long list
-alias ls='eza -1 --icons=auto' # short list
-alias ll='eza -lha --icons=auto --sort=name --group-directories-first' # long list all
-alias ld='eza -lhD --icons=auto' # long list dirs
-alias lt='eza --icons=auto --tree' # list folder as tree
-alias un='$aurhelper -Rns' # uninstall package
-alias up='$aurhelper -Syu' # update system/package/aur
-alias pl='$aurhelper -Qs' # list installed package
-alias pa='$aurhelper -Ss' # list available package
-alias pc='$aurhelper -Sc' # remove unused cache
-alias po='$aurhelper -Qtdq | $aurhelper -Rns -' # remove unused packages, also try > $aurhelper -Qqd | $aurhelper -Rsu --print -
-alias vc='code' # gui code editor
-alias fastfetch='fastfetch --logo-type kitty'
-
-# Directory navigation shortcuts
-alias ..='cd ..'
-alias ...='cd ../..'
-alias .3='cd ../../..'
-alias .4='cd ../../../..'
-alias .5='cd ../../../../..'
-
-# Always mkdir a path (this doesn't inhibit functionality to make a single dir)
-alias mkdir='mkdir -p'
-
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh
-[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-
-# Display Pokemon
-pokego --no-title -r 1,3,6
+#  This is your file 
+# Add your configurations here

--- a/Scripts/pkg_core.lst
+++ b/Scripts/pkg_core.lst
@@ -72,12 +72,12 @@ nwg-displays                                           # monitor management util
 
 # --------------------------------------------------- // Shell
 eza|zsh                                                # file lister for zsh
-oh-my-zsh-git|zsh                                    #  plugin manager for zsh (Optional)
-zsh-theme-powerlevel10k-git|zsh          # theme for zsh
+# oh-my-zsh-git|zsh                                    #  plugin manager for zsh (Optional) // Moved to pkg_custom.lst
+zsh-theme-powerlevel10k-git|zsh                        # theme for zsh
+pokego-bin|zsh                                        # display pokemon sprites in terminal (written GO)
 eza|fish                                               # file lister for fish
 starship|fish                                          # customizable shell prompt
 fastfetch                                              # system information fetch tool
-pokego-bin|zsh                                        # display pokemon sprites in terminal (written GO)
 
 # --------------------------------------------------- // HyDE
 # hyde-cli-git                                           # cli tool to manage hyde \\ Deprecated for HyDE

--- a/Scripts/pkg_custom.lst
+++ b/Scripts/pkg_custom.lst
@@ -9,7 +9,11 @@ ddccui                                                 # GUI to control brightne
 hyprgui-bin                                            # GUI for hyprland configuration // might mess your userprefs but convenient
 # satty                                                  # Annotation tool like swappy but better
 
-# --------------------------------------------------- // Dependencies
+# --------------------------------------------------- // Shell
+# oh-my-zsh-git|zsh                                      # Optional plugin manager for zsh // already installed locally
+
+
+# --------------------------------------------------- // Misc
 xdg-desktop-portal-gtk                                 # xdg desktop portal using gtk
 # emote                                                # emoji picker gtk3
 

--- a/Scripts/restore_cfg.psv
+++ b/Scripts/restore_cfg.psv
@@ -60,17 +60,19 @@ P|${HOME}/.config/waybar|config.ctl|waybar
 S|${HOME}/.config/waybar|modules config.jsonc theme.css style.css|waybar
 
  Terminal 
-P|${HOME}/.config|fish|fish
 P|${HOME}/.config|lsd|lsd
 S|${HOME}/.config|fastfetch|fastfetch
 S|${HOME}/.config/kitty|hyde.conf theme.conf|kitty
 P|${HOME}/.config/kitty|kitty.conf|kitty
 
+ Shell 
+P|${HOME}/.config|fish|fish
+P|${HOME}|.zshrc .hyde.zshrc .p10k.zsh|zsh zsh-theme-powerlevel10k pokego-bin
+S|${HOME}|.zshenv|zsh zsh-theme-powerlevel10k
 
  File Explorer 
 P|${HOME}/.local/state|dolphinstaterc|dolphin
 P|${HOME}/.config|baloofilerc|dolphin
-P|${HOME}|.zshrc .p10k.zsh|zsh oh-my-zsh-git zsh-theme-powerlevel10k pokego-bin
 S|${HOME}/.config/menus|applications.menu|dolphin
 S|${HOME}/.config|dolphinrc|dolphin
 S|${HOME}/.config|kdeglobals|dolphin

--- a/Scripts/restore_shl.sh
+++ b/Scripts/restore_shl.sh
@@ -13,32 +13,51 @@ fi
 
 # shellcheck disable=SC2154
 if chk_list "myShell" "${shlList[@]}"; then
-    print_log -g "[SHELL] " -b "detected :: " "${myShell}"
+    print_log -sec "SHELL" -stat "detected" "${myShell}"
 else
-    print_log -g "[SHELL] " -r "error :: " "no shell found..."
+    print_log -sec "SHELL" -err "error" "no shell found..."
     exit 1
 fi
 
 # add zsh plugins
-# TODO Nuke this and try to remove oh-my-zsh
 if pkg_installed zsh; then
 
-    #? Optional: oh-my-zsh 
-    if pkg_installed oh-my-zsh-git; then
+    if ! pkg_installed oh-my-zsh-git; then
+        if [[ ! -e "$HOME/.oh-my-zsh/oh-my-zsh.sh" ]]; then
+            print_log -sec "SHELL" -stat "cloning" "oh-my-zsh"
+            sh -c "$(curl -fsSL https://install.ohmyz.sh/)" "" --unattended --keep-zshrc
+        else
+            print_log -sec "SHELL" -stat "updating" "oh-my-zsh"
+            zsh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/upgrade.sh)"
+        fi
+    fi
+
+    #? Optional: oh-my-zsh
+    if pkg_installed oh-my-zsh-git || [[ -f "${HOME}/.oh-my-zsh/oh-my-zsh.sh" ]]; then
+        zsh_paths=(
+            "$HOME/.oh-my-zsh"
+            "/usr/local/share/oh-my-zsh"
+            "/usr/share/oh-my-zsh"
+        )
+        for zsh_path in "${zsh_paths[@]}"; do [[ -d $zsh_path ]] && Zsh_Path=$zsh_path && break; done
 
         # set variables
-        Zsh_rc="${ZDOTDIR:-$HOME}/.zshrc"
-        Zsh_Path="/usr/share/oh-my-zsh"
+        Zsh_rc="${ZDOTDIR:-$HOME}/.zshenv"
+        Zsh_Path="$HOME/.oh-my-zsh"
         Zsh_Plugins="$Zsh_Path/custom/plugins"
         Fix_Completion=""
 
         # generate plugins from list
         while read -r r_plugin; do
-            z_plugin=$(awk -F '/' '{print $NF}' <<< "${r_plugin}")
+            z_plugin=$(awk -F '/' '{print $NF}' <<<"${r_plugin}")
             if [ "${r_plugin:0:4}" == "http" ] && [ ! -d "${Zsh_Plugins}/${z_plugin}" ]; then
-                sudo git clone "${r_plugin}" "${Zsh_Plugins}/${z_plugin}"
+                if [ -w "${Zsh_Plugins}" ]; then
+                    git clone "${r_plugin}" "${Zsh_Plugins}/${z_plugin}"
+                else
+                    sudo git clone "${r_plugin}" "${Zsh_Plugins}/${z_plugin}"
+                fi
             fi
-            if [ "${z_plugin}" == "zsh-completions" ] && [ "$(grep 'fpath+=.*plugins/zsh-completions/src' "${Zsh_rc}" | wc -l)" -eq 0 ]; then
+            if [ "${z_plugin}" == "zsh-completions" ] && [ "$(grep -c 'fpath+=.*plugins/zsh-completions/src' "${Zsh_rc}")" -eq 0 ]; then
                 Fix_Completion='\nfpath+=${ZSH_CUSTOM:-${ZSH:-/usr/share/oh-my-zsh}/custom}/plugins/zsh-completions/src'
             else
                 [ -z "${z_plugin}" ] || w_plugin+=" ${z_plugin}"
@@ -47,7 +66,7 @@ if pkg_installed zsh; then
 
         # update plugin array in zshrc
         print_log -g "[SHELL] " -b "installing :: " "plugins (${w_plugin} )"
-        sed -i "/^plugins=/c\plugins=(${w_plugin} )${Fix_Completion}" "${Zsh_rc}"
+        sed -i "/^hyde_plugins=/c\hyde_plugins=(${w_plugin} )${Fix_Completion}" "${Zsh_rc}"
     fi
 fi
 

--- a/Scripts/restore_shl.sh
+++ b/Scripts/restore_shl.sh
@@ -43,6 +43,7 @@ if pkg_installed zsh; then
 
         # set variables
         Zsh_rc="${ZDOTDIR:-$HOME}/.zshenv"
+        Zsh_Path="${Zsh_Path:-$HOME/.oh-my-zsh}"
         Zsh_Plugins="$Zsh_Path/custom/plugins"
         Fix_Completion=""
 

--- a/Scripts/restore_shl.sh
+++ b/Scripts/restore_shl.sh
@@ -43,7 +43,6 @@ if pkg_installed zsh; then
 
         # set variables
         Zsh_rc="${ZDOTDIR:-$HOME}/.zshenv"
-        Zsh_Path="$HOME/.oh-my-zsh"
         Zsh_Plugins="$Zsh_Path/custom/plugins"
         Fix_Completion=""
 
@@ -65,15 +64,15 @@ if pkg_installed zsh; then
         done < <(cut -d '#' -f 1 "${scrDir}/restore_zsh.lst" | sed 's/ //g')
 
         # update plugin array in zshrc
-        print_log -g "[SHELL] " -b "installing :: " "plugins (${w_plugin} )"
+        print_log -sec "SHELL" -stat "installing" "plugins (${w_plugin} )"
         sed -i "/^hyde_plugins=/c\hyde_plugins=(${w_plugin} )${Fix_Completion}" "${Zsh_rc}"
     fi
 fi
 
 # set shell
 if [[ "$(grep "/${USER}:" /etc/passwd | awk -F '/' '{print $NF}')" != "${myShell}" ]]; then
-    print_log -g "[SHELL] " -b "change :: " "shell to ${myShell}..."
+    print_log -sec "SHELL" -stat "change" "shell to ${myShell}..."
     chsh -s "$(which "${myShell}")"
 else
-    print_log -y "[SHELL] " -y "exist :: " "${myShell} is already set as shell..."
+    print_log -sec "SHELL" -stat "exist" "${myShell} is already set as shell..."
 fi

--- a/Scripts/restore_zsh.lst
+++ b/Scripts/restore_zsh.lst
@@ -1,7 +1,12 @@
+# This is a plugin installer list for zsh
+# To install a plugin, uncomment the line
+# This also handles the installation from git
+
+
 git                                                     # alias and functions for git commands
-sudo                                                    # press ESC key twice to execute command with sudo prefix 
+# sudo                                                    # press ESC key twice to execute command with sudo prefix
 #python                                                 # alias for python
-#zsh-interactive-cd                                     # press tab to change dir with fzf
+#zsh-interactive-cd                                     # press tab to change dir with fzf // Manually add this to your .zshrc
 https://github.com/chrissicool/zsh-256color             # enhance terminal environment with 256 colors
 #https://github.com/zsh-users/zsh-completions           # press tab to complete command
 https://github.com/zsh-users/zsh-autosuggestions        # suggests commands as you type based on history


### PR DESCRIPTION
breaks: zshrc should manually be cleaned up or else omz will reinitialize the plugins.   

for this compromise
+ I also added a warning if loading takes up more than 3 seconds for slow PC (works on a VM) 
+ Only showed 1 time per reboot 
![image](https://github.com/user-attachments/assets/1d8f34da-6122-40ac-b669-eeb782eaabb8)


feat: Won't touch .zshrc
feat: easy updates for hyde
feat: User configuration
feat: can uninstall hyde without removing users zshrc
feat: put oh-my-zsh locally ($HOME)
feat: update omz on restore_shl.sh
feat: faster startup by only using single `alias` call 

fix: omz packaging issues, 



