### PR TITLE
[waybar] fix: apply `@main-fg` theme color to all modules

### DIFF
--- a/Configs/.local/share/waybar/styles/defaults.css
+++ b/Configs/.local/share/waybar/styles/defaults.css
@@ -26,6 +26,10 @@ window#waybar {
     background: @bar-bg;
 }
 
+.module {
+    color: @main-fg;
+}
+
 /*
  These are groups/islands configs
 


### PR DESCRIPTION
# Pull Request

## Description

For some reason `@main-fg` color is not applied to all modules and it looks inconsistent in some themes.

This PR adds color for modules explicitly.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

Rose Pine theme for example. As can be seen not all modules inherit `@main-fg` color.

### Before
<img width="1920" height="46" alt="image" src="https://github.com/user-attachments/assets/10fe7ae1-e2cb-49ec-968c-46c2e47643e0" />

### After
<img width="1921" height="46" alt="image" src="https://github.com/user-attachments/assets/5c5e0280-82a7-4c6e-98c2-059b8dea73ac" />

