### PR TITLE
Feat: Add config option for system monitor

### DIFF
--- a/Configs/.local/lib/hyde/gnome-terminal
+++ b/Configs/.local/lib/hyde/gnome-terminal
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# This is a wrapper script to be use by gtk-launch and other gtk stuff
+# that is expecting users to ALWAYS use the "gnome-terminal" command.
+# -- The HyDE Project --
+
+scrDir="$(dirname "$(realpath "$0")")"
+# shellcheck disable=SC1091
+source "${scrDir}/globalcontrol.sh"
+
+term=${TERMINAL}
+term=${term:-$(gsettings get org.gnome.desktop.default-applications.terminal exec)}
+term=${term:-kitty}
+
+$term "$@"
+cat <<NOTICE
+Note: This is a wrapper script to be use by gtk-launch 
+        and other gtk stuff that is expecting users to 
+        ALWAYS use the \"gnome-terminal\" command."
+
+-- The HyDE Project --
+
+NOTICE

--- a/Configs/.local/lib/hyde/sysmonlaunch.sh
+++ b/Configs/.local/lib/hyde/sysmonlaunch.sh
@@ -3,18 +3,18 @@
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck disable=SC1091
 source "${scrDir}/globalcontrol.sh"
-pkgChk=("io.missioncenter.MissionCenter" "htop" "btop" "top")
+pkgChk=(${UTILS_SYSTEM_MONITOR:-"io.missioncenter.MissionCenter" "htop" "btop" "top"})
 pkgChk+=("${SYSMONITOR_COMMANDS[@]}")
 
 for sysMon in "${!pkgChk[@]}"; do
-    if [ "${sysMon}" -gt 0 ]; then
-        term=$(grep -E '^\s*'"$term" "$HOME/.config/hypr/keybindings.conf" | cut -d '=' -f2 | xargs) # dumb search the config
-        term=${TERMINAL:-$term}                                                                      # Use env var
-        term=${SYSMONITOR_TERMINAL:-$term}                                                           # use the declared variable
-    fi
+  if [ "${sysMon}" != "io.missioncenter.MissionCenter" ]; then
+    term=$(grep -E '^\s*'"$term" "$HOME/.config/hypr/keybindings.conf" | cut -d '=' -f2 | xargs) # dumb search the config
+    term=${TERMINAL:-$term}                                                                      # Use env var
+    term=${SYSMONITOR_TERMINAL:-$term}                                                           # use the declared variable
+  fi
 
-    if pkg_installed "${pkgChk[sysMon]}"; then
-        pkill -x "${pkgChk[sysMon]}" || ${term} "${pkgChk[sysMon]}" &
-        break
-    fi
+  if pkg_installed "${pkgChk[sysMon]}"; then
+    pkill -x "${pkgChk[sysMon]}" || ${term} "${pkgChk[sysMon]}" &
+    break
+  fi
 done

--- a/Configs/.local/lib/hyde/sysmonlaunch.sh
+++ b/Configs/.local/lib/hyde/sysmonlaunch.sh
@@ -3,19 +3,78 @@
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck disable=SC1091
 source "${scrDir}/globalcontrol.sh"
