### PR TITLE
fix: mediaplayer conditions now work properly

### DIFF
--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -79,7 +79,7 @@ def format_artist_track(artist, track, playing, max_length):
     full_length = len(artist + track)
 
     if track and not artist:
-        if len(track) != track[:max_length]:
+        if len(track) != len(track[:max_length]):
             track = track[:max_length].rstrip() + "…"
         output_text = f"{prefix}{prefix_separator}<b>{track}</b>"
     elif track and artist:
@@ -90,9 +90,9 @@ def format_artist_track(artist, track, playing, max_length):
             artist_limit = int(max_length * artist_weight)
             track_limit = int(max_length * track_weight)
 
-            if len(artist) != artist[:artist_limit]:
+            if len(artist) != len(artist[:artist_limit]):
                 artist = artist[:artist_limit].rstrip() + "…"
-            if len(track) != track[:track_limit]:
+            if len(track) != len(track[:track_limit]):
                 track = track[:track_limit].rstrip() + "…"
 
         output_text = f"{prefix}{prefix_separator}<i>{artist}</i>{separator}<b>{track}</b>"


### PR DESCRIPTION
# Pull Request

## Description

I have mistaken when writing conditions in PR https://github.com/HyDE-Project/HyDE/pull/701

This fix eliminates mistake which lead to unnecessary adding of ellipsis.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
