### PR TITLE
fix: change `QT_QPA_PLATFORM` to correct value

### DIFF
--- a/Configs/.local/share/hyde/hyde.conf
+++ b/Configs/.local/share/hyde/hyde.conf
@@ -64,8 +64,7 @@ $start.IDLE_DAEMON=$IDLE
 
 # Toolkit Backend Variables - https://wiki.hyprland.org/Configuring/Environment-variables/#toolkit-backend-variables
 $env.GDK_BACKEND = wayland,x11,* #s GTK: Use wayland if available. If not: try x11, then any other GDK backend.
-$env.QT_QPA_PLATFORM = wayland
-xcb                            #Qt: Use wayland if available, fall back to x11 if not.
+$env.QT_QPA_PLATFORM = wayland;xcb                            #Qt: Use wayland if available, fall back to x11 if not.
 $env.SDL_VIDEODRIVER = wayland # Run SDL2 applications on Wayland. Remove or set to x11 if games that provide older versions of SDL cause compatibility issues
 $env.CLUTTER_BACKEND = wayland # Clutter package already has wayland enabled, this variable will force Clutter applications to try and use the Wayland backend
 
@@ -77,8 +76,6 @@ $env.XDG_SESSION_DESKTOP = Hyprland
 # Qt Variables  - https://wiki.hyprland.org/Configuring/Environment-variables/#qt-variables
 
 $env.QT_AUTO_SCREEN_SCALE_FACTOR = 1 # (From the Qt documentation) enables automatic scaling, based on the monitor’s pixel density
-$env.QT_QPA_PLATFORM=wayland
-xcb                                          # Tell Qt applications to use the Wayland backend, and fall back to x11 if Wayland is unavailable
 $env.QT_WAYLAND_DISABLE_WINDOWDECORATION = 1 # Disables window decorations on Qt applications
 $env.QT_QPA_PLATFORMTHEME = qt6ct            # Tells Qt based applications to pick your theme from qt5ct, use with Kvantum.
 

--- a/Configs/.local/share/hypr/env.conf
+++ b/Configs/.local/share/hypr/env.conf
@@ -17,7 +17,7 @@
 # Qt Variables  - https://wiki.hyprland.org/Configuring/Environment-variables/#qt-variables
 
 $env.QT_AUTO_SCREEN_SCALE_FACTOR = 1 # (From the Qt documentation) enables automatic scaling, based on the monitor’s pixel density
-$env.QT_QPA_PLATFORM = wayland\;xcb  # Tell Qt applications to use the Wayland backend, and fall back to x11 if Wayland is unavailable
+$env.QT_QPA_PLATFORM = wayland;xcb  # Tell Qt applications to use the Wayland backend, and fall back to x11 if Wayland is unavailable
 
 $env.QT_WAYLAND_DISABLE_WINDOWDECORATION = 1 # Disables window decorations on Qt applications
 $env.QT_QPA_PLATFORMTHEME = qt6ct            # Tells Qt based applications to pick your theme from qt5ct, use with Kvantum.
@@ -71,7 +71,7 @@ env = QT_AUTO_SCREEN_SCALE_FACTOR,1
 # hyprlang endif
 
 # hyprlang if !QT_QPA_PLATFORM
-env = QT_QPA_PLATFORM,wayland\;xcb
+env = QT_QPA_PLATFORM,wayland;xcb
 # hyprlang endif
 
 # hyprlang if !QT_WAYLAND_DISABLE_WINDOWDECORATION


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes launch problem with some QT apps after recent merges.

`;` the symbol must not be escaped, because it leads to QT_QPA_PLATFORM having and actual value of:

```sh
❯ echo $QT_QPA_PLATFORM
wayland\;xcb
```

which is not recognized with some apps resulting in error on launch:

```sh
qt.qpa.plugin: Could not find the Qt platform plugin "wayland\" in ""
```

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

