### PR TITLE
techdebt: window rules tided up

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -14,12 +14,13 @@ windowrule = idleinhibit fullscreen, class:^(.*[Ss]potify.*)$
 windowrule = idleinhibit fullscreen, class:^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*brave-browser.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
 
 # Picture-in-Picture
-windowrule = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrule = keepaspectratio, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrule = move 73% 72%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$ 
-windowrule = size 25%, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrule = float, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
-windowrule = pin, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrule = tag +picture-in-picture, title:^([Pp]icture[-\s]?[Ii]n[-\s]?[Pp]icture)(.*)$
+windowrule = float,           tag:picture-in-picture
+windowrule = keepaspectratio, tag:picture-in-picture
+windowrule = move 73% 72%,    tag:picture-in-picture
+windowrule = size 25%,        tag:picture-in-picture
+windowrule = float,           tag:picture-in-picture
+windowrule = pin,             tag:picture-in-picture
 
 windowrule = opacity 0.90 $& 0.90 $& 1,class:^(firefox)$
 windowrule = opacity 0.90 $& 0.90 $& 1,class:^(brave-browser)$
@@ -68,26 +69,6 @@ windowrule = opacity 0.80 0.80,class:^(io.gitlab.adhami3310.Impression)$ # Impre
 windowrule = opacity 0.80 0.80,class:^(io.missioncenter.MissionCenter)$ # MissionCenter-Gtk
 windowrule = opacity 0.80 0.80,class:^(io.github.flattool.Warehouse)$ # Warehouse-Gtk
 
-windowrule = float,class:^(org.kde.dolphin)$,title:^(Progress Dialog — Dolphin)$
-windowrule = float,class:^(org.kde.dolphin)$,title:^(Copying — Dolphin)$
-windowrule = float,title:^(About Mozilla Firefox)$
-windowrule = float,class:^(firefox)$,title:^(Picture-in-Picture)$
-windowrule = float,class:^(firefox)$,title:^(Library)$
-windowrule = float,class:^(kitty)$,title:^(top)$
-windowrule = float,class:^(kitty)$,title:^(btop)$
-windowrule = float,class:^(kitty)$,title:^(htop)$
-windowrule = float,class:^(vlc)$
-windowrule = float,class:^(kvantummanager)$
-windowrule = float,class:^(qt5ct)$
-windowrule = float,class:^(qt6ct)$
-windowrule = float,class:^(nwg-look)$
-windowrule = float,class:^(org.kde.ark)$
-windowrule = float,class:^(org.pulseaudio.pavucontrol)$
-windowrule = float,class:^(blueman-manager)$
-windowrule = float,class:^(nm-applet)$
-windowrule = float,class:^(nm-connection-editor)$
-windowrule = float,class:^(org.kde.polkit-kde-authentication-agent-1)$
-
 windowrule = float,class:^(Signal)$ # Signal-Gtk
 windowrule = float,class:^(com.github.rafostar.Clapper)$ # Clapper-Gtk
 windowrule = float,class:^(app.drey.Warp)$ # Warp-Gtk
@@ -99,22 +80,6 @@ windowrule = float,class:^(io.gitlab.theevilskeleton.Upscaler)$ # Upscaler-Gtk
 windowrule = float,class:^(com.github.unrud.VideoDownloader)$ # VideoDownloader-Gkk
 windowrule = float,class:^(io.gitlab.adhami3310.Impression)$ # Impression-Gtk
 windowrule = float,class:^(io.missioncenter.MissionCenter)$ # MissionCenter-Gtk
