### PR TITLE
fix: simplify window rules for `xdg-desktop-portal-gtk`

### DIFF
--- a/Configs/.local/share/hypr/windowrules.conf
+++ b/Configs/.local/share/hypr/windowrules.conf
@@ -16,7 +16,6 @@ windowrule = size <60% <90%,tag:common-popups
 windowrule = float,tag:portal-dialogs
 windowrule = center,tag:portal-dialogs
 
-
 # Only add the Core applications here
 windowrule = float,class:^(com.gabm.satty)$
 windowrule = float,class:^(org.kde.dolphin)$,title:^(Progress Dialog — Dolphin)$
@@ -39,7 +38,6 @@ windowrule = float,class:^(blueman-manager)$
 windowrule = float,class:^(nm-applet)$
 windowrule = float,class:^(nm-connection-editor)$
 windowrule = float,class:^(org.kde.polkit-kde-authentication-agent-1)$
-windowrule = float,class:^([Xx]dg-desktop-portal-gtk)$
 
 # common popups
 windowrule =  tag +common-popups,initialTitle:^(Open File)$
@@ -47,7 +45,7 @@ windowrule =  tag +common-popups,title:^(Choose Files)$
 windowrule =  tag +common-popups,title:^(Save As)$
 windowrule =  tag +common-popups,title:^(Confirm to replace files)$
 windowrule =  tag +common-popups,title:^(File Operation Progress)$
-windowrule =  tag +common-popups,class:^(xdg-desktop-portal-gtk)$
+windowrule =  tag +common-popups,class:^([Xx]dg-desktop-portal-gtk)$
 
 # portal-dialogs
 windowrule = tag +portal-dialogs,class:^(org.freedesktop.impl.portal.desktop.hyprland)$


### PR DESCRIPTION
# Pull Request

## Description

Small simplification of window rules for `xdg-desktop-portal-gtk`. These is no need to explicitly add `float` rule because window will be floating from `common-popups` tag rules

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.
