### PR TITLE
fix: Fix #677/graphic-loading for non-interactive shell

### DIFF
--- a/Configs/.user.zsh
+++ b/Configs/.user.zsh
@@ -1,6 +1,6 @@
 #  Startup 
 # Commands to execute on startup (before the prompt is shown)
-# Check if the interactive shell optin is set
+# Check if the interactive shell option is set
 if [[ $- == *i* ]]; then
     # This is a good place to load graphic/ascii art, display system information, etc.
     if command -v pokego >/dev/null; then

--- a/Configs/.user.zsh
+++ b/Configs/.user.zsh
@@ -1,15 +1,16 @@
 #  Startup 
 # Commands to execute on startup (before the prompt is shown)
-# This is a good place to load graphic/ascii art, display system information, etc.
-
-if command -v pokego >/dev/null; then
-    pokego --no-title -r 1,3,6
-elif command -v pokemon-colorscripts >/dev/null; then
-    pokemon-colorscripts --no-title -r 1,3,6
-elif command -v fastfetch >/dev/null; then
-    fastfetch --logo-type kitty
+# Check if the interactive shell optin is set
+if [[ $- == *i* ]]; then
+    # This is a good place to load graphic/ascii art, display system information, etc.
+    if command -v pokego >/dev/null; then
+        pokego --no-title -r 1,3,6
+    elif command -v pokemon-colorscripts >/dev/null; then
+        pokemon-colorscripts --no-title -r 1,3,6
+    elif command -v fastfetch >/dev/null; then
+        fastfetch --logo-type kitty
+    fi
 fi
-
 # fastfetch.sh
 
 #  Aliases 


### PR DESCRIPTION
# Pull Request
Fix #677 

## Description

Limited banner loading to interactive shells since non-interactive shells typically shouldn't load graphic/ascii art, display system information, etc. Without this change, commands such as `script -c 'echo hi' /tmp/script.log` will include the output of startup commands such as `fastfetch`.


## Type of change

Please put an `x` in the boxes that apply:
- [x] **Bug fix** (non-breaking change which fixes an issue) 
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


