### PR TITLE
make battery detection dynamic and improve icon support

### DIFF
--- a/Configs/.local/lib/hyde/battery.sh
+++ b/Configs/.local/lib/hyde/battery.sh
@@ -25,6 +25,15 @@ fi
 total_capacity=0
 battery_count=0
 
+# Find the first available battery
+battery_path=""
+for bat in /sys/class/power_supply/BAT*; do
+    if [[ -d "$bat" ]]; then
+        battery_path="$bat"
+        break
+    fi
+done
+
 for capacity in /sys/class/power_supply/BAT*/capacity; do
     if [[ -f "$capacity" ]]; then
         total_capacity=$((total_capacity + $(<"$capacity")))
@@ -42,11 +51,12 @@ average_capacity=$((total_capacity / battery_count))
 index=$((average_capacity / 10))
 
 # Define icons for charging, discharging, and status
-charging_icons=(" " " " " " " " " " " " " ")
+# Charging icons from 0% to 100% (last icons repeated to fill 11 levels)
+charging_icons=(" " " " " " " " " " " " " " " " " " " " " ") 
 discharging_icons=("󰂎" "󰁺" "󰁻" "󰁼" "󰁽" "󰁾" "󰁿" "󰂀" "󰂁" "󰂂" "󰁹")
 status_icons=("" "X" "󰂇") # Add appropriate icons for different statuses
 
-battery_status=$(cat /sys/class/power_supply/BAT0/status)
+battery_status=$(cat "$battery_path/status")
 
 # Parse format options
 formats=("$@")


### PR DESCRIPTION


# Pull Request

## Description
Fixes #829
fix script Configs/.local/lib/hyde/battery.sh:
- Dynamically detect any BAT* (BAT0, BAT1, etc.) instead of hardcoding BAT0
- Support systems with non-standard battery numbering
- Expand charging icons to 11 levels

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


Add any other context about the problem here.

- Hardcoded battery name (BAT0): The script always uses BAT0 when querying battery status/icons, but on my system the battery is named BAT1
    charging_icons array overflow
- The charging_icons array is defined with only 7 elements (for 0%, 10%, …, 60%). If the battery level exceeds 60%, the script computes an index beyond the end of the array and throws an empty icon.

