### PR TITLE
Mediaplayer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,15 +18,16 @@ _These contributors help with code review, triaging, and development._
 - [@rubiin](https://github.com/rubiin)
 - [@Metalhearf](https://github.com/Metalhearf)
 - [@prime-run](https://github.com/prime-run)
+- [@heeeeeeeeeeh](https://github.com/heeeeeeeeeeh/)
 
 ## Testers
 
 _These contributors help with quality assurance and testing._
 
-
 - [@amit-0i](https://github.com/amit-0i)
 - [@Prof-Shiba](https://github.com/Prof-Shiba)
 - [@UnaTried](https://github.com/UnaTried)
+
 ---
 
 ## How to add yourself to this list

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -108,10 +108,10 @@ def write_output(track, artist, playing, player, tooltip_text):
     logger.info("Writing output")
 
     output_data = {
-        "text": format_artist_track(artist, track, playing, max_length_module),
+        "text": escape(format_artist_track(artist, track, playing, max_length_module)),
         "class": "custom-" + player.props.player_name,
         "alt": player.props.player_name,
-        "tooltip": tooltip_text,
+        "tooltip": escape(tooltip_text),
     }
 
     sys.stdout.write(json.dumps(output_data) + "\n")
@@ -375,6 +375,10 @@ def set_player(manager, player):
 def control_music(sig, frame, action):
     if currentplayer:
         getattr(currentplayer, action)()
+
+
+def escape(string):
+    return string.replace("&", "&amp;")
 
 
 if __name__ == "__main__":

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -264,7 +264,7 @@ def parse_arguments():
 
 def main():
     global prefix_playing, prefix_paused, max_length_module, standby_text, artist_track_separator
-    global artist_color, track_color, progress_color, empty_color, time_color
+    global artist_color, artist_weight, track_color, progress_color, empty_color, time_color
 
     # Load environment variables from your config file:
     config_file = os.path.join(xdg_state_home(), "hyde", "config")
@@ -298,6 +298,7 @@ def main():
     time_color = os.getenv(
         "MEDIAPLAYER_TOOLTIP_TIME_COLOR", "#" + os.getenv("dcol_txt1", "FFFFFF")
     )
+    artist_weight = os.getenv("MEDIAPLAYER_ARTIST_WEIGHT", 0.65)
     players = os.getenv("MEDIAPLAYER_PLAYERS", None)
     if players:
         players = players.split(",")

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -90,9 +90,18 @@ def format_artist_track(artist, track, playing, max_length):
         if full_length > max_length:
             # proportion how to share max length between track and artist
             artist_weight = 0.65
-            track_weight = 1 - artist_weight
-            artist_limit = int(max_length * artist_weight)
-            track_limit = int(max_length * track_weight)
+            artist_limit = min(int(max_length * artist_weight), len(artist))
+            a_gain = max(0, artist_weight - (artist_limit / max_length))
+            track_weight = 1 - artist_weight + a_gain
+            track_limit = min(int(max_length * track_weight), len(track))
+            t_gain = max(0, track_weight - (track_limit / max_length))
+
+            if a_gain == 0 and t_gain > 0:
+                gain = int(max_length * t_gain)
+                artist_limit = artist_limit + gain
+            elif a_gain > 0 and t_gain == 0:
+                gain = int(max_length * t_gain)
+                artist_limit = artist_limit + gain
 
             if len(artist) != len(artist[:artist_limit]):
                 artist = artist[:artist_limit].rstrip() + "…"

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -86,6 +86,7 @@ def format_artist_track(artist, track, playing, max_length):
             track = track[:max_length].rstrip() + "…"
         output_text = f"{prefix}{prefix_separator}<b>{track}</b>"
     elif track and artist:
+        artist = artist.split(",")[0].split("&")[0].strip()
         if full_length > max_length:
             # proportion how to share max length between track and artist
             artist_weight = 0.65

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -319,6 +319,9 @@ def main():
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR1, lambda *args: control_music(*args, "previous"))
+    signal.signal(signal.SIGUSR2, lambda *args: control_music(*args, "next"))
+    signal.signal(signal.SIGRTMIN, lambda *args: control_music(*args, "play_pause"))
 
     found = [None] * len(players)
     for player in manager.props.player_names:
@@ -367,6 +370,11 @@ def set_player(manager, player):
             currentplayer.pause()
     currentplayer = player
     manager.move_player_to_top(player)
+
+
+def control_music(sig, frame, action):
+    if currentplayer:
+        getattr(currentplayer, action)()
 
 
 if __name__ == "__main__":

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -165,12 +165,6 @@ def on_metadata(player, metadata, manager):
         "duration": duration_seconds,
     }
 
-    # Build the tooltip
-    tooltip_text = create_tooltip_text(
-        artist, track, current_position_seconds, duration_seconds
-    )
-    write_output(track, artist, playing, player, tooltip_text)
-
 
 def on_player_appeared(manager, player, selected_players=None):
     if player is not None and (
@@ -219,6 +213,7 @@ def update_positions(manager):
     updates the tooltip, and rewrites the output to stdout.
     """
     # manager.props.players gives us the current active Player objects
+    tooltip_text = ""
     for player in manager.props.players:
         p_name = player.props.player_name
         # If we haven't stored metadata for this player yet, skip
@@ -231,11 +226,21 @@ def update_positions(manager):
         duration_seconds = players_data[p_name]["duration"]
 
         current_position_seconds = player.get_position() / 1e6
-        tooltip_text = create_tooltip_text(
-            artist, track, current_position_seconds, duration_seconds
+        tooltip_text += (
+            create_tooltip_text(
+                artist, track, current_position_seconds, duration_seconds
+            )
+            + "\n\n"
         )
 
-        write_output(track, artist, playing, player, tooltip_text)
+    player = manager.props.players[0]
+    p_name = player.props.player_name
+    playing = player.props.status == "Playing"
+    track = players_data[p_name]["track"]
+    artist = players_data[p_name]["artist"]
+    duration_seconds = players_data[p_name]["duration"]
+
+    write_output(track, artist, playing, player, tooltip_text)
 
     # Return True so the timer continues calling this function
     return True

--- a/Configs/.local/lib/hyde/mediaplayer.py
+++ b/Configs/.local/lib/hyde/mediaplayer.py
@@ -57,7 +57,7 @@ def format_time(seconds) -> str:
 
 
 def create_tooltip_text(
-    artist, track, current_position_seconds, duration_seconds
+    artist, track, current_position_seconds, duration_seconds, p_name
 ) -> str:
     """
     Build the tooltip text showing artist, track, and current position vs duration.
@@ -66,7 +66,7 @@ def create_tooltip_text(
     tooltip = ""
 
     if artist or track:
-        tooltip += f'<span foreground="{track_color}"><b>{track}</b></span>\n<span foreground="{artist_color}"><i>{artist}</i></span>\n'
+        tooltip += f'<span foreground="{track_color}"><b>{track}</b></span>\n<span foreground="{artist_color}"><i>{artist}</i></span>\n<span>{p_name}</span>\n'
         if duration_seconds > 0:
             progress = int((current_position_seconds / duration_seconds) * 20)
             bar = f'<span foreground="{progress_color}">{"━" * progress}</span><span foreground="{empty_color}">{"─" * (20 - progress)}</span>'
@@ -228,7 +228,7 @@ def update_positions(manager):
         current_position_seconds = player.get_position() / 1e6
         tooltip_text += (
             create_tooltip_text(
-                artist, track, current_position_seconds, duration_seconds
+                artist, track, current_position_seconds, duration_seconds, p_name
             )
             + "\n\n"
         )

--- a/Configs/.local/share/waybar/modules/custom-mediaplayer.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-mediaplayer.jsonc
@@ -1,0 +1,10 @@
+{
+  "custom/mediaplayer": {
+    "exec": "hyde-shell mediaplayer.py",
+    "return-type": "json",
+    "format": "{}",
+    "on-click": "pkill -SIGUSR2 -f 'python3 /home/silve/.config/waybar/waybar-mediaplayer/src/mediaplayer monitor'",
+    "on-scroll-up": "hyde-shell mediaplayer.py next",
+    "on-scroll-down": "hyde-shell mediaplayer.py previous",
+  },
+}


### PR DESCRIPTION
# Pull Request

## Description

-  24e1ee3 feat(mediaplayer): Added waybar module for mediaplayer
- 49d9a32 feat(mediaplayer): modified mediaplayer to support multiple players. I have multiple players (for offline and online use)
- 266a7ad feat(mediaplayer): Add env option for players. so that it is easier to set players
- c1aace0 fix(mediaplayer): get first player that is player(I meant playing) if there are none then get first player in list. User is more likely to want to be shown the playing then the first option they gave for player.
- faf674f feat(mediaplayer): Added media controls (next/previous/playpause). used signals bc I was lazy and it seem the easiest way to do it
- 8694197 fix(mediaplayer): escaped & in song metadata. having a & in metadata would cause an error
- 736edb1 Made text only show main artist Tooltip shows all. I think the title is more important.
- 053c9a5  fix(mediaplayer.py): redo algorithm that proportions (forgot to add text). I did this because it makes sure that if either artist or title has some extra space it passes it to the other if needed
- feat(mediaplayer.py): Added env option for artist weight. makes mediaplayer more versatile 
- 39943f6 fix(mediaplayer): moved all players output to tooltip except for current. this makes sure that waybar only  shows the current player. if write_output is called for every one that would be unnecessary because only  one player's metadata will show and it wouldn't be the current player
- ec5e588 - feat(mediaplayer): added player name to tooltip. to know that is playing what. Imma add option for the color later. Maybe there should be an option for custom icons for  player in the text field and a default as fallback 

## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

## Questions
This is my first ever pull request so I'm a bit confused. 

- I added some env options to mediaplayer but i wasn't sure how to update the document to reflect it and add it the options to the schema file
- It the contributing docs it says to make sure all the tests pass but Im not sure how to run them.
- I not sure how I've should have bundle the commits. Is like this fine, or should I have separated them into different PRs
- Where is the changelog?
- I wanted to add the progress bar to text field too but idk if that a good idea 

