### PR TITLE
Fix: README.md stars section dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-P
 
 <a href="https://star-history.com/#hyde-project/hyde&hyde-project/hyde-gallery&hyde-project/hyde-themes&Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hyde-project/hyde,hyde-project/hyde-gallery,hyde-project/hyde-themes&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hyde-project/hyde,hyde-project/hyde-gallery,hyde-project/hyde-themes&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=hyde-project/hyde,hyde-project/hyde-gallery,hyde-project/hyde-themes&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hyde-project/hyde&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hyde-project/hyde&type=Timeline" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=hyde-project/hyde&type=Timeline" />
  </picture>
 </a>


### PR DESCRIPTION
# Pull Request
Fix dark theme not rendering issue (#297)

Now it correctly renders for both dark and light theme instead of being light by default.

## Screenshots
How it was:
![image](https://github.com/user-attachments/assets/4782cc30-3934-4085-9620-d17af78f0397)
![image](https://github.com/user-attachments/assets/8e14bcfb-d30b-47c1-ad32-b7e67f9c240f)


How it is now:
![image](https://github.com/user-attachments/assets/3788cd32-80e8-4121-9833-dd54c18f235e)
![image](https://github.com/user-attachments/assets/3fecc2c1-84a7-485f-8843-117b0aa44995)

