### PR TITLE
refactor fastfetch.sh: enhance logo option parsing options

### DIFF
--- a/Configs/.local/lib/hyde/fastfetch.sh
+++ b/Configs/.local/lib/hyde/fastfetch.sh
@@ -20,27 +20,27 @@ options:
 USAGE
 }
 
-confDir="${XDG_CONFIG_HOME:-$HOME/.config}"
-iconDir="${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-image_dirs=()
-
-image_dirs=(
-  "${confDir}/fastfetch/logo"
-  "${iconDir}/Wallbash-Icon/fastfetch/"
-)
-
+# Source state and os-release
 # shellcheck source=/dev/null
 [ -f "$HYDE_STATE_HOME/staterc" ] && source "$HYDE_STATE_HOME/staterc"
 # shellcheck disable=SC1091
 [ -f "/etc/os-release" ] && source "/etc/os-release"
 
+# Set the variables
+confDir="${XDG_CONFIG_HOME:-$HOME/.config}"
+iconDir="${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+image_dirs=()
 hyde_distro_logo=${iconDir}/Wallbash-Icon/distro/$LOGO
+
+# Parse the main command 
 case $1 in
 logo) # eats around 13 ms
   random() {
     (
+      image_dirs+=("${confDir}/fastfetch/logo")
+      image_dirs+=("${iconDir}/Wallbash-Icon/fastfetch/")
       if [ -n "${HYDE_THEME}" ] && [ -d "${confDir}/hyde/themes/${HYDE_THEME}/logo" ]; then
-        image_dirs+=("${confDir}/hyde/themes/${HYDE_THEME}")
+        image_dirs+=("${confDir}/hyde/themes/${HYDE_THEME}/logo")
       fi
       [ -d "$HYDE_CACHE_HOME" ] && image_dirs+=("$HYDE_CACHE_HOME")
       [ -f "$hyde_distro_logo" ] && echo "${hyde_distro_logo}"
@@ -51,20 +51,29 @@ logo) # eats around 13 ms
   }
   help() {
     cat <<HELP
-    Usage: ${0##*/} logo [option]
+Usage: ${0##*/} logo [option]
 
 options:
-  --quad  Display a quad wallpaper logo
-  --sqre  Display a square wallpaper logo
-  --prof  Display your profile picture (~/.face.icon)
-  --rand  Display a random logo
-  *       Display a random logo
-  *help*  Display this help message
+  --quad    Display a quad wallpaper logo
+  --sqre    Display a square wallpaper logo
+  --prof    Display your profile picture (~/.face.icon)
+  --os      Display the distro logo
+  --local   Display a logo inside the fastfetch logo directory
+  --wall    Display a logo inside the wallbash fastfetch directory
+  --theme   Display a logo inside the hyde theme directory
+  --rand    Display a random logo
+  *         Display a random logo
+  *help*    Display this help message
+
+Note: Options can be combined to search across multiple sources
+Example: ${0##*/} logo --local --os --prof
 HELP
   }
 
+  # Parse the logo options
   shift
   [ -z "${*}" ] && random && exit
+  [[ "$1" = "--rand" ]] && random && exit
   [[ "$1" = *"help"* ]] && help && exit
   (
     for arg in "$@"; do
@@ -78,12 +87,24 @@ HELP
       --prof)
         [ -f "$HOME/.face.icon" ] && echo "$HOME/.face.icon"
         ;;
-      --rand)
-        random
+      --os)
+        echo "$hyde_distro_logo"
+        ;;
+      --local)
+        image_dirs+=("${confDir}/fastfetch/logo")
+        ;;
+      --wall)
+        image_dirs+=("${iconDir}/Wallbash-Icon/fastfetch/")
+        ;;
+      --theme)
+        if [ -n "${HYDE_THEME}" ] && [ -d "${confDir}/hyde/themes/${HYDE_THEME}/logo" ]; then
+          image_dirs+=("${confDir}/hyde/themes/${HYDE_THEME}/logo")
+        fi
         ;;
       esac
     done
-  ) | shuf -n 1
+	find -L "${image_dirs[@]}" -maxdepth 1 -type f \( -name "wall.quad" -o -name "wall.sqre" -o -name "*.icon" -o -name "*logo*" -o -name "*.png" \) ! -path "*/wall.set*" ! -path "*/wallpapers/*.png" 2>/dev/null
+   ) | shuf -n 1
 
   ;;
 --select | -S)


### PR DESCRIPTION
# Pull Request
This is the MR for issue #282 

## Description
fastfetch.sh now has more options to choose the logo from. The following options has been added:
```
--os      Display the distro logo
--local   Display a logo inside the fastfetch logo directory
--wall    Display a logo inside the wallbash fastfetch directory
--theme   Display a logo inside the hyde theme directory
```

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Addition info

- If you have 4 logos inside your local map, then `fastfetch.sh logo --local --os` will 4/5 times display a logo out of your local map and 1/5 times the os logo. Not 50/50 as it was previously:  `fastfetch.sh logo --quad --rand` (as `--rand` was the only option with multiple icons inside)
- `--rand` now only works if it is directly after logo. So `fastfetch.sh logo --local --rand` acts the same as `fastfetch.sh logo --local`
- On my speed tests, the speed is similar to the old script. It always takes between 3.5 and 7ms on my system (no matter the arguments)

## Additional questions

Should there be a comment on the functionality of this inside `fastfatech/config/jsonc` ?
