### PR TITLE
Fix: Update Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Multi-language README support
 <a href="#styles"><kbd> <br> Styles <br> </kbd></a>&ensp;&ensp;
 <a href="KEYBINDINGS.md"><kbd> <br> Keybindings <br> </kbd></a>&ensp;&ensp;
 <a href="https://www.youtube.com/watch?v=2rWqdKU1vu8&list=PLt8rU_ebLsc5yEHUVsAQTqokIBMtx3RFY&index=1"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-<a href="https://github.com/hyde-project/hyde/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+<a href="https://hydeproject.pages.dev/"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
 <a href="https://discord.gg/qWehcFJxPa"><kbd> <br> Discord <br> </kbd></a>
 
 </div><br><br>
@@ -228,7 +228,7 @@ For more information, visit [HyDE-Project/hyde-themes](https://github.com/HyDE-P
 </div>
 
 <div align="right">
-  <sub>Last edited on: 02/01/2025<span id="last-edited"></span></sub>
+  <sub>Last edited on: 27/02/2025<span id="last-edited"></span></sub>
 </div>
 
 <a id="star_history"></a>

--- a/Source/docs/README.de.md
+++ b/Source/docs/README.de.md
@@ -25,7 +25,7 @@ Mehrsprachige README-Unterstützung
   <a href="#stile"><kbd> <br> Stile <br> </kbd></a>&ensp;&ensp;
   <a href="KEYBINDINGS.de.md"><kbd> <br> Tastenkombinationen <br> </kbd></a>&ensp;&ensp;
   <a href="https://www.youtube.com/watch?v=2rWqdKU1vu8&list=PLt8rU_ebLsc5yEHUVsAQTqokIBMtx3RFY&index=1"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/hyde-project/hyde/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+  <a href="https://hydeproject.pages.dev/"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
   <a href="https://discord.gg/qWehcFJxPa"><kbd> <br> Discord <br> </kbd></a>
 </div><br><br>
 
@@ -237,5 +237,5 @@ Weitere Informationen finden Sie unter [HyDE-Project/hyde-themes](https://github
 </div>
 
 <div align="right">
-  <sub>Zuletzt bearbeitet am: 01.02.2025<span id="last-edited"></span></sub>
+  <sub>Zuletzt bearbeitet am: 27.02.2025<span id="last-edited"></span></sub>
 </div>

--- a/Source/docs/README.es.md
+++ b/Source/docs/README.es.md
@@ -28,7 +28,7 @@ Soporte multilingüe para el README
 <a href="#estilos"><kbd> <br> Estilos <br> </kbd></a>&ensp;&ensp;
 <a href="KEYBINDINGS.es.md"><kbd> <br> Combinaciones <br> </kbd></a>&ensp;&ensp;
 <a href="https://www.youtube.com/watch?v=2rWqdKU1vu8&list=PLt8rU_ebLsc5yEHUVsAQTqokIBMtx3RFY&index=1"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-<a href="https://github.com/hyde-project/hyde/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+<a href="https://hydeproject.pages.dev/"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
 <a href="https://discord.gg/qWehcFJxPa"><kbd> <br> Discord <br> </kbd></a>
 
 </div><br><br>

--- a/Source/docs/README.nl.md
+++ b/Source/docs/README.nl.md
@@ -25,7 +25,7 @@ Multi-language README support
   <a href="#stijlen"><kbd> <br> Stijlen <br> </kbd></a>&ensp;&ensp;
   <a href="KEYBINDINGS.nl.md"><kbd> <br> Toetscombinaties <br> </kbd></a>&ensp;&ensp;
   <a href="https://www.youtube.com/watch?v=2rWqdKU1vu8&list=PLt8rU_ebLsc5yEHUVsAQTqokIBMtx3RFY&index=1"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/hyde-project/hyde/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+  <a href="https://hydeproject.pages.dev/"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
   <a href="https://discord.gg/qWehcFJxPa"><kbd> <br> Discord <br> </kbd></a>
 </div><br><br>
 
@@ -195,5 +195,5 @@ Voor meer informatie, bezoek [HyDE-Project/hyde-themes](https://github.com/HyDE-
 </div>
 
 <div align="right">
-  <sub>Laatst bewerkt op: 02/01/2025<span id="last-edited"></span></sub>
+  <sub>Laatst bewerkt op: 27/02/2025<span id="last-edited"></span></sub>
 </div>

--- a/Source/docs/README.zh.md
+++ b/Source/docs/README.zh.md
@@ -29,7 +29,7 @@ Multi-language README support
 <a href="#styles"><kbd> <br> 风格 <br> </kbd></a>&ensp;&ensp;
 <a href="KEYBINDINGS.zh.md"><kbd> <br> 按键映射 <br> </kbd></a>&ensp;&ensp;
 <a href="https://www.youtube.com/watch?v=2rWqdKU1vu8&list=PLt8rU_ebLsc5yEHUVsAQTqokIBMtx3RFY&index=1"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-<a href="https://github.com/hyde-project/hyde/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+<a href="https://hydeproject.pages.dev/"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
 <a href="https://discord.gg/qWehcFJxPa"><kbd> <br> Discord <br> </kbd></a>
 
 </div><br><br>
@@ -230,5 +230,5 @@ For more details, you can refer to [Hyde-cli - dots management wiki](https://git
 </div>
 
 <div align="right">
-  <sub>最后编辑: 02/01/2025<span id="last-edited"></span></sub>
+  <sub>最后编辑: 27/02/2025<span id="last-edited"></span></sub>
 </div>


### PR DESCRIPTION
# Pull Request
The wiki button in `README.md` now links to the website (https://hydeproject.pages.dev/) instead of the GitHub wiki.

