### PR TITLE
consistent shabangs

### DIFF
--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # This script will soon be use to resolve $PATHS and LIB_DIR specific to hyde
 # wallbash script can source this script to resolve the paths cleanly on a separate shell
 

--- a/Configs/.local/lib/hyde/cava.sh
+++ b/Configs/.local/lib/hyde/cava.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 #----- Optimized bars animation without much CPU usage increase --------
 #----- Optimized bars animation without much CPU usage increase pt2 --------
 

--- a/Configs/.local/lib/hyde/emoji-picker.sh
+++ b/Configs/.local/lib/hyde/emoji-picker.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Set variables
 scrDir=$(dirname "$(realpath "$0")")

--- a/Configs/.local/lib/hyde/fastfetch.sh
+++ b/Configs/.local/lib/hyde/fastfetch.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # Early load to maintain fastfetch speed
 if [ -z "${*}" ]; then

--- a/Configs/.local/lib/hyde/font.sh
+++ b/Configs/.local/lib/hyde/font.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # Script to resolve fonts
 
 font_dir="${XDG_DATA_HOME:-$HOME/.local/share}/fonts"

--- a/Configs/.local/lib/hyde/glyph-picker.sh
+++ b/Configs/.local/lib/hyde/glyph-picker.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC1091
 if ! source "$(which hyde-shell)"; then

--- a/Configs/.local/lib/hyde/hypr.unbind.sh
+++ b/Configs/.local/lib/hyde/hypr.unbind.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 scrDir="$(dirname "$(realpath "$0")")"
 source "${scrDir}/globalcontrol.sh"

--- a/Configs/.local/lib/hyde/keyboardswitch.sh
+++ b/Configs/.local/lib/hyde/keyboardswitch.sh
@@ -1,10 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-scrDir=`dirname "$(realpath "$0")"`
+scrDir=$(dirname "$(realpath "$0")")
 source $scrDir/globalcontrol.sh
 
 hyprctl switchxkblayout all next
 
 layMain=$(hyprctl -j devices | jq '.keyboards' | jq '.[] | select (.main == true)' | awk -F '"' '{if ($2=="active_keymap") print $4}')
 notify-send -a "HyDE Alert" -r 91190 -t 800 -i "${iconsDir}/Wallbash-Icon/keyboard.svg" "${layMain}"
-

--- a/Configs/.local/lib/hyde/lockscreen.sh
+++ b/Configs/.local/lib/hyde/lockscreen.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck source=$HOME/.local/lib/hyde/globalcontrol.sh

--- a/Configs/.local/lib/hyde/parse.config.py
+++ b/Configs/.local/lib/hyde/parse.config.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 import tomllib
 import argparse
 import logging

--- a/Configs/.local/lib/hyde/polkitkdeauth.sh
+++ b/Configs/.local/lib/hyde/polkitkdeauth.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Use different directory on NixOS
 if [ -d /run/current-system/sw/libexec ]; then

--- a/Configs/.local/lib/hyde/sensorsinfo.py
+++ b/Configs/.local/lib/hyde/sensorsinfo.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import json
 import subprocess

--- a/Configs/.local/lib/hyde/swwwallkon.sh
+++ b/Configs/.local/lib/hyde/swwwallkon.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env sh
-
+#!/usr/bin/env bash
 
 #// Set variables
 
@@ -11,47 +10,45 @@ kmenuDesk="${kmenuPath}/hydewallpaper.desktop"
 tgtPath="$(dirname "${HYDE_THEME_DIR}")"
 get_themes
 
-
 #// Evaluate options
 
-while getopts "t:w:" option ; do
+while getopts "t:w:" option; do
     case $option in
 
-        t ) # Set theme
-            for x in "${!thmList[@]}" ; do
-                if [ "${thmList[x]}" == "$OPTARG" ] ; then
-                    setTheme="${thmList[x]}"
-                    break
-                fi
-            done
-            [ -z "${setTheme}" ] && echo "Error: '$OPTARG' theme not available..." && exit 1
-            ;;
-
-        w ) # Set wallpaper
-            if [ -f "$OPTARG" ] && file --mime-type "$OPTARG" | grep -q 'image/' ; then
-                setWall="$OPTARG"
-            else
-                echo "Error: '$OPTARG' is not an image file..."
-                exit 1
+    t) # Set theme
+        for x in "${!thmList[@]}"; do
+            if [ "${thmList[x]}" == "$OPTARG" ]; then
+                setTheme="${thmList[x]}"
+                break
             fi
-            ;;
+        done
+        [ -z "${setTheme}" ] && echo "Error: '$OPTARG' theme not available..." && exit 1
+        ;;
 
