### PR TITLE
chore(waybar): make CSS import path portable

### DIFF
--- a/Configs/.config/waybar/style.css
+++ b/Configs/.config/waybar/style.css
@@ -13,10 +13,10 @@
     /* Modified by Hyde */
 
     /* Modify/add style in ~/.config/waybar/styles/ */
-    @import "/home/khing/.local/share/waybar/styles/defaults.css";
+    @import "~/.local/share/waybar/styles/defaults.css";
 
     /* Imports wallbash colors */
-    @import "/home/khing/.cache/hyde/wallbash/gtk.css";
+    @import "~/.cache/hyde/wallbash/gtk.css";
 
     /* Colors and theme configuration is generated through the `theme.css` file */
     @import "theme.css";


### PR DESCRIPTION
Replaced hardcoded /home/khing/... with ~/.local/share/waybar/styles/defaults.css so that the import works across different user accounts.

## Description

This change replaces the hardcoded absolute CSS import path in the Waybar configuration:

```diff
- @import "/home/khing/.local/share/waybar/styles/defaults.css";
+ @import "~/.local/share/waybar/styles/defaults.css";
```

By using `~`, the import now resolves relative to the current user’s home directory, making the configuration portable across different accounts without embedding a username.

*Closes no existing issue.*

---

## Type of change

* [x] **Bug fix** (non-breaking change which fixes an issue)

---

## Checklist

* [x] My code follows the code style of this project.
* [x] My commit message follows the commit guidelines.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] I have tested my code locally and it works as expected.


