### PR TITLE
fix: do not escape `;` symbol in QT_QPA_PLATFORM env var

### DIFF
--- a/Configs/.local/share/hypr/env.conf
+++ b/Configs/.local/share/hypr/env.conf
@@ -17,7 +17,7 @@
 # Qt Variables  - https://wiki.hyprland.org/Configuring/Environment-variables/#qt-variables
 
 $env.QT_AUTO_SCREEN_SCALE_FACTOR = 1 # (From the Qt documentation) enables automatic scaling, based on the monitor’s pixel density
-$env.QT_QPA_PLATFORM = wayland\;xcb  # Tell Qt applications to use the Wayland backend, and fall back to x11 if Wayland is unavailable
+$env.QT_QPA_PLATFORM = wayland;xcb  # Tell Qt applications to use the Wayland backend, and fall back to x11 if Wayland is unavailable
 
 $env.QT_WAYLAND_DISABLE_WINDOWDECORATION = 1 # Disables window decorations on Qt applications
 $env.QT_QPA_PLATFORMTHEME = qt6ct            # Tells Qt based applications to pick your theme from qt5ct, use with Kvantum.
@@ -71,7 +71,7 @@ env = QT_AUTO_SCREEN_SCALE_FACTOR,1
 # hyprlang endif
 
 # hyprlang if !QT_QPA_PLATFORM
-env = QT_QPA_PLATFORM,wayland\;xcb
+env = QT_QPA_PLATFORM,wayland;xcb
 # hyprlang endif
 
 # hyprlang if !QT_WAYLAND_DISABLE_WINDOWDECORATION


### PR DESCRIPTION
Looks like part of changes is missing after megres. 

This PR is a copy of https://github.com/HyDE-Project/HyDE/pull/1078
