### PR TITLE
Added volume boost feature: Update volumecontrol.sh

### DIFF
--- a/Configs/.local/lib/hyde/volumecontrol.sh
+++ b/Configs/.local/lib/hyde/volumecontrol.sh
@@ -12,7 +12,7 @@ isNotify=${VOLUME_NOTIFY:-true}
 if command -v swayosd-client >/dev/null 2>&1 && pgrep -x swayosd-server >/dev/null; then
     use_swayosd=true
 fi
-isVolumeBoost=false 
+isVolumeBoost="${VOLUME_BOOST:-false}"
 # Define functions
 
 print_usage() {
@@ -76,11 +76,14 @@ change_volume() {
 
     [ "${action}" = "i" ] && delta="+"
     [ "${srce}" = "--default-source" ] && mode="--input-volume"
-    boost_flag=[ "$isVolumeBoost" = true ] && boost_flag="--allow-boost --set-limit 150"
     case $device in
     "pamixer")
         $use_swayosd && swayosd-client ${mode} "${delta}${step}" && exit 0
-        pamixer "$srce" -"$action" "$step" $boost_flag
+        if [ "$isVolumeBoost" = true ]; then
+            pamixer "$srce" --allow-boost --set-limit "${VOLUME_BOOST_LIMIT:-150}" -"${action}" "$step"
+        else
+            pamixer "$srce" -"${action}" "$step"
+        fi
         vol=$(pamixer "$srce" --get-volume)
         ;;
     "playerctl")

--- a/Configs/.local/lib/hyde/volumecontrol.sh
+++ b/Configs/.local/lib/hyde/volumecontrol.sh
@@ -12,7 +12,7 @@ isNotify=${VOLUME_NOTIFY:-true}
 if command -v swayosd-client >/dev/null 2>&1 && pgrep -x swayosd-server >/dev/null; then
     use_swayosd=true
 fi
-
+isVolumeBoost=false 
 # Define functions
 
 print_usage() {
@@ -50,6 +50,8 @@ EOF
 notify_vol() {
     angle=$((((vol + 2) / 5) * 5))
     iconStyle="knob"
+    # cap the icon at 100 if vol > 100
+    [ "$angle" -gt 100 ] && angle=100
     ico="${icodir}/${iconStyle}-${angle}.svg"
     bar=$(seq -s "." $((vol / 15)) | sed 's/[0-9]//g')
     [[ "${isNotify}" == true ]] && notify-send -a "HyDE Notify" -r 69 -t 800 -i "${ico}" "${vol}${bar}" "${nsink}"
@@ -74,10 +76,11 @@ change_volume() {
 
     [ "${action}" = "i" ] && delta="+"
     [ "${srce}" = "--default-source" ] && mode="--input-volume"
+    boost_flag=[ "$isVolumeBoost" = true ] && boost_flag="--allow-boost --set-limit 150"
     case $device in
     "pamixer")
         $use_swayosd && swayosd-client ${mode} "${delta}${step}" && exit 0
-        pamixer "$srce" -"$action" "$step"
+        pamixer "$srce" -"$action" "$step" $boost_flag
         vol=$(pamixer "$srce" --get-volume)
         ;;
     "playerctl")


### PR DESCRIPTION
# Pull Request

## Description

- Added a mechanism to toggle volume boost using the `isVolumeBoost` flag.
- Set the default volume boost state to `false` (`isVolumeBoost=false`).
- Modified `change_volume` to conditionally apply the `--allow-boost --set-limit 150` flag for `pamixer` when volume boost is enabled.
- Updated `notify_vol` to show a volume icon capped at 100 when the volume exceeds 100.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Motivation

My laptop's volume is pretty low, even at 100%, so I figured enabling volume boost would help improve it.
