### PR TITLE
fix: fix the package manager alias

### DIFF
--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -62,34 +62,6 @@ function load_zsh_plugins {
     [[ -r $ZSH/oh-my-zsh.sh ]] && source $ZSH/oh-my-zsh.sh
 }
 
-# Install packages from both Arch and AUR
-function in {
-    local -a inPkg=("$@")
-    local -a arch=()
-    local -a aur=()
-
-    # If `in` is called with no argument, let the user choose the packages interactively
-    if [[ ${#inPkg[@]} -eq 0 ]]; then
-        ${PM} install
-    fi
-
-    for pkg in "${inPkg[@]}"; do
-        if pacman -Si "${pkg}" &>/dev/null; then
-            arch+=("${pkg}")
-        else
-            aur+=("${pkg}")
-        fi
-    done
-
-    if [[ ${#arch[@]} -gt 0 ]]; then
-        sudo pacman -S "${arch[@]}"
-    fi
-
-    if [[ ${#aur[@]} -gt 0 ]]; then
-        ${PM} install "${aur[@]}"
-    fi
-}
-
 # Function to display a slow load warning
 function slow_load_warning {
     local lock_file="/tmp/.hyde_slow_load_warning.lock"
@@ -203,6 +175,7 @@ if [ -t 1 ]; then
     fi
 
     alias c='clear' \
+        in='$PM install' \
         un='$PM remove' \
         up='$PM upgrade' \
         pl='$PM search installed' \

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -68,6 +68,11 @@ function in {
     local -a arch=()
     local -a aur=()
 
+    # If `in` is called with no argument, let the user choose the packages interactively
+    if [[ ${#inPkg[@]} -eq 0 ]]; then
+        ${PM} install
+    fi
+
     for pkg in "${inPkg[@]}"; do
         if pacman -Si "${pkg}" &>/dev/null; then
             arch+=("${pkg}")
@@ -81,7 +86,7 @@ function in {
     fi
 
     if [[ ${#aur[@]} -gt 0 ]]; then
-        ${PM} -S "${aur[@]}"
+        ${PM} install "${aur[@]}"
     fi
 }
 
@@ -198,10 +203,10 @@ if [ -t 1 ]; then
     fi
 
     alias c='clear' \
-        un='$PM uninstall' \
+        un='$PM remove' \
         up='$PM upgrade' \
         pl='$PM search installed' \
-        pa='$PM search installed' \
+        pa='$PM search all' \
         vc='code' \
         fastfetch='fastfetch --logo-type kitty' \
         ..='cd ..' \


### PR DESCRIPTION
# Pull Request

## Description

Some package manager aliases in `.zshenv` were using the wrong `pm.sh` command and so will not work. I fixed those to the correct `pm.sh` command. I also make the `in` alias to open an interactive panel for choosing package when it is called without any argument. This makes `in` to be more parallel to `un`.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
