### PR TITLE
fix: add missing whitespace in shuffle menu entry for spotify waybar module

### DIFF
--- a/Configs/.local/share/waybar/modules/custom-spotify.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-spotify.jsonc
@@ -16,7 +16,7 @@
       "next": "playerctl next --player spotify",
       "previous": "playerctl previous --player spotify",
       "stop": "playerctl stop --player spotify",
-      "shuffle": "playerctl shuffle toggle--player spotify",
+      "shuffle": "playerctl shuffle toggle --player spotify",
       "repeat": "playerctl loop Track --player spotify",
       "loop": "playerctl loop Playlist --player spotify",
       "disable-loop": "playerctl loop None --player spotify",


### PR DESCRIPTION
# Pull Request

## Description

Small fix which add missing whitespace. This fixes shuffle toggle for spotify.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
