### PR TITLE
fix: change config names in `uninstall.sh` note to actual values

### DIFF
--- a/Scripts/uninstall.sh
+++ b/Scripts/uninstall.sh
@@ -87,12 +87,12 @@ $HOME/.icons                            # remove icons from here
 $HOME/.themes                           # remove themes from here
 
 Revert back bootloader/pacman/sddm settings manually from these backups
-/boot/loader/entries/*.conf.t2.bkp      # restore systemd-boot from this backup
-/etc/default/grub.t2.bkp                # restore grub from this backup
-/boot/grub/grub.t2.bkp                  # restore grub from this backup
+/boot/loader/entries/*.conf.hyde.bkp    # restore systemd-boot from this backup
+/etc/default/grub.hyde.bkp              # restore grub from this backup
+/boot/grub/grub.hyde.bkp                # restore grub from this backup
 /usr/share/grub/themes                  # remove grub themes from here
-/etc/pacman.conf.t2.bkp                 # restore pacman from this backup
-/etc/sddm.conf.d/kde_settings.t2.bkp    # restore sddm from this backup
+/etc/pacman.conf.hyde.bkp               # restore pacman from this backup
+/etc/sddm.conf.d/kde_settings.hyde.bkp  # restore sddm from this backup
 /usr/share/sddm/themes                  # remove sddm themes from here
 
 Uninstall the packages manually that are no longer required based on these list


### PR DESCRIPTION
# Pull Request

## Description

Looks like this note was missed when refactoring was done. This PR changes naming of configs to actual values.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

