### PR TITLE
fix: adapt `screenshot.sh` for updated grimblast script

### DIFF
--- a/Configs/.local/lib/hyde/screenshot.sh
+++ b/Configs/.local/lib/hyde/screenshot.sh
@@ -102,7 +102,7 @@ s) # drag to manually snip an area / click on a window to print it
 	take_screenshot "area"
 	;;
 sf) # frozen screen, drag to manually snip an area / click on a window to print it
-	take_screenshot "area" "--freeze" "--cursor"
+	take_screenshot "area" "--freeze"
 	;;
 m) # print focused monitor
 	take_screenshot "output"


### PR DESCRIPTION
## Description

This PR fixes error:

```sh
❯ hyde-shell screenshot.sh sf
Error: Error: '--cursor' cannot be used with subject 'area'
```

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
