### PR TITLE
fix: includes the XDG cache directory in the discord wallbash script 

### DIFF
--- a/Configs/.config/hyde/wallbash/scripts/discord.sh
+++ b/Configs/.config/hyde/wallbash/scripts/discord.sh
@@ -2,7 +2,7 @@
 
 
 #// source variables
-
+cacheDir="${cacheDir:-$XDG_CACHE_HOME/hyde}"
 discord_col="${cacheDir}/wallbash/discord.css"
 declare -a client_list=()
 


### PR DESCRIPTION
# Pull Request

## Description

Please read these instructions and remove unnecessary text.

Sets the XDG cache home to for the cachedir param, if missing the script failed the cp steps

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.


