### PR TITLE
Fix:  gamemode.sh windowrule syntax issue when changing window opacity

### DIFF
--- a/Configs/.local/lib/hyde/gamemode.sh
+++ b/Configs/.local/lib/hyde/gamemode.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-HYPRGAMEMODE=$(hyprctl getoption animations:enabled | sed -n '1p' | awk '{print $2}')
-if [ "$HYPRGAMEMODE" = 1 ]; then
-    hyde-shell workflows --set gaming
+LOCK_FILE="${XDG_RUNTIME_DIR}/hyde/gamemode.lck"
+
+if [ -f "$LOCK_FILE" ]; then
+    # Gamemode is ON → turn it OFF
+    hyprctl reload config-only -q
+    rm -f "$LOCK_FILE"
 else
-    hyde-shell workflows --set default
+    # Gamemode is OFF → turn it ON
+    mkdir -p "${XDG_RUNTIME_DIR}/hyde"
+    hyprctl keyword source "${XDG_CONFIG_HOME}/hypr/workflows/gaming.conf"
+    touch "$LOCK_FILE"
 fi


### PR DESCRIPTION
# Pull Request

## Description

Fixed a syntax issue in gamemode.sh that caused the script to not change the opacity of windows.

## Type of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated gamemode toggle mechanism to use persistent state management for more reliable switching between gaming and normal modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->