### PR TITLE
docs: extend `temperature` waybar module docs with AMD notes

### DIFF
--- a/Configs/.local/share/waybar/modules/temperature.jsonc
+++ b/Configs/.local/share/waybar/modules/temperature.jsonc
@@ -82,7 +82,8 @@
   // Model name:                              AMD Ryzen 7 9700X 8-Core Processor
   // 
   // 3. Take desired `hwmon-path` from the output of the script, replace `thermal-zone` with `hwmon-path` in waybar module config
-  //    i.e. "thermal-zone": 2 -> "hwmon-path": "/sys/class/hwmon/hwmon0"
+  //    i.e. "thermal-zone": 2 -> "hwmon-path": "/sys/class/hwmon/hwmon0/temp1_input"
+  //    p.s. do not forget to add temperature source (`temp1_input` in example above)
   //
   // PERFORMANCE NOTES:
   // - thermal-zone method is FASTER than custom scripts (no subprocess overhead)


### PR DESCRIPTION
# Pull Request

## Description

This PR adds note with how-to steps to get `temperature` waybar module working with AMD hardware

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

# Screenshots

Script is working:
<img width="987" height="577" alt="image" src="https://github.com/user-attachments/assets/57b8eb93-deda-452b-8654-aa3a20da94b1" />

