### PR TITLE
Enhance Kitty Tab Bar Appearance and Add "New Tab in Current Directory" Shortcut and Add commented guides  to minimize latency in kitty 

### DIFF
--- a/Configs/.config/kitty/hyde.conf
+++ b/Configs/.config/kitty/hyde.conf
@@ -10,23 +10,6 @@ font_size 9.0
 window_padding_width 25
 cursor_trail 1
 
-# Minimal Tab bar styling 
-tab_bar_edge                bottom
-tab_bar_style               powerline
-tab_powerline_style         slanted
-tab_title_template          {title}{' :{}:'.format(num_windows) if num_windows > 1 else ''}
-
-# remap to open new kitty tab in the same dir
-map ctrl+shift+t            new_tab_with_cwd
-
-# Uncomment the following 4 lines to minimize kitty latency (higher energy usage)
-# input_delay 0
-# repaint_delay 2
-# sync_to_monitor no
-# wayland_enable_ime no
-
-
-
 # Themes can override any settings in this file
 include theme.conf
 #background_opacity 0.60

--- a/Configs/.config/kitty/hyde.conf
+++ b/Configs/.config/kitty/hyde.conf
@@ -10,6 +10,23 @@ font_size 9.0
 window_padding_width 25
 cursor_trail 1
 
+# Minimal Tab bar styling 
+tab_bar_edge                bottom
+tab_bar_style               powerline
+tab_powerline_style         slanted
+tab_title_template          {title}{' :{}:'.format(num_windows) if num_windows > 1 else ''}
+
+# remap to open new kitty tab in the same dir
+map ctrl+shift+t            new_tab_with_cwd
+
+# Uncomment the following 4 lines to minimize kitty latency (higher energy usage)
+# input_delay 0
+# repaint_delay 2
+# sync_to_monitor no
+# wayland_enable_ime no
+
+
+
 # Themes can override any settings in this file
 include theme.conf
 #background_opacity 0.60

--- a/Configs/.config/kitty/kitty.conf
+++ b/Configs/.config/kitty/kitty.conf
@@ -1,2 +1,16 @@
 include hyde.conf
-# Add your custom configurations here
+
+# Minimal Tab bar styling 
+tab_bar_edge                bottom
+tab_bar_style               powerline
+tab_powerline_style         slanted
+tab_title_template          {title}{' :{}:'.format(num_windows) if num_windows > 1 else ''}
+
+# remap to open new kitty tab in the same directory (default is home dir)
+# map ctrl+shift+t            new_tab_with_cwd
+
+# Uncomment the following 4 lines to minimize kitty latency (higher energy usage)
+# input_delay 0
+# repaint_delay 2
+# sync_to_monitor no
+# wayland_enable_ime no


### PR DESCRIPTION
feat:  add Kitty tab bar styling and add new tab shortcut

# Pull Request

## Description
Summary of Changes:

This pull request refines the Kitty terminal's appearance with minimal tab bar styling and introduces a more intuitive keyboard shortcut (Ctrl+Shift+T) for opening a new tab in the current working directory.

Motivation and Context:

The default Kitty tab bar appearance was considered less visually appealing. This change implements a minimal styling to improve its aesthetics by placing it at the bottom, using a powerline style with slanted separators, and displaying the number of windows when relevant.

Additionally, a new keyboard shortcut (Ctrl+Shift+T) has been added to open a new tab within the current working directory. This provides a more direct and commonly expected behavior for users who frequently need to open new tabs in the same location. While the default $mod+t shortcut remains available for opening a new tab with the default behavior, Ctrl+Shift+T offers a more relatable alternative for this specific use case.

The commented-out lines related to performance optimization are taken directly from the official Kitty documentation (https://sw.kovidgoyal.net/kitty/performance/) and were included for potential future experimentation with latency reduction. They are not active in this commit.

Dependencies:

No new dependencies are introduced by this change.


## Type of change

Please put an `x` in the boxes that apply:

- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![250416_21h00m17s_screenshot](https://github.com/user-attachments/assets/4862b48b-8834-4002-80f3-d9432f4cac7c)


## Additional context

In some kitty colorschemes (themes) the default tab bar title was unreadable, this PR also fixes it