### PR TITLE
feat: port kanji & roman options of `hyprland/workspaces` waybar module

### DIFF
--- a/Configs/.local/share/waybar/modules/hyprland-workspaces#kanji.jsonc
+++ b/Configs/.local/share/waybar/modules/hyprland-workspaces#kanji.jsonc
@@ -1,0 +1,39 @@
+{
+    "hyprland/workspaces#kanji": {
+        "rotate": 0,
+        "class": "no-margin-padding",
+        "all-outputs": true,
+        "active-only": false,
+        "on-click": "activate",
+        "disable-scroll": false,
+        "on-scroll-up": "hyprctl dispatch workspace -1",
+        "on-scroll-down": "hyprctl dispatch workspace +1",
+        "persistent-workspaces": {},
+        "format": "{icon}",
+        "format-icons": {
+            "1": "一",
+            "2": "二",
+            "3": "三",
+            "4": "四",
+            "5": "五",
+            "6": "六",
+            "7": "七",
+            "8": "八",
+            "9": "九",
+            "10": "十",
+            "11": "十一",
+            "12": "十二",
+            "13": "十三",
+            "14": "十四",
+            "15": "十五",
+            "16": "十六",
+            "17": "十七",
+            "18": "十八",
+            "19": "十九",
+            "20": "二十",
+            "urgent": "",
+            "focused": "",
+            "default": " "
+        }
+    }
+}

--- a/Configs/.local/share/waybar/modules/hyprland-workspaces#roman.jsonc
+++ b/Configs/.local/share/waybar/modules/hyprland-workspaces#roman.jsonc
@@ -1,0 +1,39 @@
+{
+    "hyprland/workspaces#roman": {
+        "rotate": 0,
+        "class": "no-margin-padding",
+        "all-outputs": true,
+        "active-only": false,
+        "on-click": "activate",
+        "disable-scroll": false,
+        "on-scroll-up": "hyprctl dispatch workspace -1",
+        "on-scroll-down": "hyprctl dispatch workspace +1",
+        "persistent-workspaces": {},
+        "format": "{icon}",
+        "format-icons": {
+            "1": "I",
+            "2": "II",
+            "3": "III",
+            "4": "IV",
+            "5": "V",
+            "6": "VI",
+            "7": "VII",
+            "8": "VIII",
+            "9": "IX",
+            "10": "X",
+            "11": "XI",
+            "12": "XII",
+            "13": "XIII",
+            "14": "XIV",
+            "15": "XV",
+            "16": "XVII",
+            "17": "XVI",
+            "18": "XVIII",
+            "19": "XIX",
+            "20": "XX",
+            "urgent": "",
+            "focused": "",
+            "default": " "
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I had ported versions of [kanji](https://github.com/HyDE-Project/HyDE/blob/v0.3.0/Configs/.config/waybar/modules/workspaces%23%23kanji.jsonc) and [roman](https://github.com/HyDE-Project/HyDE/blob/v0.3.0/Configs/.config/waybar/modules/workspaces%23%23roman.jsonc) waybar `hyprland/workspaces` module

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/user-attachments/assets/c32b9530-eda3-4e84-b594-b44051497f30)

![image](https://github.com/user-attachments/assets/a10c31d8-55c7-47f9-abd6-b2793b7fa847)
