### PR TITLE
refactor: style match emoji-picker.sh with glyph-picker.sh

### DIFF
--- a/Configs/.local/lib/hyde/emoji-picker.sh
+++ b/Configs/.local/lib/hyde/emoji-picker.sh
@@ -77,11 +77,6 @@ parse_arguments() {
             use_rofile=${2}
             shift
             ;;
-        --deps)
-            # nonexistent function?
-            resolve_deps
-            exit 0
-            ;;
         -*)
             cat <<HELP
 Usage:

--- a/Configs/.local/lib/hyde/emoji-picker.sh
+++ b/Configs/.local/lib/hyde/emoji-picker.sh
@@ -1,73 +1,89 @@
 #!/usr/bin/env bash
 
-# Set variables
-scrDir=$(dirname "$(realpath "$0")")
-scrDir="${scrDir:-$HOME/.config/hyde}"
-# shellcheck disable=SC1091
-source "$scrDir/globalcontrol.sh"
-confDir="${confDir:-$XDG_CONFIG_HOME}"
-cacheDir="${cacheDir:-$XDG_CACHE_HOME/hyde}"
+# shellcheck disable=SC1090
+if ! source "$(command -v hyde-shell)"; then
+    echo "[wallbash] code :: Error: hyde-shell not found."
+    echo "[wallbash] code :: Is HyDE installed?"
+    exit 1
+fi
 
-# Set rofi scaling
-font_scale="${ROFI_EMOJI_SCALE}"
-[[ "${font_scale}" =~ ^[0-9]+$ ]] || font_scale=${ROFI_SCALE:-10}
+# Define paths and files
+emoji_dir=${HYDE_DATA_HOME:-$HOME/.local/share/hyde}
+emoji_data="${emoji_dir}/emoji.db"
+cache_dir="${HYDE_CACHE_HOME:-$HOME/.cache/hyde}"
+recent_data="${cache_dir}/landing/show_emoji.recent"
 
