### PR TITLE
minor modifications to fish config

### DIFF
--- a/Configs/.config/fish/config.fish
+++ b/Configs/.config/fish/config.fish
@@ -2,9 +2,14 @@ set -g fish_greeting
 
 source ~/.config/fish/hyde_config.fish
 
-if status is-interactive
+if type -q starship
     starship init fish | source
+    set -gx STARSHIP_CACHE $XDG_CACHE_HOME/starship
+    set -gx STARSHIP_CONFIG $XDG_CONFIG_HOME/starship/starship.toml
 end
+
+set fish_pager_color_prefix cyan
+set fish_color_autosuggestion brblack 
 
 # List Directory
 alias l='eza -lh  --icons=auto' # long list

--- a/Configs/.config/starship/starship.toml
+++ b/Configs/.config/starship/starship.toml
@@ -12,7 +12,6 @@ $kubernetes\
 $vcsh\
 $hg_branch\
 $pijul_channel\
-$docker_context\
 $c\
 $cmake\
 $cobol\
@@ -105,7 +104,7 @@ format = " [  $branch](fg:#9198a1)"
 ahead = '⇡${count}'
 behind = '⇣${count}'
 diverged = '⇕⇡${ahead_count}⇣${behind_count}'
-format = '[[( $all_status$ahead_behind )](fg:#769ff0)]($style)'
+format = '[[( $all_status$ahead_behind )](fg:#769ff0)]($style)'
 style = "bg:#394260"
 
 
@@ -115,7 +114,7 @@ format = '[[  $time ](fg:#a0a9cb )]($style)'
 time_format = "%R"                            # Hour:Minute Format
 
 [deno]
-format = " [deno](italic) [∫ $version](green bold)"
+format = " [deno](italic) [ $version](green bold)"
 version_format = "${raw}"
 
 [lua]
@@ -128,19 +127,19 @@ version_format = "${raw}"
 detect_extensions = []
 detect_files = ["package-lock.json", "yarn.lock"]
 detect_folders = ["node_modules"]
-format = " [node](italic) [◫ ](bold bright-green)"
+format = "[ ](bold bright-green)"
 version_format = "${raw}"
 
 [python]
 format = " [py](italic) [${symbol}${version}]($style)"
 style = "bold bright-yellow"
-symbol = "[⌉](bold bright-blue)⌊ "
+symbol = "[ ](bold bright-blue)⌊ "
 version_format = "${raw}"
 
 [ruby]
 format = " [rb](italic) [${symbol}${version}]($style)"
 style = "bold red"
-symbol = "◆ "
+symbol = " "
 version_format = "${raw}"
 
 [rust]
@@ -150,14 +149,14 @@ symbol = " "
 [swift]
 format = " [sw](italic) [${symbol}${version}]($style)"
 style = "bold bright-red"
-symbol = "◁ "
+symbol = " "
 version_format = "${raw}"
 
 [aws]
 disabled = true
 format = " [aws](italic) [$symbol $profile $region]($style)"
 style = "bold blue"
-symbol = "▲ "
+symbol = " "
 
 [buf]
 format = " [buf](italic) [$symbol $version $buf_version]($style)"
@@ -173,15 +172,12 @@ symbol = "◯ "
 
 [dart]
 format = " dart [$symbol($version )]($style)"
-symbol = "◁◅ "
+symbol = " "
 
-[docker_context]
-format = " docker [$symbol$context]($style)"
-symbol = "◧ "
 
 [elixir]
 format = " exs [$symbol $version OTP $otp_version ]($style)"
-symbol = "△ "
+symbol = " "
 
 [elm]
 format = " elm [$symbol($version )]($style)"
@@ -197,7 +193,7 @@ symbol = "❯λ "
 
 [java]
 format = " java [${symbol}(${version} )]($style)"
-symbol = "∪ "
+symbol = " "
 
 [julia]
 format = " jl [$symbol($version )]($style)"
@@ -216,7 +212,7 @@ format = '[$symbol nix⎪$state⎪]($style) [$name](italic dimmed white)'
 impure_msg = '[⌽](bold dimmed red)'
 pure_msg = '[⌾](bold dimmed green)'
 style = 'bold italic dimmed blue'
-symbol = '✶'
+symbol = ' '
 unknown_msg = '[◌](bold dimmed ellow)'
 
 [spack]


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes:

#### fish config:
- modified starship loading seq in fish.conf to match `.zshenv`
- set `fish_pager_color_prefix` to remove annoying underline in autocomplete suggestions and settled for a color cahnge! (checkout screenshot 1)
 
- change `fish_color_autosuggestion` to a darker variant! 

#### starship:
- programming languages' icons changed to NerdIcons for maximum support!
- python-uv `$version` removed (inconvenient)
- removed `$docker_context` 


## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
(1)
![screenshot1](https://github.com/user-attachments/assets/1588d7c7-1660-43b8-9e25-65f81baef374)

note: in screenshot above `cyan` part is underlined by default! 

------
(2)
![screenshot2](https://github.com/user-attachments/assets/f08024cd-51f8-4caf-a18f-1c259d05054a)


