### PR TITLE
Parallelize pkg_installed

### DIFF
--- a/Configs/.local/lib/hyde/globalcontrol.sh
+++ b/Configs/.local/lib/hyde/globalcontrol.sh
@@ -166,16 +166,12 @@ fi
 #// extra fns
 
 pkg_installed() {
-    local pkgIn=$1
-    if hyde-shell pm.sh pq "${pkgIn}" &>/dev/null; then
-        return 0
-    elif pacman -Qi "flatpak" &>/dev/null && flatpak info "${pkgIn}" &>/dev/null; then
-        return 0
-    elif command -v "${pkgIn}" &>/dev/null; then
-        return 0
-    else
-        return 1
-    fi
+    local pkgIn="$1"
+    parallel --halt now,success=1 --jobs 3 '{}' ::: \
+      "hyde-shell pm.sh pq '${pkgIn}' &>/dev/null" \
+      "( pacman -Qi flatpak >/dev/null 2>&1 && flatpak info '${pkgIn}' &>/dev/null )" \
+      "command -v '${pkgIn}' &>/dev/null" \
+    && return 0 || return 1
 }
 
 get_aurhlpr() {

--- a/Configs/.local/lib/hyde/globalcontrol.sh
+++ b/Configs/.local/lib/hyde/globalcontrol.sh
@@ -165,23 +165,13 @@ fi
 
 #// extra fns
 
-# Check packages concurrently (faster) with fallback to sequential method
 pkg_installed() {
-    local pkgIn="$1"
-    parallel --halt now,success=1 --jobs 3 '{}' ::: \
-        "hyde-shell pm.sh pq '${pkgIn}' &>/dev/null" \
-        "( pacman -Qi flatpak >/dev/null 2>&1 && flatpak info '${pkgIn}' &>/dev/null )" \
-        "command -v '${pkgIn}' &>/dev/null" &&
-        return 0 || return 1
-}
-
-pkg_installed_sequential() {
     local pkgIn=$1
-    if hyde-shell pm.sh pq "${pkgIn}" &>/dev/null; then
+    if command -v "${pkgIn}" &>/dev/null; then
         return 0
-    elif pacman -Qi "flatpak" &>/dev/null && flatpak info "${pkgIn}" &>/dev/null; then
+    elif command -v "flatpak" &>/dev/null && flatpak info "${pkgIn}" &>/dev/null; then
         return 0
-    elif command -v "${pkgIn}" &>/dev/null; then
+    elif hyde-shell pm.sh pq "${pkgIn}" &>/dev/null; then
         return 0
     else
         return 1


### PR DESCRIPTION
**Check three at the same time to save time.**

In resent update, pkg_installed was called in rofi launch script, and it is very slow when uwsm is not installed, so I parallelize it to deal with the lag.