-# set font name
-font_name=${ROFI_EMOJI_FONT:-$ROFI_FONT}
-font_name=${font_name:-$(get_hyprConf "MENU_FONT")}
-font_name=${font_name:-$(get_hyprConf "FONT")}
+# checks if an emoji entry is valid
+is_valid_emoji() {
+    local emoji_entry="$1"
 
-# set rofi font override
-font_override="* {font: \"${font_name:-"JetBrainsMono Nerd Font"} ${font_scale}\";}"
+    # return false if emoji is empty or unique_entries is not set
+    [[ -z "${emoji_entry}" || -z "${unique_entries}" ]] && return 1
 
-hypr_border=${hypr_border:-"$(hyprctl -j getoption decoration:rounding | jq '.int')"}
-wind_border=$((hypr_border * 3 / 2))
-elem_border=$((hypr_border == 0 ? 5 : hypr_border))
-
-# Set rofi location
-rofi_position=$(get_rofi_pos)
-
-hypr_width=${hypr_width:-"$(hyprctl -j getoption general:border_size | jq '.int')"}
-r_override="window{border:${hypr_width}px;border-radius:${wind_border}px;}wallbox{border-radius:${elem_border}px;} element{border-radius:${elem_border}px;}"
-
-save_recent() {
-    # Only proceed if a valid emoji entry was selected
-    [ -z "${dataEmoji}" ] && return 0
-    # Verify that the full selected entry (emoji with description) exists in the valid list
-    if ! echo -e "${unique_entries}" | grep -Fxq "${dataEmoji}"; then
-        return 0
-    fi
-    # Prepend the full selected emoji entry to the top of the recentData file
-    awk -v var="$dataEmoji" 'BEGIN { print var } { print }' "${recentData}" >temp && mv temp "${recentData}"
-    # Remove duplicates and empty lines, keeping the most recent entry at the top
-    awk 'NF' "${recentData}" | awk '!seen[$0]++' >temp && mv temp "${recentData}"
+    # uses bash's pattern matching instead of echo and grep
+    echo -e "${unique_entries}" | grep -Fxq "${emoji_entry}"
 }
 
+# save selected emoji to recent list, remove duplicates
+save_recent() {
+    is_valid_emoji "${data_emoji}" || return 0
+    awk -v var="$data_emoji" 'BEGIN{print var} {print}' "${recent_data}" >temp && mv temp "${recent_data}"
+    awk 'NF' "${recent_data}" | awk '!seen[$0]++' >temp && mv temp "${recent_data}"
+}
 
-# Loop through all arguments
-while (($# > 0)); do
-    case $1 in
-    --style | -s)
-        if (($# > 1)); then
-            emoji_style="$2"
-            shift # Consume the value argument
-        else
-            print_log +y "[warn] " "--style needs argument"
-            emoji_style="clipboard"
+# rofi settings
+setup_rofi_config() {
+    # font scale
+    local font_scale="${ROFI_EMOJI_SCALE}"
+    [[ "${font_scale}" =~ ^[0-9]+$ ]] || font_scale=${ROFI_SCALE:-10}
+
+    # font name
+    local font_name=${ROFI_EMOJI_FONT:-$ROFI_FONT}
+    font_name=${font_name:-$(get_hyprConf "MENU_FONT")}
+    font_name=${font_name:-$(get_hyprConf "FONT")}
+
+    # rofi font override
+    font_override="* {font: \"${font_name:-"JetBrainsMono Nerd Font"} ${font_scale}\";}"
+
+    # border settings
+    local hypr_border=${hypr_border:-"$(hyprctl -j getoption decoration:rounding | jq '.int')"}
+    local wind_border=$((hypr_border * 3 / 2))
+    local elem_border=$((hypr_border == 0 ? 5 : hypr_border))
+
+    # rofi position
+    rofi_position=$(get_rofi_pos)
+
+    # border width
+    local hypr_width=${hypr_width:-"$(hyprctl -j getoption general:border_size | jq '.int')"}
+    r_override="window{border:${hypr_width}px;border-radius:${wind_border}px;}wallbox{border-radius:${elem_border}px;} element{border-radius:${elem_border}px;}"
+}
+
+# Parse command line arguments
+parse_arguments() {
+    while (($# > 0)); do
+        case $1 in
+        --style | -s)
+            if (($# > 1)); then
+                emoji_style="$2"
+                shift # Consume the value argument
+            else
+                print_log +y "[warn] " "--style needs argument"
+                emoji_style="clipboard"
+                shift
+            fi
+            ;;
+        --rasi)
+            [[ -z ${2} ]] && print_log +r "[error] " +y "--rasi requires an file.rasi config file" && exit 1
+            use_rofile=${2}
             shift
-        fi
-        ;;
-    --rasi)
-        [[ -z ${2} ]] && print_log +r "[error] " +y "--rasi requires an file.rasi config file" && exit 1
-        useRofile=${2}
-        shift
-        ;;
-    --deps)
-        resolve_deps
-        exit 0
-        ;;
-    -*)
-        cat <<HELP
+            ;;
+        --deps)
+            # nonexistent function?
+            resolve_deps
+            exit 0
+            ;;
+        -*)
+            cat <<HELP
 Usage:
 --style [1 | 2]     Change Emoji style
                     Add 'emoji_style=[1|2]' variable in .~/.config/hyde/config.toml'
@@ -76,60 +92,84 @@ Usage:
                     or select styles from 'rofi-theme-selector'
 HELP
 
-        exit 0
-        ;;
-    esac
-    shift # Shift off the current option being processed
-done
+            exit 0
+            ;;
+        esac
+        shift # Shift off the current option being processed
+    done
+}
 
-emojiDir=${XDG_DATA_HOME:-$HOME/.local/share}/hyde
-emojiData="${emojiDir}/emoji.db"
-recentData="${cacheDir}/landing/show_emoji.recent"
+# Get emoji selection from rofi
+get_emoji_selection() {
+    if [[ -n ${use_rofile} ]]; then
+        echo "${unique_entries}" | rofi -dmenu -i -config "${use_rofile}"
+    else
+        local style_type="${emoji_style:-$ROFI_EMOJI_STYLE}"
+        case ${style_type} in
+        2 | grid)
+            local size_override=""
+            echo "${unique_entries}" | rofi -dmenu -i -display-columns 1 \
+                -display-column-separator " " \
+                -theme-str "listview {columns: 8;}" \
+                -theme-str "entry { placeholder: \" 🔎 Emoji\";} ${rofi_position} ${r_override}" \
+                -theme-str "${font_override}" \
+                -theme-str "${size_override}" \
+                -theme "clipboard"
+            ;;
+        1 | list)
+            echo "${unique_entries}" | rofi -dmenu -multi-select -i \
+                -theme-str "entry { placeholder: \" 🔎 Emoji\";} ${rofi_position} ${r_override}" \
+                -theme-str "${font_override}" \
+                -theme "clipboard"
+            ;;
+        *)
+            echo "${unique_entries}" | rofi -dmenu -multi-select -i \
+                -theme-str "entry { placeholder: \" 🔎 Emoji\";} ${rofi_position} ${r_override}" \
+                -theme-str "${font_override}" \
+                -theme "${style_type:-clipboard}"
+            ;;
+        esac
+    fi
+}
 
