### PR TITLE
Load OMZ in .hyde.zshrc

### DIFF
--- a/Configs/.hyde.zshrc
+++ b/Configs/.hyde.zshrc
@@ -1,6 +1,3 @@
-#  Load OMZ Scripts 
-source $ZSH/oh-my-zsh.sh
-
 #  Startup 
 # Commands on startup (before the prompt is shown)
 # This is a good place to load graphic/ascii art, display system information, etc.

--- a/Configs/.hyde.zshrc
+++ b/Configs/.hyde.zshrc
@@ -1,3 +1,6 @@
+#  Load OMZ Scripts 
+source $ZSH/oh-my-zsh.sh
+
 #  Startup 
 # Commands on startup (before the prompt is shown)
 # This is a good place to load graphic/ascii art, display system information, etc.

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -180,15 +180,6 @@ export XDG_CONFIG_HOME XDG_CONFIG_DIR XDG_DATA_HOME XDG_STATE_HOME XDG_CACHE_HOM
 XDG_TEMPLATES_DIR XDG_PUBLICSHARE_DIR XDG_DOCUMENTS_DIR XDG_MUSIC_DIR XDG_PICTURES_DIR XDG_VIDEOS_DIR
 
 
-# Load plugins
-load_zsh_plugins
-
-# Warn if the shell is slow to load
-autoload -Uz add-zsh-hook
-add-zsh-hook -Uz precmd slow_load_warning
-# add-zsh-hook zshexit cleanup
-
-
 # Helpful aliases
 if [[ -x "$(which eza)" ]]; then
     alias ls='eza' \
@@ -213,4 +204,13 @@ alias c='clear' \
     .4='cd ../../../..' \
     .5='cd ../../../../..' \
     mkdir='mkdir -p' # Always mkdir a path (this doesn't inhibit functionality to make a single dir)
+
+
+# Load plugins
+load_zsh_plugins
+
+# Warn if the shell is slow to load
+autoload -Uz add-zsh-hook
+add-zsh-hook -Uz precmd slow_load_warning
+# add-zsh-hook zshexit cleanup
 


### PR DESCRIPTION
I notice that after update Hyde, my custom sctipts in omz wouldn't load properly.

So I bring back the OMZ loading script at the top of .hyde.zshrc
I think this should be managed by hyde if we use OMZ by defualt.

