### PR TITLE
style: set waybar language module `min-width` to prevent unnecessary folding

### DIFF
--- a/Configs/.config/waybar/modules/style.css
+++ b/Configs/.config/waybar/modules/style.css
@@ -109,6 +109,10 @@ ${modules_ls}
     padding-${x4}: ${g_paddin}px;
 }
 
+#language {
+    min-width: ${g_minwidth}px;
+}
+
 #workspaces,
 #taskbar {
     padding: 0px;

--- a/Configs/.config/waybar/style.css
+++ b/Configs/.config/waybar/style.css
@@ -146,6 +146,10 @@ tooltip {
     padding-right: 4px;
 }
 
+#language {
+    min-width: 11px;
+}
+
 #workspaces,
 #taskbar {
     padding: 0px;

--- a/Configs/.local/lib/hyde/wbarstylegen.sh
+++ b/Configs/.local/lib/hyde/wbarstylegen.sh
@@ -37,6 +37,7 @@ export w_margin=$((b_height * 10 / 100)) # workspace margin 10% of height
 export w_paddin=$((b_height * 10 / 100)) # workspace padding 10% of height
 export w_padact=$((b_height * 40 / 100)) # workspace active padding 40% of height
 export s_fontpx=$((b_height * 34 / 100)) # font size 34% of height
+export g_minwidth=$((b_height * 39 / 100)) # module minimal width 39% of height
 
 if [ "$b_height" -lt 30 ]; then
     export e_paddin=0


### PR DESCRIPTION
# Pull Request

## Description

When waybar is highly loaded with stuff, `language` module "folds", and no space is freed with this folding, but module became useless.

I tried to select `min-width` for language module with criteria:
1. do not increase it's actual width
2. prevent folding

I have tested it with different waybar sizes and looks like no flaws were detected.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/29b41ce0-87a0-428e-a512-e6cf2ba92cf2)

### After

![image](https://github.com/user-attachments/assets/2e835526-14e2-467a-84f2-c6d3e201bca5)

