### PR TITLE
fix: system monitor hotkey now uses non-deprecated script

### DIFF
--- a/Configs/.config/hypr/keybindings.conf
+++ b/Configs/.config/hypr/keybindings.conf
@@ -86,7 +86,7 @@ bindd = $mainMod Alt, T, $d dropdown terminal , exec, hyde-shell pypr toggle con
 bindd = $mainMod, E, $d file explorer , exec, $EXPLORER
 bindd = $mainMod, C, $d text editor , exec, $EDITOR
 bindd = $mainMod, B, $d web browser , exec, $BROWSER
-bindd = Control Shift, Escape, $d system monitor , exec, hyde-shell sysmonlaunch
+bindd = Control Shift, Escape, $d system monitor , exec, hyde-shell system.monitor
 
 $d=[$l|Rofi menus]
 $rofi-launch=hyde-shell rofilaunch

--- a/Configs/.local/share/hyde/keybindings.conf
+++ b/Configs/.local/share/hyde/keybindings.conf
@@ -33,7 +33,7 @@ bind = $mainMod, T, exec, $TERMINAL # launch terminal emulator
 bind = $mainMod, E, exec, $EXPLORER # launch file manager
 bind = $mainMod, C, exec, $EDITOR # launch text editor
 bind = $mainMod, F, exec, $BROWSER # launch web browser
-bind = Ctrl+Shift, Escape, exec, $scrPath/sysmonlaunch.sh # launch system monitor (htop/btop or fallback to top)
+bind = Ctrl+Shift, Escape, exec, hyde-shell system.monitor # launch system monitor (htop/btop or fallback to top)
 
 # Rofi menus
 bind = alt, space, exec, pkill -x rofi || $scrPath/rofilaunch.sh d # launch application launcher


### PR DESCRIPTION
# Pull Request

## Description

Actually this is one-line fix.

The old script shows depreaction notice:
```
notify-send -a "Deprecation Notice" "sysmonitor.sh is deprecated. Please use hyde-shell system.monitor open instead." -i dialog-information
```

P.S. I have not used `open` arg to new script to preserve the existing behaviour - sysmon shoud be closed with same hotkey if it is already running.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated system monitor launch keybinding (Ctrl+Shift+Escape) to use an improved command execution method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->