-if [[ ! -f "${recentData}" ]]; then
-    echo "    Arch linux I use Arch BTW" >"${recentData}"
-fi
-#? Read the contents of recent.db and main.db separately
-recent_entries=$(cat "${recentData}")
-main_entries=$(cat "${emojiData}")
-#? Combine the recent entries with the main entries
-combined_entries="${recent_entries}\n${main_entries}"
-#? Remove duplicates from the combined entries
-unique_entries=$(echo -e "${combined_entries}" | awk '!seen[$0]++')
+main() {
+    # Parse command line arguments
+    parse_arguments "$@"
 
-if [[ -n ${useRofile} ]]; then
-    dataEmoji=$(rofi -dmenu -i -config "${useRofile}" <<<"${unique_entries}")
-else
-    emoji_style="${emoji_style:-$ROFI_EMOJI_STYLE}"
-    case ${emoji_style} in
-    2 | grid)
-        size_override=""
-        dataEmoji=$(rofi -dmenu -i -display-columns 1 \
-            -display-column-separator " " \
-            -theme-str "listview {columns: 8;}" \
-            -theme-str "entry { placeholder: \" 🔎 Emoji\";} ${rofi_position} ${r_override}" \
-            -theme-str "${font_override}" \
-            -theme-str "${size_override}" \
-            -theme "clipboard" <<<"${unique_entries}")
-        ;;
-    1 | list)
-        dataEmoji=$(rofi -dmenu -multi-select -i \
-            -theme-str "entry { placeholder: \" 🔎 Emoji\";} ${rofi_position} ${r_override}" \
-            -theme-str "${font_override}" \
-            -theme "clipboard" <<<"${unique_entries}")
-        ;;
-    *)
-        dataEmoji=$(rofi -dmenu -multi-select -i \
-            -theme-str "entry { placeholder: \" 🔎 Emoji\";} ${rofi_position} ${r_override}" \
-            -theme-str "${font_override}" \
-            -theme "${emoji_style:-clipboard}" <<<"${unique_entries}")
-        ;;
-    esac
-fi
+    # create recent data file if it doesn't exist
+    if [[ ! -f "${recent_data}" ]]; then
+        mkdir -p "$(dirname "${recent_data}")"
+        echo " Arch linux - I use Arch, BTW" >"${recent_data}"
+    fi
 
-# selEmoji=$(echo -n "${selEmoji}" | cut -d' ' -f1 | tr -d '\n' | wl-copy)
+    # read recent and main entries
+    local recent_entries main_entries
+    recent_entries=$(cat "${recent_data}")
+    main_entries=$(cat "${emoji_data}")
+
+    # combine entries and remove duplicates
+    combined_entries="${recent_entries}\n${main_entries}"
+    unique_entries=$(echo -e "${combined_entries}" | awk '!seen[$0]++')
+
+    # rofi config
+    setup_rofi_config
+
+    # get emoji selection from rofi
+    data_emoji=$(get_emoji_selection)
+
+    # avoid copying typed text to clipboard, only copy valid emoji
+    [ -z "${data_emoji}" ] && exit 0
+
+    # extract and copy selected emoji(s)
+    local sel_emoji
+    sel_emoji=$(printf "%s" "${data_emoji}" | cut -d' ' -f1 | tr -d '\n\r')
+
+    wl-copy "${sel_emoji}"
+    paste_string "${@}"
+}
+
+# exit trap to save recent emojis
 trap save_recent EXIT
-selEmoji=$(printf "%s" "${dataEmoji}" | cut -d' ' -f1 | tr -d '\n\r')
-[ -z "${selEmoji}" ] && exit 0
-wl-copy "${selEmoji}"
-paste_string "${*}"
+
+# run main function
+main "$@"


### PR DESCRIPTION
# Pull Request

<!--
MUlti-language PULL_REQUEST_TEMPLATE support
-->

[![es](https://img.shields.io/badge/lang-es-yellow.svg)](PULL_REQUEST_TEMPLATE.es.md)
[![de](https://img.shields.io/badge/lang-de-black.svg)](PULL_REQUEST_TEMPLATE.de.md)
[![fr](https://img.shields.io/badge/lang-fr-blue.svg)](PULL_REQUEST_TEMPLATE.fr.md)

## Description

Refactor emoji-picker to match the style of glyph-picker due to their similar functionality. Improves code readability and maintainability, and migrates variables to snake_case.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.
