### PR TITLE
fix: make waybar ignore example layouts

### DIFF
--- a/Configs/.local/lib/hyde/waybar.py
+++ b/Configs/.local/lib/hyde/waybar.py
@@ -44,6 +44,8 @@ LAYOUT_DIRS = [
     os.path.join("usr", "share", "waybar", "layouts"),
 ]
 
+LAYOUT_IGNORE = ["test.jsonc", "dock#sample.jsonc"]
+
 STYLE_DIRS = [
     os.path.join(str(xdg_config_home()), "waybar", "styles"),
     os.path.join(str(xdg_data_home()), "waybar", "styles"),
@@ -85,7 +87,7 @@ def find_layout_files():
     for layout_dir in LAYOUT_DIRS:
         for root, _, files in os.walk(layout_dir):
             for file in files:
-                if file.endswith(".jsonc"):
+                if file.endswith(".jsonc") and file not in LAYOUT_IGNORE:
                     layouts.append(os.path.join(root, file))
     return sorted(layouts)
 


### PR DESCRIPTION
# Pull Request

## Description

Looks like there is example and test layouts which are not expected to be used directly; but when using `hyde-shell waybar --next` or `hyde-shell waybar --select` and selecting one of the example/test layouts waybar do not work properly.

This PR offer "ignore list" feature to skip some layouts.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
