### PR TITLE
feat: Add dropdown terminal

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -78,6 +78,7 @@ bindd = $mainMod, J, $d toggle split, togglesplit
 $l=Launcher
 $d=[$l|Apps]
 bindd = $mainMod, T, $d terminal emulator , exec, $TERMINAL
+bindd = $mainMod Alt, T, $d dropdown terminal, exec, [float; move 20% 5%; size 60% 60%] $TERMINAL
 bindd = $mainMod, E, $d file explorer , exec, $EXPLORER
 bindd = $mainMod, C, $d text editor , exec, $EDITOR
 bindd = $mainMod, B, $d web browser , exec, $BROWSER

--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -8,6 +8,8 @@
 # This symbol indicates that the following values will override the default configuration
 $&=override
 
+windowrulev2 = idleinhibit fullscreen, class:.* 
+
 windowrulev2 = opacity 0.90 $& 0.90 $& 1,class:^(firefox)$
 windowrulev2 = opacity 0.90 $& 0.90 $& 1,class:^(Brave-browser)$
 windowrulev2 = opacity 0.80 $& 0.80 $& 1,class:^(code-oss)$


### PR DESCRIPTION
This adds a keybind for an auto-focused floating dropdown terminal. Useful for when you quickly need to open a terminal but don't want to deal with everything else on the screen (or swap workspaces).

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshot

![250524_21h37m42s_screenshot](https://github.com/user-attachments/assets/e59b2716-a87c-48c5-848c-86ffb7851005)
