### PR TITLE
fix: Added checkupdates since updates on bar don't refresh on -Qua

### DIFF
--- a/Configs/.local/lib/hyde/systemupdate.sh
+++ b/Configs/.local/lib/hyde/systemupdate.sh
@@ -44,6 +44,11 @@ if [ "$1" == "up" ] ; then
     exit 0
 fi
 
+# Check official package updates (without sudo)
+if command -v checkupdates &> /dev/null; then
+    ofc=$(checkupdates 2>/dev/null | wc -l)
+fi
+
 # Check for AUR updates
 aur=$(${aurhlpr} -Qua | wc -l) 
 ofc=$(pacman -Qu | wc -l)


### PR DESCRIPTION
# Pull Request

## Description

- Sorry khing didn't noticed earlier but the Qua didn't pulled new updates from server only checkupdates do i also tried -Sy flag but requires a password

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
