### PR TITLE
fix: change plugin and alias load order in .zshenv

### DIFF
--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -183,6 +183,8 @@ if [ -t 1 ];then
     # Optionally load user configuration // usefull for customizing the shell without modifying the main file
     [[ -f ~/.hyde.zshrc ]] && source ~/.hyde.zshrc
 
+    # Load plugins
+    load_zsh_plugins
 
     # Helpful aliases
     if [[ -x "$(which eza)" ]]; then
@@ -209,9 +211,6 @@ if [ -t 1 ];then
         .5='cd ../../../../..' \
         mkdir='mkdir -p' # Always mkdir a path (this doesn't inhibit functionality to make a single dir)
 
-
-    # Load plugins
-    load_zsh_plugins
 
     # Warn if the shell is slow to load
     autoload -Uz add-zsh-hook


### PR DESCRIPTION
# Pull Request

## Description

This commit changes the order of plugin loading function and alias definition in .zshenv to make the default 'ls' alias of HyDE works as expected. The original order defines the alias first before calling the function to load plugins. However, that function executes the script oh-my-zsh.sh, which in turn executes the scripts in the "lib" folder of oh-my-zsh. Some of these scripts redefine the 'ls' alias to the default of Oh My Zsh.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