-        * ) # Refresh menu
-            unset setTheme
-            unset setWall
-            ;;
+    w) # Set wallpaper
+        if [ -f "$OPTARG" ] && file --mime-type "$OPTARG" | grep -q 'image/'; then
+            setWall="$OPTARG"
+        else
+            echo "Error: '$OPTARG' is not an image file..."
+            exit 1
+        fi
+        ;;
+
+    *) # Refresh menu
+        unset setTheme
+        unset setWall
+        ;;
 
     esac
 done
 
-
 #// Regenerate desktop
 
-if [ ! -z "${setTheme}" ] && [ ! -z "${setWall}" ] ; then
+if [ ! -z "${setTheme}" ] && [ ! -z "${setWall}" ]; then
 
     inwallHash="$(set_hash "${setWall}")"
     get_hashmap "${tgtPath}/${setTheme}"
-    if [[ "${wallHash[@]}" == *"${inwallHash}"* ]] ; then
+    if [[ "${wallHash[@]}" == *"${inwallHash}"* ]]; then
         notify-send -a "HyDE Notify" -i "${thmbDir}/${inwallHash}.sqre" "Error" "Hash matched in ${setTheme}"
         exit 0
     fi
@@ -64,10 +61,9 @@ if [ ! -z "${setTheme}" ] && [ ! -z "${setWall}" ] ; then
 
 else
 
-    echo -e "[Desktop Entry]\nType=Service\nMimeType=image/png;image/jpeg;image/jpg;image/gif\nActions=Menu-Refresh$(printf ";%s" "${thmList[@]}")\nX-KDE-Submenu=Set As Wallpaper...\n\n[Desktop Action Menu-Refresh]\nName=.: Refresh List :.\nExec=${scrName}" > "${kmenuDesk}"
-    for i in "${!thmList[@]}" ; do
-        echo -e "\n[Desktop Action ${thmList[i]}]\nName=${thmList[i]}\nExec=${scrName} -t \"${thmList[i]}\" -w %u" >> "${kmenuDesk}"
+    echo -e "[Desktop Entry]\nType=Service\nMimeType=image/png;image/jpeg;image/jpg;image/gif\nActions=Menu-Refresh$(printf ";%s" "${thmList[@]}")\nX-KDE-Submenu=Set As Wallpaper...\n\n[Desktop Action Menu-Refresh]\nName=.: Refresh List :.\nExec=${scrName}" >"${kmenuDesk}"
+    for i in "${!thmList[@]}"; do
+        echo -e "\n[Desktop Action ${thmList[i]}]\nName=${thmList[i]}\nExec=${scrName} -t \"${thmList[i]}\" -w %u" >>"${kmenuDesk}"
     done
 
 fi
-

--- a/Configs/.local/lib/hyde/sysmonlaunch.sh
+++ b/Configs/.local/lib/hyde/sysmonlaunch.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck disable=SC1091

--- a/Configs/.local/lib/hyde/testrunner.sh
+++ b/Configs/.local/lib/hyde/testrunner.sh
@@ -1,23 +1,23 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-scrDir=`dirname "$(realpath "$0")"`
+scrDir=$(dirname "$(realpath "$0")")
 source $scrDir/globalcontrol.sh
 rofDir="${confDir}/rofi"
 
-if [ "${1}" == "--verbose" ] || [ "${1}" == "-v" ] ; then
+if [ "${1}" == "--verbose" ] || [ "${1}" == "-v" ]; then
 
     case ${enableWallDcol} in
-        0) wallbashStatus="disabled";;
-        1) wallbashStatus="enabled // auto change based on wallpaper brightness";;
-        2) wallbashStatus="enabled // dark mode --forced";;
-        3) wallbashStatus="enabled // light mode --forced";;
+    0) wallbashStatus="disabled" ;;
+    1) wallbashStatus="enabled // auto change based on wallpaper brightness" ;;
+    2) wallbashStatus="enabled // dark mode --forced" ;;
+    3) wallbashStatus="enabled // light mode --forced" ;;
     esac
 
     echo -e "\n\ncurrent theme :: \"${HYDE_THEME}\" :: \"$(readlink "${HYDE_THEME_DIR}/wall.set")\""
     echo -e "wallbash status :: ${enableWallDcol} :: ${wallbashStatus}\n"
     get_themes
 
-    for x in "${!thmList[@]}" ; do
+    for x in "${!thmList[@]}"; do
         echo -e "\nTheme $((x + 1)) :: \${thmList[${x}]}=\"${thmList[x]}\" :: \${thmWall[${x}]}=\"${thmWall[x]}\"\n"
         get_hashmap "$(dirname "${HYDE_THEME_DIR}")/${thmList[x]}" --verbose
         echo -e "\n"

