### PR TITLE
fix: waybar dunst module doesn't show up

### DIFF
--- a/Configs/.local/share/waybar/modules/custom-dunst.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-dunst.jsonc
@@ -24,7 +24,7 @@
     },
     "return-type": "json",
     // "exec-if": "which dunstctl",
-    "exec-if": "dunstctl  is-paused 2> /dev/null", // This is to check if dunst is running
+    "exec-if": "dunstctl  is-paused &> /dev/null", // This is to check if dunst is running
     "exec": "hyde-shell notifications",
     "on-scroll-down": "sleep 0.1 && dunstctl history-pop",
     "on-click": "dunstctl set-paused toggle",


### PR DESCRIPTION
# Pull Request

## Description

Fix waybar `custom-dunst.jsonc` module bug which is introduced in commit `086144f`.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.
