### PR TITLE
fix: mediaplayer.py `artist_track_separator` refers to undefined var

### DIFF
--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -96,7 +96,7 @@ def format_artist_track(artist, track, playing, max_length):
                 track = track[:track_limit].rstrip() + "…"
 
         output_text = (
-            f"{prefix}{prefix_separator}<i>{artist}</i>{separator}<b>{track}</b>"
+            f"{prefix}{prefix_separator}<i>{artist}</i>{artist_track_separator}<b>{track}</b>"
         )
     else:
         output_text = "<b>Nothing playing</b>"


### PR DESCRIPTION
# Pull Request

## Description

Looks like in some merge there was a mistake which leads to using undefined `separator` var.

This fix the mistake and use correct `artist_track_separator` var

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