--- a/Configs/.local/lib/hyde/wallbash.hypr.sh
+++ b/Configs/.local/lib/hyde/wallbash.hypr.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 scrDir="$(dirname "$(realpath "$0")")"
 export scrDir

--- a/Configs/.local/lib/hyde/wallbash.print.colors.sh
+++ b/Configs/.local/lib/hyde/wallbash.print.colors.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2154
 
 if [[ -z $dcol_pry1 ]]; then

--- a/Configs/.local/lib/hyde/wallbash.qt.sh
+++ b/Configs/.local/lib/hyde/wallbash.qt.sh
@@ -1,16 +1,13 @@
-#!/usr/bin/env sh
-
+#!/usr/bin/env bash
 
 # set variables
 
-scrDir=`dirname "$(realpath "$0")"`
+scrDir=$(dirname "$(realpath "$0")")
 source $scrDir/globalcontrol.sh
-
 
 # sync qt5 and qt6 colors
 
 cp "${confDir}/qt5ct/colors.conf" "${confDir}/qt6ct/colors.conf"
-
 
 # restart dolphin
 
@@ -20,4 +17,3 @@ cp "${confDir}/qt5ct/colors.conf" "${confDir}/qt6ct/colors.conf"
 #    hyprctl dispatch closewindow pid:${dpid}
 #    hyprctl dispatch exec dolphin &
 #fi
-

--- a/Scripts/chaotic_aur.sh
+++ b/Scripts/chaotic_aur.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 #! REQUIRED ROOT
 execName="$0 $*"
@@ -84,30 +84,47 @@ check_Integrity() {
 }
 
 install() {
-    handle_error(){
+    handle_error() {
         tput setaf 1
         echo "ERROR :: Failed to install Chaotic AUR"
         tput sgr0
-        echo   "WARNING :: Reverting changes..."
-        { purge && echo "Reverted successfully" ; }|| echo "Failed to revert"
+        echo "WARNING :: Reverting changes..."
+        { purge && echo "Reverted successfully"; } || echo "Failed to revert"
         exit 1
     }
 
-
     box_me "Installing the key"
-    pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com || { box_me "Failed to install the key"; handle_error; }
-    pacman-key --lsign-key 3056513887B78AEB || { box_me "Failed to locally sign the key"; handle_error; }
+    pacman-key --recv-key 3056513887B78AEB --keyserver keyserver.ubuntu.com || {
+        box_me "Failed to install the key"
+        handle_error
+    }
+    pacman-key --lsign-key 3056513887B78AEB || {
+        box_me "Failed to locally sign the key"
+        handle_error
+    }
 
     box_me "Downloading the keyring"
-    pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' || { box_me "Failed to download the keyring"; handle_error; }
+    pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-keyring.pkg.tar.zst' || {
+        box_me "Failed to download the keyring"
+        handle_error
+    }
 
     box_me "Downloading the mirrorlist"
-    pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst' || { box_me "Failed to download the mirrorlist"; handle_error; }
+    pacman -U --noconfirm 'https://cdn-mirror.chaotic.cx/chaotic-aur/chaotic-mirrorlist.pkg.tar.zst' || {
+        box_me "Failed to download the mirrorlist"
+        handle_error
+    }
 
-    write_ChaoticAUR "append" || { box_me "Failed to append Chaotic AUR"; handle_error; }
+    write_ChaoticAUR "append" || {
+        box_me "Failed to append Chaotic AUR"
+        handle_error
+    }
 
     box_me "Refreshing the mirrorlists"
-    pacman -Sy || { box_me "Failed to refresh the mirrorlists"; handle_error; }
+    pacman -Sy || {
+        box_me "Failed to refresh the mirrorlists"
+        handle_error
+    }
 
     box_me "Chaotic-AUR has been successfully installed!"
 }

--- a/Scripts/restore_thm.sh
+++ b/Scripts/restore_thm.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck disable=SC1091


### PR DESCRIPTION
# Consistency 

- This is to support modern distro. 
- We need to have a common interpreter to debug correctly



####  For legacy distro
I think we can just manually link  `/bin/env`  to `/usr/bin/env`  or vice versa, just like how other distros do it. 

So my proposal will be in `install.sh` we will add a strict check if `/usr/bin/env` exist if not find it if error abort. 

But on debian12 it is /usr/bin/env is already supported. (using distrobox)
![image](https://github.com/user-attachments/assets/77cf3423-91f9-4b94-8179-053c807bc54a)
 
#### why use bash instead of sh ? 

Because most of the scripts that use `sh` are actually written in  `bash`! That means there will be unpredictable stuff. And debugging is annoying. 


I would like to discuss it here @Senshi111  @rubiin @richen604 

ref: https://github.com/HyDE-Project/HyDE/discussions/149#discussioncomment-11949678
