### PR TITLE
feat: add hyde-menu module to all hyprdots-ported layouts

### DIFF
--- a/Configs/.local/share/waybar/layouts/hyprdots/01.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/01.jsonc
@@ -68,10 +68,8 @@
     },
     "group/pill#right3": {
         "modules": [
-            "custom/wallchange",
-            "custom/theme",
-            "custom/wbar",
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ],
         "orientation": "inherit"

--- a/Configs/.local/share/waybar/layouts/hyprdots/01.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/01.jsonc
@@ -68,6 +68,9 @@
     },
     "group/pill#right3": {
         "modules": [
+            "custom/wallchange",
+            "custom/theme",
+            "custom/wbar",
             "custom/cliphist",
             "custom/hyde-menu",
             "custom/power"

--- a/Configs/.local/share/waybar/layouts/hyprdots/02.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/02.jsonc
@@ -83,6 +83,7 @@
         "orientation": "inherit",
         "modules": [
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/03.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/03.jsonc
@@ -83,6 +83,7 @@
         "orientation": "inherit",
         "modules": [
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/04.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/04.jsonc
@@ -71,10 +71,8 @@
     "group/pill#right3": {
         "orientation": "inherit",
         "modules": [
-            "custom/wallchange",
-            "custom/theme",
-            "custom/wbar",
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/04.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/04.jsonc
@@ -71,6 +71,9 @@
     "group/pill#right3": {
         "orientation": "inherit",
         "modules": [
+            "custom/wallchange",
+            "custom/theme",
+            "custom/wbar",
             "custom/cliphist",
             "custom/hyde-menu",
             "custom/power"

--- a/Configs/.local/share/waybar/layouts/hyprdots/05.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/05.jsonc
@@ -74,10 +74,8 @@
     "group/pill#right3": {
         "orientation": "inherit",
         "modules": [
-            "custom/wallchange",
-            "custom/theme",
-            "custom/wbar",
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/05.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/05.jsonc
@@ -74,6 +74,9 @@
     "group/pill#right3": {
         "orientation": "inherit",
         "modules": [
+            "custom/wallchange",
+            "custom/theme",
+            "custom/wbar",
             "custom/cliphist",
             "custom/hyde-menu",
             "custom/power"

--- a/Configs/.local/share/waybar/layouts/hyprdots/06.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/06.jsonc
@@ -75,10 +75,8 @@
     "group/pill#right3": {
         "orientation": "inherit",
         "modules": [
-            "custom/wallchange",
-            "custom/theme",
-            "custom/wbar",
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/06.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/06.jsonc
@@ -75,6 +75,9 @@
     "group/pill#right3": {
         "orientation": "inherit",
         "modules": [
+            "custom/wallchange",
+            "custom/theme",
+            "custom/wbar",
             "custom/cliphist",
             "custom/hyde-menu",
             "custom/power"

--- a/Configs/.local/share/waybar/layouts/hyprdots/07.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/07.jsonc
@@ -25,10 +25,8 @@
         "orientation": "inherit",
         "modules": [
             "custom/power",
+            "custom/hyde-menu",
             "custom/cliphist",
-            "custom/wbar",
-            "custom/theme",
-            "custom/wallchange",
             "wlr/taskbar",
             "custom/spotify"
         ]

--- a/Configs/.local/share/waybar/layouts/hyprdots/07.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/07.jsonc
@@ -27,6 +27,9 @@
             "custom/power",
             "custom/hyde-menu",
             "custom/cliphist",
+            "custom/wbar",
+            "custom/theme",
+            "custom/wallchange",
             "wlr/taskbar",
             "custom/spotify"
         ]

--- a/Configs/.local/share/waybar/layouts/hyprdots/08.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/08.jsonc
@@ -26,10 +26,8 @@
         "orientation": "inherit",
         "modules": [
             "custom/power",
-            "custom/cliphist",
-            "custom/wbar",
-            "custom/theme",
-            "custom/wallchange"
+            "custom/hyde-menu",
+            "custom/cliphist"
         ]
     },
     "group/pill#left2": {

--- a/Configs/.local/share/waybar/layouts/hyprdots/08.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/08.jsonc
@@ -26,7 +26,10 @@
         "modules": [
             "custom/power",
             "custom/hyde-menu",
-            "custom/cliphist"
+            "custom/cliphist",
+            "custom/wbar",
+            "custom/theme",
+            "custom/wallchange"
         ]
     },
     "group/pill#left2": {

--- a/Configs/.local/share/waybar/layouts/hyprdots/08.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/08.jsonc
@@ -19,8 +19,7 @@
     // positions generated based on config.ctl //
     "modules-left": [
         "group/pill#left1",
-        "group/pill#left2",
-        "group/pill#left3"
+        "group/pill#left2"
     ],
     "group/pill#left1": {
         "orientation": "inherit",
@@ -35,13 +34,6 @@
         "modules": [
             "wlr/taskbar",
             "custom/spotify"
-        ]
-    },
-    "group/pill#left3": {
-        "orientation": "inherit",
-        "modules": [
-            "idle_inhibitor",
-            "clock"
         ]
     },
     "modules-center": [

--- a/Configs/.local/share/waybar/layouts/hyprdots/09.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/09.jsonc
@@ -26,7 +26,10 @@
         "modules": [
             "custom/power",
             "custom/hyde-menu",
-            "custom/cliphist"
+            "custom/cliphist",
+            "custom/wbar",
+            "custom/theme",
+            "custom/wallchange"
         ]
     },
     "group/pill#left2": {

--- a/Configs/.local/share/waybar/layouts/hyprdots/09.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/09.jsonc
@@ -25,10 +25,8 @@
         "orientation": "inherit",
         "modules": [
             "custom/power",
-            "custom/cliphist",
-            "custom/wbar",
-            "custom/theme",
-            "custom/wallchange"
+            "custom/hyde-menu",
+            "custom/cliphist"
         ]
     },
     "group/pill#left2": {

--- a/Configs/.local/share/waybar/layouts/hyprdots/10.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/10.jsonc
@@ -56,9 +56,7 @@
     "group/pill#center5": {
         "orientation": "inherit",
         "modules": [
-            "custom/wbar",
-            "custom/wallchange",
-            "custom/theme"
+            "custom/hyde-menu"
         ]
     },
     "modules-right": []

--- a/Configs/.local/share/waybar/layouts/hyprdots/10.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/10.jsonc
@@ -56,6 +56,9 @@
     "group/pill#center5": {
         "orientation": "inherit",
         "modules": [
+            "custom/wbar",
+            "custom/wallchange",
+            "custom/theme",
             "custom/hyde-menu"
         ]
     },

--- a/Configs/.local/share/waybar/layouts/hyprdots/11.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/11.jsonc
@@ -62,14 +62,16 @@
             "custom/updates",
             "custom/keybindhint"
         ]
-    }
-},
+    },
     "group/pill#right2": {
         "orientation": "inherit",
         "modules": [
             "privacy",
             "tray",
             "battery",
+            "custom/wallchange",
+            "custom/theme",
+            "custom/wbar",
             "custom/cliphist",
             "custom/hyde-menu",
             "custom/power"

--- a/Configs/.local/share/waybar/layouts/hyprdots/11.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/11.jsonc
@@ -39,10 +39,14 @@
         ]
     },
     "modules-center": [
-	            "wlr/taskbar"
-
+        "group/pill#center1"
     ],
-
+    "group/pill#center1": {
+        "orientation": "inherit",
+        "modules": [
+            "wlr/taskbar"
+        ]
+    },
     "modules-right": [
         "group/pill#right1",
         "group/pill#right2"

--- a/Configs/.local/share/waybar/layouts/hyprdots/11.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/11.jsonc
@@ -64,10 +64,8 @@
             "privacy",
             "tray",
             "battery",
-            "custom/wallchange",
-            "custom/theme",
-            "custom/wbar",
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/12.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/12.jsonc
@@ -57,10 +57,8 @@
             "privacy",
             "tray",
             "battery",
-            "custom/wallchange",
-            "custom/theme",
-            "custom/wbar",
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/12.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/12.jsonc
@@ -57,6 +57,9 @@
             "privacy",
             "tray",
             "battery",
+            "custom/wallchange",
+            "custom/theme",
+            "custom/wbar",
             "custom/cliphist",
             "custom/hyde-menu",
             "custom/power"

--- a/Configs/.local/share/waybar/layouts/hyprdots/13.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/13.jsonc
@@ -73,6 +73,7 @@
         "orientation": "inherit",
         "modules": [
             "custom/cliphist",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/14.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/14.jsonc
@@ -26,7 +26,10 @@
         "modules": [
             "custom/power",
             "custom/hyde-menu",
-            "custom/cliphist"
+            "custom/cliphist",
+            "custom/wbar",
+            "custom/theme",
+            "custom/wallchange"
         ]
     },
     "group/pill#left2": {

--- a/Configs/.local/share/waybar/layouts/hyprdots/14.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/14.jsonc
@@ -25,10 +25,8 @@
         "orientation": "inherit",
         "modules": [
             "custom/power",
-            "custom/cliphist",
-            "custom/wbar",
-            "custom/theme",
-            "custom/wallchange"
+            "custom/hyde-menu",
+            "custom/cliphist"
         ]
     },
     "group/pill#left2": {

--- a/Configs/.local/share/waybar/layouts/hyprdots/15.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/15.jsonc
@@ -51,6 +51,7 @@
             "custom/keybindhint",
             "custom/cliphist",
             "custom/hyprsunset",
+            "custom/hyde-menu",
             "custom/power"
         ]
     }

--- a/Configs/.local/share/waybar/layouts/hyprdots/16.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/16.jsonc
@@ -58,7 +58,8 @@
             "custom/gpuinfo",
             "custom/cpuinfo",
             "custom/sensorsinfo",
-            "custom/swaync"
+            "custom/swaync",
+            "custom/hyde-menu"
         ]
     }
 }

--- a/Configs/.local/share/waybar/layouts/hyprdots/17.jsonc
+++ b/Configs/.local/share/waybar/layouts/hyprdots/17.jsonc
@@ -60,7 +60,8 @@
             "custom/gpuinfo",
             "custom/cpuinfo",
             "custom/sensorsinfo",
-            "custom/swaync"
+            "custom/swaync",
+            "custom/hyde-menu"
         ]
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

As discussed here: https://github.com/HyDE-Project/HyDE/pull/215#issuecomment-2943062146

The point was to add menu closer to the corner of the bar and remove any modules which functions are duplicated by menu, if those modules are in same group.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

