### PR TITLE
add best fzf aliases ever

### DIFF
--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -141,7 +141,7 @@ _fuzzy_open_directory() {
     fi
 
     #type -d
-    selected_dir=$(find . -maxdepth max_depth -type d \( -name .git -o -name node_modules -o -name .venv -o -name target \) -prune -o -print 2>/dev/null | fzf "${fzf_options[@]}")
+    selected_dir=$(find . -maxdepth $max_depth -type d \( -name .git -o -name node_modules -o -name .venv -o -name target \) -prune -o -print 2>/dev/null | fzf "${fzf_options[@]}")
 
     if [[ -n "$selected_dir" && -d "$selected_dir" ]]; then
         cd "$selected_dir" || return 1 #  if cd fails
@@ -161,7 +161,7 @@ _fuzzy_edit_search_file() {
     fi
 
     # -type f: only find files
-    selected_file=$(find . -maxdepth max_depth -type f 2>/dev/null | fzf "${fzf_options[@]}")
+    selected_file=$(find . -maxdepth $max_depth -type f 2>/dev/null | fzf "${fzf_options[@]}")
 
     if [[ -n "$selected_file" && -f "$selected_file" ]]; then
         if command -v "$EDITOR" &>/dev/null; then

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -164,8 +164,12 @@ _fuzzy_edit_search_file() {
     selected_file=$(find . -maxdepth max_depth -type f 2>/dev/null | fzf "${fzf_options[@]}")
 
     if [[ -n "$selected_file" && -f "$selected_file" ]]; then
-        $EDITOR "$selected_file"
-        #FIX: if ! $EDITOR case
+        if command -v "$EDITOR" &>/dev/null; then
+            "$EDITOR" "$selected_file"
+        else
+            echo "EDITOR is not specified. using vim.  (you can export EDITOR in ~/.zshrc)"
+            vim "$selected_file"
+        fi
     else
         return 1
     fi
@@ -177,7 +181,13 @@ _fuzzy_edit_search_file_content() {
     selected_file=$(grep -irl "${1:-}" ./ | fzf --preview 'cat {}' --preview-window right:60%)
 
     if [[ -n "$selected_file" ]]; then
-        nvim "$selected_file"
+        if command -v "$EDITOR" &>/dev/null; then
+            "$EDITOR" "$selected_file"
+        else
+            echo "EDITOR is not specified. using vim.  (you can export EDITOR in ~/.zshrc)"
+            vim "$selected_file"
+        fi
+
     else
         echo "No file selected or search returned no results."
     fi

--- a/Configs/.zshrc
+++ b/Configs/.zshrc
@@ -12,3 +12,5 @@
 
 #  This is your file 
 # Add your configurations here
+# export EDITOR=nvim
+export EDITOR=code


### PR DESCRIPTION
## Description

This PR introduces three functions to `.zshenv` taking advantage of `fzf`, aiming for better and faster Terminal navigation.

The mentioned aliased functions are as follows:
```bash
- f_efc='_fuzzy_edit_search_file_content'       # [fz]f [e]dit  [f]ile, search by [c]ontent
- fcd='_fuzzy_open_directory'             # [fz]f [o]pen [d]irectory
- f_ef='_fuzzy_edit_search_file'          # [fz]f [e]dit [f]ile
```

This approach takes advantage of `fzf` by directly inputting `query` which benefits us by:
- a) generally faster navigation
- b) triggering fzf filters at once

#### Some extra features:
1- excluding unwanted search results in `fod` function
2- null `$EDITOR` fallback
3- adjustable `max_depth=5` for fuzzy finding
4- etc...


## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenrecors

### `fcd`

https://github.com/user-attachments/assets/64a46d47-186e-4b20-b8f1-5b1736487e4b

instead of doing : `cd ~/Projects/rust/wallrust/src`
we just `fuzzy` it via `fcd` 

video demonstrates 2 fuzzy "searchings" for the target dir!

------

### `f_efc`

https://github.com/user-attachments/assets/f92715a3-fb31-486e-a070-94dbf15bfe13

we fuzzy find files containing target keyword (in this case `save` and `os`) in the directory and selecting it opens the file in $EDITOR



## Additional context

- This features can elevated with tools like `bat` and `ripgrep`
- same aliases for `fish` shell will be pushed in a different PR 
