### PR TITLE
fix: vertical game launcher and sizing changes

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -121,7 +121,7 @@ $ut=Utilities
 $d=[$ut]
 binddl = $mainMod, K, $d toggle keyboard layout , exec, $scrPath/keyboardswitch.sh # switch keyboard layout
 bindd = $mainMod Alt, G, $d game mode , exec, $scrPath/gamemode.sh # disable hypr effects for gamemode
-bindd = $mainMod Shift, G, $d open game launcher , exec, $scrPath/gamelauncher.sh # run game launcher for steam and lutris
+bindd = $mainMod Shift, G, $d open game launcher , exec, $scrPath/gamelauncher.sh 5# run game launcher for steam and lutris
 
 $d=[$ut|Screen Capture]
 bindd = $mainMod Shift, P, $d color picker, exec, hyprpicker -an # Pick color (Hex) >> clipboard#

--- a/Configs/.local/share/hyde/rofi/themes/gamelauncher_5_vertical.rasi
+++ b/Configs/.local/share/hyde/rofi/themes/gamelauncher_5_vertical.rasi
@@ -42,14 +42,14 @@ mainbox {
     background-color:            transparent;
     orientation:                 horizontal;
     spacing:                     0em;
-    padding:                     17.8% 19.6% 18.4% 19.8%;
+    padding:                     38.4% 19.6% 38.6% 19.8%;
 }
 
 
 // Lists //
 listview {
     enabled:                     true;
-    columns:                     5;
+    columns:                     3;
     flow:                        horizontal;
     spacing:                     2.5em;
     padding:                     3em 5em 2em 5em;
@@ -82,7 +82,7 @@ element selected.normal {
     text-color:                  @select-fg;
 }
 element-icon {
-    size:                        13em;
+    size:                        9em;
     spacing:                     0em;
     padding:                     0em;
     cursor:                      inherit;


### PR DESCRIPTION
# Pull Request

## Description

Adds a vertical monitor rasi file and auto detection for the game launcher, updates the keybind to auto run mode 5

## Type of change

- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have added necessary comments/documentation to my code.
- [x] I have tested my code locally and it works as expected.


## Additional context

Follows a discussion found here
https://github.com/HyDE-Project/HyDE/issues/12#issuecomment-2914057854
Screenshots of  both monitor orientations attached