-
-# common modals
-windowrule = float,title:^(Open)$
-windowrule = float, title:^(Authentication Required)$
-windowrule = float, title:^(Add Folder to Workspace)$
-windowrule = float,initialtitle:^(Open File)$
-windowrule = float,title:^(Choose Files)$
-windowrule = float,title:^(Save As)$
-windowrule = float,title:^(Confirm to replace files)$
-windowrule = float,title:^(File Operation Progress)$
-windowrule = float,class:^([Xx]dg-desktop-portal-gtk)$
-windowrule = float, title:^(File Upload)(.*)$
-windowrule = float, title:^(Choose wallpaper)(.*)$
-windowrule = float, title:^(Library)(.*)$
-windowrule = float,class:^(.*dialog.*)$
-windowrule = float,title:^(.*dialog.*)$
 
 # workaround for jetbrains IDEs dropdowns/popups cause flickering
 windowrule = noinitialfocus,class:^(.*jetbrains.*)$,title:^(win[0-9]+)$

--- a/Configs/.local/share/hypr/windowrules.conf
+++ b/Configs/.local/share/hypr/windowrules.conf
@@ -21,8 +21,6 @@ windowrule = float,class:^(com.gabm.satty)$
 windowrule = float,class:^(org.kde.dolphin)$,title:^(Progress Dialog — Dolphin)$
 windowrule = float,class:^(org.kde.dolphin)$,title:^(Copying — Dolphin)$
 windowrule = float,title:^(About Mozilla Firefox)$
-windowrule = float,class:^(firefox)$,title:^(Picture-in-Picture)$
-windowrule = float,class:^(firefox)$,title:^(Library)$
 windowrule = float,class:^(.*)$,initialTitle:^(top)$
 windowrule = float,class:^(.*)$,initialTitle:^(btop)$
 windowrule = float,class:^(.*)$,initialTitle:^(htop)$
@@ -40,12 +38,20 @@ windowrule = float,class:^(nm-connection-editor)$
 windowrule = float,class:^(org.kde.polkit-kde-authentication-agent-1)$
 
 # common popups
-windowrule =  tag +common-popups,initialTitle:^(Open File)$
-windowrule =  tag +common-popups,title:^(Choose Files)$
-windowrule =  tag +common-popups,title:^(Save As)$
-windowrule =  tag +common-popups,title:^(Confirm to replace files)$
-windowrule =  tag +common-popups,title:^(File Operation Progress)$
-windowrule =  tag +common-popups,class:^([Xx]dg-desktop-portal-gtk)$
+windowrule = tag +common-popups,initialTitle:^(Open File)$
+windowrule = tag +common-popups,title:^(Choose Files)$
+windowrule = tag +common-popups,title:^(Save As)$
+windowrule = tag +common-popups,title:^(Confirm to replace files)$
+windowrule = tag +common-popups,title:^(File Operation Progress)$
+windowrule = tag +common-popups,class:^([Xx]dg-desktop-portal-gtk)$
+windowrule = tag +common-popups,title:^(Open)$
+windowrule = tag +common-popups,title:^(Authentication Required)$
+windowrule = tag +common-popups,title:^(Add Folder to Workspace)$
+windowrule = tag +common-popups,title:^(File Upload)(.*)$
+windowrule = tag +common-popups,title:^(Choose wallpaper)(.*)$
+windowrule = tag +common-popups,title:^(Library)(.*)$
+windowrule = tag +common-popups,class:^(.*dialog.*)$
+windowrule = tag +common-popups,title:^(.*dialog.*)$
 
 # portal-dialogs
 windowrule = tag +portal-dialogs,class:^(org.freedesktop.impl.portal.desktop.hyprland)$


### PR DESCRIPTION
# Pull Request

## Description

This PR try to simplify window rules provided by HyDE without sacrificing any functionality.

What was done here:

1. Duplicated rules removed
2. Specific rules which are overlapped by more broad once removed 
    i.e. 
        
        windowrule = float,class:^(firefox)$,title:^(Library)$ 

    is overlapped by

        windowrule = tag +common-popups,title:^(Library)(.*)$
4. All popups rules moved to `Configs/.local/share/hypr/windowrules.conf`
5. PIP rules made more readable with help of tags

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

