### PR TITLE
Fix hyprland keybinds

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -47,7 +47,7 @@ bindd = $mainMod, Left, $d focus left, movefocus, l
 bindd = $mainMod, Right, $d focus right , movefocus, r
 bindd = $mainMod, Up, $d focus up , movefocus, u
 bindd = $mainMod, Down , $d focus down, movefocus, d
-bindd = ALT, Tab,$d Cycle through windows, cyclenext
+bindd = ALT, Tab,$d Cycle focus, cyclenext
 
 $d=[$wm|Resize Active Window]
 # Resize windows

--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -29,7 +29,7 @@ $d=[$wm]
 bindd = $mainMod, Q, $d close focused window, exec, $scrPath/dontkillsteam.sh
 bindd = Alt, F4, $d close focused window, exec, $scrPath/dontkillsteam.sh
 bindd = $mainMod, Delete, $d kill hyprland session, exit
-bindd = $mainMod, W, $d toggle float, togglefloating, #
+bindd = $mainMod, W, $d Toggle floating,  exec, hyprctl --batch "dispatch togglefloating; dispatch resizeactive exact 95% 95%; dispatch centerwindow"
 bindd = $mainMod, G, $d toggle group, togglegroup
 bindd = Shift, F11, $d toggle fullscreen, fullscreen
 bindd = $mainMod, L, $d lock screen, exec, lockscreen.sh
@@ -47,7 +47,7 @@ bindd = $mainMod, Left, $d focus left, movefocus, l
 bindd = $mainMod, Right, $d focus right , movefocus, r
 bindd = $mainMod, Up, $d focus up , movefocus, u
 bindd = $mainMod, Down , $d focus down, movefocus, d
-# bindd = Alt, TAB, $d focus , movefocus, d,
+bindd = ALT, Tab,$d Cycle through windows, cyclenext
 
 $d=[$wm|Resize Active Window]
 # Resize windows

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -52,7 +52,8 @@ Multi-language KEYBINDINGS support
 
 Here are all HyDE specific keybindings listed.
 
-> [!TIP] > <kbd>Super</kbd> + <kbd>/</kbd> shows the keybindings.
+> [!TIP]  
+> <kbd>Super</kbd> + <kbd>/</kbd> shows the keybindings.
 
 <!-- ## <a id=window-management>Window Management</a> -->
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -87,6 +87,7 @@ Here are all HyDE specific keybindings listed.
 | <kbd>SUPER</kbd> + <kbd>Right</kbd> | focus right |
 | <kbd>SUPER</kbd> + <kbd>Up</kbd>    | focus up    |
 | <kbd>SUPER</kbd> + <kbd>Down</kbd>  | focus down  |
+| <kbd>ALT</kbd> + <kbd>Tab</kbd>     | cycle focus |
 
 ### Resize Active Window
 


### PR DESCRIPTION
# Pull Request

## Description

This Pr fixes:

- previously broken and commented Alt Tab keybind in hyprland keybinds
- window size when a widnow was set to float via $Mod W (previously It filled screen and this bug was more noticable on smaller screens causing negative margins)
- typo in `KEYBINDINGS.md` [!TIP] 

and Updates:
- `KEYBINDINGS.md` adding  `<Alt-T>` accordingly!


## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
