### PR TITLE
Gamelauncher steam header icon

### DIFF
--- a/Configs/.local/lib/hyde/gamelauncher.sh
+++ b/Configs/.local/lib/hyde/gamelauncher.sh
@@ -20,6 +20,11 @@ icon_border=$((elem_border - 3))
 r_override="element{border-radius:${elem_border}px;} element-icon{border-radius:${icon_border}px;}"
 
 fn_steam() {
+
+  notify-send -a "HyDE Alert" "Please wait... " -t 4000
+
+  libraryThumbName="library_600x900.jpg"
+  libraryHeaderName="header.jpg"
   # Get all manifests found within steam libs
   # SteamLib might contain more than one path
   ManifestList=$(grep '"path"' $SteamLib | awk -F '"' '{print $4}' | while read sp; do
@@ -28,6 +33,9 @@ fn_steam() {
   find "${sp}/steamapps" -type f -name "appmanifest_*.acf" 2>/dev/null 
   done)
 
+if [ -z "${ManifestList}" ]; then
+    notify-send -a "HyDE Alert" "Cannot Fetch Steam Games!" && exit 1
+  fi
 
   # read installed games
   GameList=$(echo "$ManifestList" | while read acf; do

--- a/Configs/.local/lib/hyde/gamelauncher.sh
+++ b/Configs/.local/lib/hyde/gamelauncher.sh
@@ -54,9 +54,8 @@ fn_steam() {
     echo "$GameList" | while read acf; do
       appid=$(echo "${acf}" | cut -d '|' -f 2)
       game=$(echo "${acf}" | cut -d '|' -f 1)
-
       # find the lib image
-      libImage=$(find "${SteamThumb}/${appid}/" -type f -name "${libraryThumbName}")
+      libImage=$(find "${SteamThumb}/${appid}/" -type f -name "${libraryThumbName}" | head  -1)
       printf "%s\x00icon\x1f${libImage}\n" "${game}" >&2
       printf "%s\x00icon\x1f${libImage}\n" "${game}"
     done | rofi -dmenu \

--- a/Configs/.local/lib/hyde/gamelauncher.sh
+++ b/Configs/.local/lib/hyde/gamelauncher.sh
@@ -3,7 +3,6 @@
 # set variables
 MODE=${1}
 scrDir=$(dirname "$(realpath "$0")")
-thumbName="library_600x900.jpg"
 source $scrDir/globalcontrol.sh
 # ThemeSet="${confDir}/hypr/themes/theme.conf"
 
@@ -33,7 +32,7 @@ fn_steam() {
   find "${sp}/steamapps" -type f -name "appmanifest_*.acf" 2>/dev/null 
   done)
 
-if [ -z "${ManifestList}" ]; then
+  if [ -z "${ManifestList}" ]; then
     notify-send -a "HyDE Alert" "Cannot Fetch Steam Games!" && exit 1
   fi
 
@@ -57,7 +56,7 @@ if [ -z "${ManifestList}" ]; then
       game=$(echo "${acf}" | cut -d '|' -f 1)
 
       # find the lib image
-      libImage=$(find "${SteamThumb}/${appid}/" -type f -name "${thumbName}")
+      libImage=$(find "${SteamThumb}/${appid}/" -type f -name "${libraryThumbName}")
       printf "%s\x00icon\x1f${libImage}\n" "${game}" >&2
       printf "%s\x00icon\x1f${libImage}\n" "${game}"
     done | rofi -dmenu \
@@ -66,12 +65,13 @@ if [ -z "${ManifestList}" ]; then
   )
 
   # launch game
-  if [ -n "$RofiSel" ]; then
+  if [ -n "$RofiSel" ]; then 
     launchid=$(echo "$GameList" | grep "$RofiSel" | cut -d '|' -f 2)
+
+    headerImage=$(find "${SteamThumb}/${launchid}/" -type f -name "*${libraryHeaderName}")
     ${steamlaunch} -applaunch "${launchid} [gamemoderun %command%]" &
     # dunstify "HyDE Alert" -a "Launching ${RofiSel}..." -i ${SteamThumb}/${launchid}_header.jpg -r 91190 -t 2200
-    notify-send -a "HyDE Alert" -i "${SteamThumb}/${launchid}_header.jpg" "Launching ${RofiSel}..."
-
+    notify-send -a "HyDE Alert" -i "$headerImage" "Launching ${RofiSel}..."
   fi
 }
 


### PR DESCRIPTION
# Pull Request

## Description

- Adds in feedback when processing steam games and if no games are found
- Handles multiple steam library images by taking the first only (Elder scrolls online has multiple...)
- Fixes the steam games header image not showing in the notification on launch

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.

## Screenshots
Launch notification before changes
![image](https://github.com/user-attachments/assets/c8f55ec5-b3d5-48fd-9ec5-baf135215321)

Launch notification after changes
![250523_10h09m07s_screenshot](https://github.com/user-attachments/assets/379307c6-844f-4399-a88b-c04018aa7d5d)
