### PR TITLE
fix: do not use uwsm for hyprlock

### DIFF
--- a/Configs/.local/lib/hyde/hyprlock.sh
+++ b/Configs/.local/lib/hyde/hyprlock.sh
@@ -320,7 +320,7 @@ if [ -z "${*}" ]; then
     print_log -sec "hyprlock" -stat "setting" " $HYDE_CACHE_HOME/wallpapers/hyprlock.png"
     "${scrDir}/wallpaper.sh" -s "$(readlink "${HYDE_THEME_DIR}/wall.set")" --backend hyprlock
   fi
-  uwsm app -- hyprlock || hyprlock
+  pidof hyprlock || hyprlock
   exit 0
 fi
 


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes flaky bug when sometimes if hyprlock was launched using uwsm, after unlocking hyprlock is started again forcing user to unlock one more time. 

Maybe bug is related to `Restart=on-failure` option in unit file used by uwsm and non-zero exit code by hyprlock, but I can not reproduce the bug stable enough.

Solution is not to use uwsm for launching hyprlock, if uwsm is not used - bug is not present in any scenarios.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
