### PR TITLE
fix: adapt `screenshot.sh` for updated grimblast script

### DIFF
--- a/Configs/.local/lib/hyde/screenshot.sh
+++ b/Configs/.local/lib/hyde/screenshot.sh
@@ -102,7 +102,7 @@ s) # drag to manually snip an area / click on a window to print it
 	take_screenshot "area"
 	;;
 sf) # frozen screen, drag to manually snip an area / click on a window to print it
-	take_screenshot "area" "--freeze" "--cursor"
+	take_screenshot "area" "--freeze"
 	;;
 m) # print focused monitor
 	take_screenshot "output"


### PR DESCRIPTION
This is just a copy of https://github.com/HyDE-Project/HyDE/pull/1049

Looks like commit was dropeed in recent merges and area screenshot isn't working again
