### PR TITLE
fix: improve mediaplayer.py `max_length` behavior in case of extremely long artist and track

### DIFF
--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -71,32 +71,41 @@ def create_tooltip_text(
 
     return tooltip
 
+def format_artist_track(artist, track, playing, max_length):
+    # Use the appropriate prefix based on playback status
+    prefix = prefix_playing if playing else prefix_paused
+    prefix_separator = "  "
+    separator = "  "
+    full_length = len(artist + track)
+
+    if track and not artist:
+        if len(track) != track[:max_length]:
+            track = track[:max_length].rstrip() + "…"
+        output_text = f"{prefix}{prefix_separator}<b>{track}</b>"
+    elif track and artist:
+        if full_length > max_length:
+            # proportion how to share max length between track and artist
+            artist_weight = 0.65
+            track_weight = 1 - artist_weight
+            artist_limit = int(max_length * artist_weight)
+            track_limit = int(max_length * track_weight)
+
+            if len(artist) != artist[:artist_limit]:
+                artist = artist[:artist_limit].rstrip() + "…"
+            if len(track) != track[:track_limit]:
+                track = track[:track_limit].rstrip() + "…"
+
+        output_text = f"{prefix}{prefix_separator}<i>{artist}</i>{separator}<b>{track}</b>"
+    else:
+        output_text = "<b>Nothing playing</b>"
+    return output_text
+
 
 def write_output(track, artist, playing, player, tooltip_text):
     logger.info("Writing output")
 
-    # Use the appropriate prefix based on playback status
-    prefix = prefix_playing if playing else prefix_paused
-    max_length = max_length_module
-
-    # Calculate the total length and truncate track if necessary
-    total_length = len(track) + len(artist)
-    if total_length > max_length:
-        available_length = max(0, max_length - len(artist))
-        track = (
-            f"{track[:available_length]}…" if len(track) > available_length else track
-        )
-
-    # Generate the "text" based on the presence of track and artist
-    if track and not artist:
-        output_text = f"{prefix}  <b>{track}</b>"
-    elif track and artist:
-        output_text = f"{prefix}  <i>{artist}</i>  <b>{track}</b>"
-    else:
-        output_text = "<b>Nothing playing</b>"
-
     output_data = {
-        "text": output_text,
+        "text": format_artist_track(artist, track, playing, max_length_module),
         "class": "custom-" + player.props.player_name,
         "alt": player.props.player_name,
         "tooltip": tooltip_text,


### PR DESCRIPTION
# Pull Request

## Description

Current flow limits only track length, but does not touch artist. This can cause overflowing a desired max length a lot in some cases.

I want to offer improved length limiting flow, which proportionally limits length of artist and track.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots
### Mediaplayer settings
![image](https://github.com/user-attachments/assets/88e92d87-01e3-4885-a375-092372f85093)

### Before
![image](https://github.com/user-attachments/assets/590d7ff7-280b-442c-a429-4aabec038535)

![image](https://github.com/user-attachments/assets/a416c9bf-44db-4a9f-a9d4-4894766a3653)

### After
![image](https://github.com/user-attachments/assets/cc5c0b92-b6d1-4021-84c8-070e53c91638)

![image](https://github.com/user-attachments/assets/0aa5005e-762f-4dee-9df4-e801b5e7964d)


