### PR TITLE
ci: do not create automated PRs on forked repos, second attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dev-to-master-pr:
     name: Create or Update PR from Dev to Master
-    if: github.ref == 'refs/heads/dev' && github.event.repository.full_name == github.repository
+    if: github.ref == 'refs/heads/dev' && github.repository == 'HyDE-Project/HyDE'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
 
   release:
     name: release
-    if: github.ref == 'refs/heads/master' && github.event.repository.full_name == github.repository
+    if: github.ref == 'refs/heads/master' && github.repository == 'HyDE-Project/HyDE'
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v3


### PR DESCRIPTION
# Pull Request

## Description

This is second attempt to make ci gh workflow to skip forked repos. Previous was here: https://github.com/HyDE-Project/HyDE/pull/746

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

> [!WARNING]
> This time I also do not test anything unfortunatelly
