### PR TITLE
fix: include nixos wrapped program to prevent infinite reloads

### DIFF
--- a/Configs/.local/lib/hyde/waybar.py
+++ b/Configs/.local/lib/hyde/waybar.py
@@ -1403,7 +1403,7 @@ def watch_waybar():
                 time.sleep(2)
                 continue
 
-            result = subprocess.run(["ps", "-C", "waybar"], capture_output=True)
+            result = subprocess.run(["ps", "-C", "waybar,.waybar-wrapped"], capture_output=True)
             if result.returncode != 0:
                 run_waybar_command("killall waybar; waybar & disown")
                 logger.debug("Waybar restarted")


### PR DESCRIPTION
# Pull Request

## Description

fixes infinite reload of the waybar python script because nixos is special and has special named programs :sweat_smile: 

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/user-attachments/assets/6081f1ab-e8e9-4dcf-b57e-196d71669739)

## Additional context

on a sidenote i have a sed script already that replaces `killall waybar` with `.waybar-wrapped` globally, weirdly `pkill waybar` somehow works
