### PR TITLE
fix: waybar typos

### DIFF
--- a/Configs/.local/share/waybar/menus/hyde-menu.xml
+++ b/Configs/.local/share/waybar/menus/hyde-menu.xml
@@ -110,7 +110,7 @@
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-style-select">
-                                <property name="label">  Select Sytle</property>
+                                <property name="label">  Select Style</property>
                             </object>
                         </child>
 

--- a/Configs/.local/share/waybar/menus/hyde-menu.xml
+++ b/Configs/.local/share/waybar/menus/hyde-menu.xml
@@ -181,7 +181,7 @@
 
                         <child>
                             <object class="GtkMenuItem" id="lockscreen-select">
-                                <property name="label">  Select ockscreen</property>
+                                <property name="label">  Select lockscreen</property>
                             </object>
                         </child>
 


### PR DESCRIPTION
# Pull Request
Fixes a missing character on the waybar selector for hyprlock layouts, and misspelling on waybars style selector

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
