### PR TITLE
feat: customizable separator for mediaplayer.py

### DIFF
--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -75,7 +75,6 @@ def format_artist_track(artist, track, playing, max_length):
     # Use the appropriate prefix based on playback status
     prefix = prefix_playing if playing else prefix_paused
     prefix_separator = "  "
-    separator = "  "
     full_length = len(artist + track)
 
     if track and not artist:
@@ -95,7 +94,7 @@ def format_artist_track(artist, track, playing, max_length):
             if len(track) != len(track[:track_limit]):
                 track = track[:track_limit].rstrip() + "…"
 
-        output_text = f"{prefix}{prefix_separator}<i>{artist}</i>{separator}<b>{track}</b>"
+        output_text = f"{prefix}{prefix_separator}<i>{artist}</i>{artist_track_separator}<b>{track}</b>"
     else:
         output_text = "<b>Nothing playing</b>"
     return output_text
@@ -244,7 +243,7 @@ def parse_arguments():
 
 
 def main():
-    global prefix_playing, prefix_paused, max_length_module, standby_text
+    global prefix_playing, prefix_paused, max_length_module, standby_text, artist_track_separator
     global artist_color, track_color, progress_color, empty_color, time_color
 
     # Load environment variables from your config file:
@@ -261,6 +260,7 @@ def main():
     prefix_paused = os.getenv("MEDIAPLAYER_PREFIX_PAUSED", "  ")
     max_length_module = int(os.getenv("MEDIAPLAYER_MAX_LENGTH", "70"))
     standby_text = os.getenv("MEDIAPLAYER_STANDBY_TEXT", "  Music")
+    artist_track_separator = os.getenv("MEDIAPLAYER_ARTIST_TRACK_SEPARATOR", "  ")
 
     # Initialize tooltip colors
     artist_color = os.getenv(

--- a/Configs/.local/share/hyde/schema/config.toml
+++ b/Configs/.local/share/hyde/schema/config.toml
@@ -745,3 +745,8 @@ type      = "object"
     default     = "  Music"
     description = "To display on standby."
     type        = "string"
+
+[properties.mediaplayer.properties.artist_track_separator]
+    default     = "  "
+    description = "Separator symbols to display between artist and track."
+    type        = "string"

--- a/Configs/.local/share/hyde/schema/config.toml.json
+++ b/Configs/.local/share/hyde/schema/config.toml.json
@@ -817,6 +817,11 @@
                     "default": "\uf001  Music",
                     "description": "To display on standby.",
                     "type": "string"
+                },
+                "artist_track_separator": {
+                    "default": "\u2004\uf444 ",
+                    "description": "Separator symbols to display between artist and track.",
+                    "type": "string"
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Description

Small feature for `mediaplayer.py` - ability to change separator between artist and track to any custom one.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

### Default
![image](https://github.com/user-attachments/assets/950774cc-f19e-42c3-bbd3-9dc9c082ea4f)

### With custom config
![image](https://github.com/user-attachments/assets/edbab5ed-d4e2-4757-b692-631ee2d1e72d)
![image](https://github.com/user-attachments/assets/512fd1a0-ca1e-4313-a462-8feca2b96ca0)