-pkgChk=("${SYSMONITOR_COMMANDS:-("io.missioncenter.MissionCenter" "htop" "btop" "top")}")
-pkgChk=("$SYSMONITOR_EXECUTE" "${pkgChk[@]}")
-pkgChk+=("${SYSMONITOR_COMMANDS[@]}")
+
+show_help() {
+  cat <<HELP
+Usage: $(basename "$0") --[option] 
+    -h, --help  Display this help and exit
+    -e, --execute   Explicit command to execute
+
+Config: ~/.config/hyde/config.toml
+    
+    [sysmonitor]
+    execute = "btop"                    # Default command to execute // accepts executable or app.desktop
+    commands = ["btop", "htop", "top"]  # Fallback command options
+    terminal = "kitty"                  # Explicit terminal // uses \$TERMINAL if available
+
+
+This script launches the system monitor application. 
+    It will launch the first available system monitor 
+    application from the list of 'commands' provided.
+
+
+HELP
+}
+
+case $1 in
+-h | --help)
+  show_help
+  exit 0
+  ;;
+-e | --execute)
+  shift
+  SYSMONITOR_EXECUTE=$1
+  ;;
+-*)
+  echo "Unknown option: $1" >&2
+  exit 1
+  ;;
+esac
+
+pidFile="$HYDE_RUNTIME_DIR/sysmonlaunch.pid"
+
+# TODO: As there is no proper protocol at terminals, we need to find a way to kill the processes
+# * This enables toggling the sysmonitor on and off
+if [ -f "$pidFile" ]; then
+  while IFS= read -r line; do
+    pid=$(awk -F ':::' '{print $1}' <<<"$line")
+    cmd=$(awk -F ':::' '{print $2}' <<<"$line")
+    pkill -P "$pid"
+    pkg_installed flatpak && flatpak kill "$cmd" 2>/dev/null
+  done <"$pidFile"
+  rm "$pidFile"
+  exit 0
+fi
+
+pkgChk=("io.missioncenter.MissionCenter" "htop" "btop" "top")                     # Array of commands to check
+pkgChk+=("${SYSMONITOR_COMMANDS[@]}")                                             # Add the user defined array commands
+[ -n "${SYSMONITOR_EXECUTE}" ] && pkgChk=("${SYSMONITOR_EXECUTE}" "${pkgChk[@]}") # Add the user defined executable
 
 for sysMon in "${!pkgChk[@]}"; do
-  if [ "${sysMon}" != "io.missioncenter.MissionCenter" ]; then
+  if gtk-launch "${pkgChk[sysMon]}"; then
+    pid=$(pgrep -n -f "${pkgChk[sysMon]}")
+    echo "${pid}:::${pkgChk[sysMon]}" >"$pidFile" # Save the PID to the file
+    break
+  fi
+  if pkg_installed "${pkgChk[sysMon]}"; then
     term=$(grep -E '^\s*'"$term" "$HOME/.config/hypr/keybindings.conf" | cut -d '=' -f2 | xargs) # dumb search the config
     term=${TERMINAL:-$term}                                                                      # Use env var
-    term=${SYSMONITOR_TERMINAL:-$term}                                                           # use the declared variable
-  fi
-
-  if pkg_installed "${pkgChk[sysMon]}"; then
-    pkill -x "${pkgChk[sysMon]}" || ${term} "${pkgChk[sysMon]}" &
-    break
+    term=${SYSMONITOR_TERMINAL:-$term}
+    if ${term} "${pkgChk[sysMon]}"; then
+      pid="${!}"
+      echo "${pid}:::${pkgChk[sysMon]}" >"$pidFile" # Save the PID to the file
+      disown
+      break
+    fi
   fi
 done

--- a/Configs/.local/lib/hyde/sysmonlaunch.sh
+++ b/Configs/.local/lib/hyde/sysmonlaunch.sh
@@ -3,7 +3,7 @@
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck disable=SC1091
 source "${scrDir}/globalcontrol.sh"
-pkgChk=(${UTILS_SYSTEM_MONITOR:-"io.missioncenter.MissionCenter" "htop" "btop" "top"})
+read -r -a pkgChk <<<"${UTILS_SYSTEM_MONITOR:-io.missioncenter.MissionCenter htop btop top}"
 pkgChk+=("${SYSMONITOR_COMMANDS[@]}")
 
 for sysMon in "${!pkgChk[@]}"; do

--- a/Configs/.local/lib/hyde/sysmonlaunch.sh
+++ b/Configs/.local/lib/hyde/sysmonlaunch.sh
@@ -3,7 +3,8 @@
 scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck disable=SC1091
 source "${scrDir}/globalcontrol.sh"
-read -r -a pkgChk <<<"${UTILS_SYSTEM_MONITOR:-io.missioncenter.MissionCenter htop btop top}"
+pkgChk=("${SYSMONITOR_COMMANDS:-("io.missioncenter.MissionCenter" "htop" "btop" "top")}")
+pkgChk=("$SYSMONITOR_EXECUTE" "${pkgChk[@]}")
 pkgChk+=("${SYSMONITOR_COMMANDS[@]}")
 
 for sysMon in "${!pkgChk[@]}"; do


### PR DESCRIPTION
Add support for user to select a systom monitor with config option in ~/.config/hyde/config.toml like this.
```toml
[utils]
system_monitor = "btop"
```