### PR TITLE
feat: use `duf` as alias for `df`

### DIFF
--- a/Configs/.config/fish/functions/df.fish
+++ b/Configs/.config/fish/functions/df.fish
@@ -1,0 +1,11 @@
+function df
+    if test $argv
+        set last_arg $argv[-1]
+        if test -e "$last_arg"
+            duf "$last_arg"
+            return
+        end
+    end
+
+    duf
+end

--- a/Configs/.zshenv
+++ b/Configs/.zshenv
@@ -195,6 +195,14 @@ _fuzzy_edit_search_file() {
     fi
 }
 
+_df() {
+    if [[ $# -ge 1 && -e "${@: -1}" ]]; then
+        duf "${@: -1}"
+    else
+        duf
+    fi
+}
+
 function _load_post_init() {
     #! Never load time consuming functions here
     _load_persistent_aliases
@@ -292,7 +300,8 @@ function _load_if_terminal {
             mkdir='mkdir -p' \
             ffec='_fuzzy_edit_search_file_content' \
             ffcd='_fuzzy_change_directory' \
-            ffe='_fuzzy_edit_search_file'
+            ffe='_fuzzy_edit_search_file' \
+            df='_df'
 
         # Some binds won't work on first prompt when deferred
         bindkey '\e[H' beginning-of-line

--- a/Scripts/pkg_core.lst
+++ b/Scripts/pkg_core.lst
@@ -77,9 +77,11 @@ fzf                                                    # Command-line fuzzy find
 eza|zsh                                                # file lister for zsh
 zsh-theme-powerlevel10k-git|zsh                        # Powerlevel10k is a theme for Zsh. It emphasizes speed, flexibility and out-of-the-box experience.
 starship|zsh                                           # customizable shell prompt written in Rust
+duf|zsh                                                # prettier version of df for zsh
 # starship-git                                         # The cross-shell prompt for astronauts  
 eza|fish                                               # file lister for fish
 starship|fish                                          # customizable shell prompt
+duf|fish                                               # prettier version of df for fish
 fastfetch                                              # system information fetch tool
 
 # --------------------------------------------------- // HyDE


### PR DESCRIPTION
# Pull Request

## Description

`duf` does the same as `df`, but with pretty output. Simple aliases would not work because `df` and `duf` have different options. Functions for zsh and fish drop all `df` arguments except of path, so `duf` is called without arguments or with path only.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/b290be4a-05d4-405f-933c-70cc322d53e4)
![image](https://github.com/user-attachments/assets/e4e925ac-17d4-4383-b479-b1d0de2264c1)


### After

![image](https://github.com/user-attachments/assets/6199a5bc-0c2e-4495-8f2a-a514906b04a2)
![image](https://github.com/user-attachments/assets/58a35e30-4ce5-4dcb-95bb-55bb175431f8)


