### PR TITLE
fix: Missing scrollbars on Discord Clients

### DIFF
--- a/Configs/.config/hyde/wallbash/always/discord.dcol
+++ b/Configs/.config/hyde/wallbash/always/discord.dcol
@@ -2,16 +2,16 @@ ${XDG_CACHE_HOME}/hyde/wallbash/discord.css|${WALLBASH_SCRIPTS}/discord.sh
 @import url('https://mwittrien.github.io/BetterDiscordAddons/Themes/DiscordRecolor/DiscordRecolor.css');
 
 :root {
-  --accentcolor: <wallbash_pry1_rgb>;
+  --accentcolor: <wallbash_1xa6_rgb>;
   --accentcolor2: <wallbash_pry2_rgb>;
-  --linkcolor: <wallbash_txt2_rgb>;
+  --linkcolor: <wallbash_1xa6_rgb>;
   --mentioncolor: <wallbash_1xa5_rgb>;
   --textbrightest: <wallbash_txt1_rgb>;
   --textbrighter: <wallbash_txt2_rgb>;
   --textbright: <wallbash_1xa9_rgb>;
   --textdark: <wallbash_3xa9_rgb>;
-  --textdarker: <wallbash_txt3_rgb>;
-  --textdarkest: <wallbash_txt4_rgb>;
+  --textdarker: <wallbash_3xa5_rgb>;
+  --textdarkest: <wallbash_3xa1_rgb>;
 
   --backgroundaccent: <wallbash_1xa5_rgb>;
   --backgroundprimary: <wallbash_2xa1_rgb>;
@@ -19,8 +19,9 @@ ${XDG_CACHE_HOME}/hyde/wallbash/discord.css|${WALLBASH_SCRIPTS}/discord.sh
   --backgroundsecondaryalt: <wallbash_pry1_rgb>;
   --backgroundtertiary: <wallbash_pry1_rgb>;
   --backgroundfloating: <wallbash_2xa1_rgb>;;
-  --settingsicons: 1;
+  --settingsicons: 0;
 }
+
 
 ::-webkit-scrollbar {
   width: 10px !important;

--- a/Configs/.config/hyde/wallbash/always/discord.dcol
+++ b/Configs/.config/hyde/wallbash/always/discord.dcol
@@ -2,16 +2,16 @@ ${XDG_CACHE_HOME}/hyde/wallbash/discord.css|${WALLBASH_SCRIPTS}/discord.sh
 @import url('https://mwittrien.github.io/BetterDiscordAddons/Themes/DiscordRecolor/DiscordRecolor.css');
 
 :root {
-  --accentcolor: <wallbash_1xa6_rgb>;
+  --accentcolor: <wallbash_pry1_rgb>;
   --accentcolor2: <wallbash_pry2_rgb>;
-  --linkcolor: <wallbash_1xa6_rgb>;
+  --linkcolor: <wallbash_txt2_rgb>;
   --mentioncolor: <wallbash_1xa5_rgb>;
   --textbrightest: <wallbash_txt1_rgb>;
   --textbrighter: <wallbash_txt2_rgb>;
   --textbright: <wallbash_1xa9_rgb>;
   --textdark: <wallbash_3xa9_rgb>;
-  --textdarker: <wallbash_3xa5_rgb>;
-  --textdarkest: <wallbash_3xa1_rgb>;
+  --textdarker: <wallbash_txt3_rgb>;
+  --textdarkest: <wallbash_txt4_rgb>;
 
   --backgroundaccent: <wallbash_1xa5_rgb>;
   --backgroundprimary: <wallbash_2xa1_rgb>;
@@ -19,7 +19,19 @@ ${XDG_CACHE_HOME}/hyde/wallbash/discord.css|${WALLBASH_SCRIPTS}/discord.sh
   --backgroundsecondaryalt: <wallbash_pry1_rgb>;
   --backgroundtertiary: <wallbash_pry1_rgb>;
   --backgroundfloating: <wallbash_2xa1_rgb>;;
-  --settingsicons: 0;
+  --settingsicons: 1;
 }
 
+::-webkit-scrollbar {
+  width: 10px !important;
+}
+
+::-webkit-scrollbar-thumb {
+  /* On bigger screens, the scrollbar's border radius falls short, 
+  so we put an obscenely large value for the border radius */
+  border-radius: 500px !important;
+  background: rgba(var(--accentcolor), 0.7) !important;
+  background-clip: content-box !important;
+  border: 2px solid transparent !important; /* Margin for the scrollbar */
+}
 /* Any custom CSS below here */

--- a/Configs/.config/hyde/wallbash/always/discord.dcol
+++ b/Configs/.config/hyde/wallbash/always/discord.dcol
@@ -22,7 +22,6 @@ ${XDG_CACHE_HOME}/hyde/wallbash/discord.css|${WALLBASH_SCRIPTS}/discord.sh
   --settingsicons: 0;
 }
 
-
 ::-webkit-scrollbar {
   width: 10px !important;
 }
@@ -35,4 +34,5 @@ ${XDG_CACHE_HOME}/hyde/wallbash/discord.css|${WALLBASH_SCRIPTS}/discord.sh
   background-clip: content-box !important;
   border: 2px solid transparent !important; /* Margin for the scrollbar */
 }
+
 /* Any custom CSS below here */


### PR DESCRIPTION
# Fix missing scrollbars on discord clients
This PR changes the custom styling to reveal the hidden scrollbars. Observe the images with and without the scrollbars for reference. (#665) 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
### Without the proposed styling:
![image](https://github.com/user-attachments/assets/514cfc67-8aa5-4fa4-a481-b4c836233b9a)
### With the proposed styling:
![image](https://github.com/user-attachments/assets/b3717349-b9a1-43ad-a5cf-ece09a20662e)

## Additional context

I understand that the margin is not needed for the scrollbars but I think it is necessary because without it, the scrollbars stick to the sides (bad UX)
