### PR TITLE
fix(zsh): zsh-autosuggestions won't work on first prompt when deferred

### DIFF
--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -211,6 +211,11 @@ function _load_post_init() {
         eval "$(fzf --zsh)"
     fi
 
+    # zsh-autosuggestions won't work on first prompt when deferred
+    if typeset -f _zsh_autosuggest_start > /dev/null; then
+      _zsh_autosuggest_start
+    fi
+
     # User rc file always overrides
     [[ -f $HOME/.zshrc ]] && source $HOME/.zshrc
 


### PR DESCRIPTION
# Pull Request

## Description

Adding _zsh_autosuggest_start to _load_post_init fixes DEFER_OMZ_LOAD causing the first prompt not to work

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)


## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.
