### PR TITLE
feat: Add a backend for hyprpaper for wallpaper.sh

### DIFF
--- a/Configs/.local/lib/hyde/wallpaper.hyprpaper.sh
+++ b/Configs/.local/lib/hyde/wallpaper.hyprpaper.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# A backend for hyprpaper
+# A wallpaper backend adapter for hyprpaper
 # * Notes
 # For future backends, this can be used as a base, just
 # change the hyprctl commands for the desired backend's commands
@@ -12,9 +12,26 @@ if ! source "$(which hyde-shell)"; then
     exit 1
 fi
 
+# ? Be sure the wallpaper daemon is running
+if [[ ! -f "${XDG_RUNTIME_FIR}/hypr/$HYPRLAND_INSTANCE_SIGNATURE/hyprpaper.lock" ]]; then
+    systemctl --user start hyprpaper.service || setsid hyprpaper &
+    sleep 1
+fi
+
 selected_wall="${1:-${XDG_CACHE_HOME:-$HOME/.cache}/hyde/wall.set}"
 [ -z "${selected_wall}" ] && echo "No input wallpaper" && exit 1
 selected_wall="$(readlink -f "${selected_wall}")"
 
-hyprctl hyprpaper preload "${selected_wall}"
-hyprctl hyprpaper wallpaper ",${selected_wall}"
+#? hyprlock do not support videos, so we need to convert them to images
+is_video=$(file --mime-type -b "${selected_wall}" | grep -c '^video/')
+if [ "${is_video}" -eq 1 ]; then
+    print_log -sec "wallpaper" -stat "converting video" "$selected_wall"
+    mkdir -p "${HYDE_CACHE_HOME}/wallpapers/thumbnails"
+    cached_thumb="$HYDE_CACHE_HOME/wallpapers/$(${hashMech:-sha1sum} "${selected_wall}" | cut -d' ' -f1).png"
+    extract_thumbnail "${selected_wall}" "${cached_thumb}"
+    selected_wall="${cached_thumb}"
+fi
+
+# ? Setting wallpaper using hyprctl IPC!
+# https://wiki.hypr.land/Hypr-Ecosystem/hyprpaper/#the-reload-keyword
+hyprctl hyprpaper reload ",${selected_wall}"


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a backend for hyprpaper in wallpaper.sh, which allows people to have the splash, note that this requires the user who wants hyprpaper to install hyprpaper, but it's not an issue.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
