### PR TITLE
Fix lockscreen environment variable precedence

### DIFF
--- a/Configs/.local/lib/hyde/lockscreen.sh
+++ b/Configs/.local/lib/hyde/lockscreen.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 [[ $HYDE_SHELL_INIT -ne 1 ]] && eval "$(hyde-shell init)"
-lockscreen="${HYPRLAND_LOCKSCREEN:-$lockscreen}"
-lockscreen="${LOCKSCREEN:-hyprlock}"
+lockscreen="${HYPRLAND_LOCKSCREEN:-hyprlock}"
+lockscreen="${LOCKSCREEN:-$lockscreen}"
 lockscreen="${HYDE_LOCKSCREEN:-$lockscreen}"
 source "${LIB_DIR}/hyde/shutils/argparse.sh"
 argparse_init "$@"


### PR DESCRIPTION
# Pull Request

## Description

This change fixes how the lockscreen command is selected from environment variables.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the configuration precedence order for lockscreen selection, improving how default values are resolved when multiple configuration options are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->