### PR TITLE
fix: no need to source HyDE runtime env in `lockscreen.sh`

### DIFF
--- a/Configs/.local/lib/hyde/lockscreen.sh
+++ b/Configs/.local/lib/hyde/lockscreen.sh
@@ -4,8 +4,5 @@ scrDir="$(dirname "$(realpath "$0")")"
 # shellcheck source=$HOME/.local/lib/hyde/globalcontrol.sh
 # shellcheck disable=SC1091
 source "${scrDir}/globalcontrol.sh"
-HYDE_RUNTIME_DIR="${HYDE_RUNTIME_DIR:-$XDG_RUNTIME_DIR/hyde}"
-# shellcheck disable=SC1091
-source "${HYDE_RUNTIME_DIR}/environment"
 
 "${LOCKSCREEN:-hyprlock}" "${@}"


### PR DESCRIPTION
# Pull Request

## Description

There is no need to source `${HYDE_RUNTIME_DIR}/environment` in `lockscreen.sh` script, because it It already sourced in [`globalcontrol.sh`](https://github.com/HyDE-Project/HyDE/blob/master/Configs/.local/lib/hyde/globalcontrol.sh#L243)

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
