### PR TITLE
feat: add keybinding for rofi animation select menu

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -141,6 +141,7 @@ bindd = $mainMod Alt, Up, $d next waybar layout , exec, $scrPath/wbarconfgen.sh 
 bindd = $mainMod Alt, Down, $d previous waybar layout , exec, $scrPath/wbarconfgen.sh p # previous waybar mode
 bindd = $mainMod Shift, R, $d wallbash mode selector , exec, pkill -x rofi || $scrPath/wallbashtoggle.sh -m # launch wallbash mode select menu
 bindd = $mainMod Shift, T, $d select a theme, exec, pkill -x rofi || $scrPath/themeselect.sh # launch theme select menu
+bindd = $mainMod+Shift, Y, $d select animations, exec, pkill -x rofi || $scrPath/animations.sh --select # launch animations select menu
 
 
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -212,6 +212,7 @@ Here are all HyDE specific keybindings listed.
 | <kbd>SUPER</kbd> + <kbd>ALT</kbd> + <kbd>Down</kbd>  | previous waybar layout |
 | <kbd>SUPER</kbd> + <kbd>SHIFT</kbd> + <kbd>R</kbd>   | wallbash mode selector |
 | <kbd>SUPER</kbd> + <kbd>SHIFT</kbd> + <kbd>T</kbd>   | select a theme         |
+| <kbd>SUPER</kbd> + <kbd>SHIFT</kbd> + <kbd>Y</kbd>   | select animations      |
 
 <!-- ## <a id=workspaces>Workspaces</a> -->
 


### PR DESCRIPTION
# Pull Request

## Description

`animations.sh` script does not have a default keybinding, but looks like it should have some.

This PR offers some suitable keybinding and documentation update for it.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.