### PR TITLE
fix: add `prompt.zsh` to config restore list

### DIFF
--- a/Configs/.config/zsh/conf.d/hyde/terminal.zsh
+++ b/Configs/.config/zsh/conf.d/hyde/terminal.zsh
@@ -184,7 +184,7 @@ fi
 _load_compinit
 
     # Try to load prompts immediately
-if ! source ${ZDOTDIR}/prompt.zsh; then
+if ! source ${ZDOTDIR}/prompt.zsh &>/dev/null; then
     [[ -f $ZDOTDIR/conf.d/hyde/prompt.zsh ]] && source $ZDOTDIR/conf.d/hyde/prompt.zsh
 fi
 

--- a/Scripts/restore_cfg.psv
+++ b/Scripts/restore_cfg.psv
@@ -87,7 +87,7 @@ S|${HOME}/.config/zsh/completions|fzf.zsh|zsh fzf
 S|${HOME}/.config/zsh/completions|hydectl.zsh|zsh
 
 
-P|${HOME}/.config/zsh|.zshrc user.zsh|zsh
+P|${HOME}/.config/zsh|.zshrc user.zsh prompt.zsh|zsh
 P|${HOME}/.config/zsh|.p10k.zsh|zsh zsh-theme-powerlevel10k
 
 


### PR DESCRIPTION
# Pull Request

## Description

This fixes an error on shell start:
```
/home/zee/.config/zsh/conf.d/hyde/terminal.zsh:source:181: no such file or directory: /home/zee/.config/zsh/prompt.zsh
```

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
