### PR TITLE
feat: add `reboot to UEFI` to waybar power menu

### DIFF
--- a/Configs/.local/share/waybar/menus/power.xml
+++ b/Configs/.local/share/waybar/menus/power.xml
@@ -32,12 +32,12 @@
                 <child type="submenu">
                     <object class="GtkMenu">
                         <child>
-                            <object class="GtkMenuItem" id="shutdown_now">
-                                <property name="label">Suspend Now</property>
+                            <object class="GtkMenuItem" id="shutdown-now">
+                                <property name="label">Shutdown Now</property>
                             </object>
                         </child>
                         <child>
-                            <object class="GtkMenuItem" id="shutdown_wait">
+                            <object class="GtkMenuItem" id="shutdown-wait">
                                 <property name="label">Shutdown (wait)</property>
                             </object>
                         </child>
@@ -50,8 +50,23 @@
 
 
         <child>
-            <object class="GtkMenuItem" id="reboot">
+            <object class="GtkMenuItem" id="reboot_sub">
                 <property name="label">Reboot</property>
+
+                <child type="submenu">
+                    <object class="GtkMenu">
+                        <child>
+                            <object class="GtkMenuItem" id="reboot-now">
+                                <property name="label">Reboot</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="GtkMenuItem" id="reeboot-firmware">
+                                <property name="label">Reboot to UEFI</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
             </object>
         </child>
 

--- a/Configs/.local/share/waybar/menus/power.xml
+++ b/Configs/.local/share/waybar/menus/power.xml
@@ -61,7 +61,7 @@
                             </object>
                         </child>
                         <child>
-                            <object class="GtkMenuItem" id="reeboot-firmware">
+                            <object class="GtkMenuItem" id="reboot-firmware">
                                 <property name="label">Reboot to UEFI</property>
                             </object>
                         </child>

--- a/Configs/.local/share/waybar/modules/custom-power.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-power.jsonc
@@ -7,7 +7,7 @@
         "menu": "on-click-right",
         "menu-file": "${HYDE_WAYBAR_MENU_DIR:-$XDG_DATA_HOME/waybar/menus}/power.xml",
         "menu-actions": {
-            "shutdown-now": "systemctl shutdown now",
+            "shutdown-now": "shutdown now",
             "shutdown-wait": "systemctl poweroff",
             "reboot-now": "systemctl reboot",
             "reboot-firmware": "systemctl reboot --firmware-setup",

--- a/Configs/.local/share/waybar/modules/custom-power.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-power.jsonc
@@ -10,7 +10,7 @@
             "shutdown-now": "systemctl shutdown now",
             "shutdown-wait": "systemctl poweroff",
             "reboot-now": "systemctl reboot",
-            "reeboot-firmware": "systemctl reboot --firmware-setup",
+            "reboot-firmware": "systemctl reboot --firmware-setup",
             "suspend": "systemctl suspend",
             "hibernate": "systemctl hibernate"
         },

--- a/Configs/.local/share/waybar/modules/custom-power.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-power.jsonc
@@ -9,7 +9,8 @@
         "menu-actions": {
             "shutdown-now": "systemctl shutdown now",
             "shutdown-wait": "systemctl poweroff",
-            "reboot": "reboot",
+            "reboot-now": "systemctl reboot",
+            "reeboot-firmware": "systemctl reboot --firmware-setup",
             "suspend": "systemctl suspend",
             "hibernate": "systemctl hibernate"
         },

--- a/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
@@ -5,7 +5,7 @@
         "menu": "on-click-right",
         "menu-file": "${HYDE_WAYBAR_MENU_DIR:-$XDG_DATA_HOME/waybar/menus}/power.xml",
         "menu-actions": {
-            "shutdown-now": "systemctl shutdown now",
+            "shutdown-now": "shutdown now",
             "shutdown-wait": "systemctl poweroff",
             "reboot-now": "systemctl reboot",
             "reboot-firmware": "systemctl reboot --firmware-setup",

--- a/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
@@ -5,8 +5,10 @@
         "menu": "on-click-right",
         "menu-file": "${HYDE_WAYBAR_MENU_DIR:-$XDG_DATA_HOME/waybar/menus}/power.xml",
         "menu-actions": {
-            "shutdown": "shutdown",
-            "reboot": "reboot",
+            "shutdown-now": "systemctl shutdown now",
+            "shutdown-wait": "systemctl poweroff",
+            "reboot-now": "systemctl reboot",
+            "reeboot-firmware": "systemctl reboot --firmware-setup",
             "suspend": "systemctl suspend",
             "hibernate": "systemctl hibernate"
         },

--- a/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
@@ -8,7 +8,7 @@
             "shutdown-now": "systemctl shutdown now",
             "shutdown-wait": "systemctl poweroff",
             "reboot-now": "systemctl reboot",
-            "reeboot-firmware": "systemctl reboot --firmware-setup",
+            "reboot-firmware": "systemctl reboot --firmware-setup",
             "suspend": "systemctl suspend",
             "hibernate": "systemctl hibernate"
         },


### PR DESCRIPTION
# Pull Request

## Description

This PR offers a feature for rebooting to UEFI settings from waybar power menu.

Also it fixes IDs of power menu, because IDs with underscore do not match menu actions names in waybar modules and do not work.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/user-attachments/assets/a1e635e9-4fad-4810-ba85-c01efc674900)

