### PR TITLE
Fix dunst font setting invalid bug

### DIFF
--- a/Configs/.hyde.zshrc
+++ b/Configs/.hyde.zshrc
@@ -1,6 +1,3 @@
-#  Load OMZ Scripts 
-source $ZSH/oh-my-zsh.sh
-
 #  Startup 
 # Commands on startup (before the prompt is shown)
 # This is a good place to load graphic/ascii art, display system information, etc.

--- a/Configs/.hyde.zshrc
+++ b/Configs/.hyde.zshrc
@@ -1,3 +1,6 @@
+#  Load OMZ Scripts 
+source $ZSH/oh-my-zsh.sh
+
 #  Startup 
 # Commands on startup (before the prompt is shown)
 # This is a good place to load graphic/ascii art, display system information, etc.

--- a/Configs/.local/share/hyde/wallbash/scripts/dunst.sh
+++ b/Configs/.local/share/hyde/wallbash/scripts/dunst.sh
@@ -3,9 +3,9 @@
 # shellcheck source=$HOME/.local/bin/hyde-shell
 # shellcheck disable=SC1091
 if ! source "$(which hyde-shell)"; then
-    echo "[wallbash] code :: Error: hyde-shell not found."
-    echo "[wallbash] code :: Is HyDE installed?"
-    exit 1
+  echo "[wallbash] code :: Error: hyde-shell not found."
+  echo "[wallbash] code :: Is HyDE installed?"
+  exit 1
 fi
 
 confDir="${confDir:-$HOME/.config}"
@@ -70,13 +70,6 @@ WARN
 grep -v '^\s*#' "${dunstDir}/dunst.conf" | grep -v '^\s*$' | envsubst >>"${dunstDir}/dunstrc"
 
 cat <<MANDATORY >>"${dunstDir}/dunstrc"
-# HyDE Mandatory section // Non overridable // please open a request in https://github.com/HyDE-Project/HyDE
-# ------------------------------------------------------------------------------
-[global]
-
-font = ${font_name:-mononoki Nerd Font} 8
-dmenu = $(which rofi) -config notification -dmenu -p dunst:
-
 
 # Wallbash section
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
When modify the dunst font in donst.conf, the modified font will be added to dunstrc, but forced reset to defualt value.

Delete unnecessary font config and duplicate setting of dmenu(witch is already set at the top of the script).
