### PR TITLE
config: fixed windowrule regex that matches unintended windows

### DIFF
--- a/Configs/.local/share/hyde/hyprland.conf
+++ b/Configs/.local/share/hyde/hyprland.conf
@@ -422,7 +422,7 @@ exec-once = systemctl --user start hyde-config.service #! If this is not working
 # See https://wiki.hyprland.org/Configuring/Window-Rules/
 
 # Ony add the Core applications here
-windowrule = float, class:^(com.gabm.satty)$
+windowrule = float,class:^(com.gabm.satty)$
 windowrule = float,class:^(org.kde.dolphin)$,title:^(Progress Dialog — Dolphin)$
 windowrule = float,class:^(org.kde.dolphin)$,title:^(Copying — Dolphin)$
 windowrule = float,title:^(About Mozilla Firefox)$


### PR DESCRIPTION
# Pull Request

## Description

I propose to this edit because the regex were matching unrelated stuff such as when I launch dolphin with SUPER + E if the last opened directory is "Desktop" it creates the window in floating mode because "Desktop" has "top" in it.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

