### PR TITLE
fix: Fix spelling/wording in default keybindings

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -59,10 +59,10 @@ bindde = $mainMod Shift, Down, $d resize  window down, resizeactive, 0 30
 # Move active window around current workspace with mainMod + Shift + Control [←→↑↓]
 $d=[$wm|Move active window across workspace]
 $moveactivewindow=grep -q "true" <<< $(hyprctl activewindow -j | jq -r .floating) && hyprctl dispatch moveactive
-bindde = $mainMod Shift Control, left, Move activewindow to the right, exec, $moveactivewindow -30 0 || hyprctl dispatch movewindow l
+bindde = $mainMod Shift Control, left, Move activewindow to the left, exec, $moveactivewindow -30 0 || hyprctl dispatch movewindow l
 bindde = $mainMod Shift Control, right, Move activewindow to the right, exec, $moveactivewindow 30 0 || hyprctl dispatch movewindow r
-bindde = $mainMod Shift Control, up, Move activewindow to the right, exec, $moveactivewindow  0 -30 || hyprctl dispatch movewindow u
-bindde = $mainMod Shift Control, down, Move activewindow to the right, exec, $moveactivewindow 0 30 || hyprctl dispatch movewindow d
+bindde = $mainMod Shift Control, up, Move activewindow up, exec, $moveactivewindow  0 -30 || hyprctl dispatch movewindow u
+bindde = $mainMod Shift Control, down, Move activewindow down, exec, $moveactivewindow 0 30 || hyprctl dispatch movewindow d
 
 # Move/Resize focused window
 $d=[$wm|Move & Resize with mouse]


### PR DESCRIPTION
# Pull Request

<!--
MUlti-language PULL_REQUEST_TEMPLATE support
-->

[![es](https://img.shields.io/badge/lang-es-yellow.svg)](PULL_REQUEST_TEMPLATE.es.md)
[![de](https://img.shields.io/badge/lang-de-black.svg)](PULL_REQUEST_TEMPLATE.de.md)
[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](PULL_REQUEST_TEMPLATE.fr.md)

## Description

Purely a spelling/wording PR
E.g.
```
bindde = $mainMod Shift Control, left, Move activewindow to the left, exec $moveactivewindow -30 0 || hyprctl dispatch movewindow l

```
Changed to accurately reflect what the keybind is doing.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

Before
![image](https://github.com/user-attachments/assets/63d423cd-07d5-4e0d-a553-bbecc11d2065)
After
![image](https://github.com/user-attachments/assets/52168e6d-a595-484b-b8e9-4384594ca025)

