### PR TITLE
feat: added default weather location for os.env

### DIFF
--- a/Configs/.local/lib/hyde/weather.py
+++ b/Configs/.local/lib/hyde/weather.py
@@ -195,18 +195,20 @@ def set_default_weather_location(weather_lang="en"):
     if not os.getenv("WEATHER_LOCATION"):
         try:
             URL = "https://ipinfo.io/json"
-            headers = {
-                "User-Agent": "Mozilla/5.0",
-                "Accept-Language": weather_lang
-            }
-            response = requests.get(URL, timeout=10, headers=headers)
+            response = requests.get(URL, timeout=10, headers={"User-Agent": "Mozilla/5.0"})
             response.raise_for_status()  # raise for HTTP errors
             data = response.json()
-            location = data.get("city")
-            if location:
-                os.environ["WEATHER_LOCATION"] = location.replace(" ", "_")
+            location = data.get("city", "").replace(" ", "_")
+            os.environ["WEATHER_LOCATION"] = location
+            # Persist so the next invocation skips the HTTP call entirely
+            staterc = os.path.join(os.environ.get("HOME", ""), ".local", "state", "hyde", "staterc")
+            try:
+                with open(staterc, "a", encoding="utf-8") as f:
+                    f.write(f'\nWEATHER_LOCATION="{location}"\n')
+            except OSError:
+                pass
         except Exception:
-            os.environ["WEATHER_LOCATION"] = "" 
+            os.environ.setdefault("WEATHER_LOCATION", "")
 
 ### Variables ###
 def_lang, def_temp, def_time, def_wind = get_default_locale() # default vals based on locale

--- a/Configs/.local/lib/hyde/weather.py
+++ b/Configs/.local/lib/hyde/weather.py
@@ -191,36 +191,61 @@ def get_default_locale():
         pass
     return lang, temp, time, wind
 
-def set_default_weather_location():
+def set_default_weather_location() -> None:
     """
     Set WEATHER_LOCATION using IP-based geolocation if not already defined.
 
-    If the WEATHER_LOCATION environment variable is unset or empty,
-    the function queries ipinfo.io to detect the user's city and stores
-    it in the process environment. The detected value is also appended
-    to HyDE's staterc file for persistence across sessions.
+    If the WEATHER_LOCATION environment variable is unset, this function
+    queries ipinfo.io to detect the user's city and stores it in the process
+    environment. A successfully detected value is persisted to HyDE's
+    staterc file to avoid repeated network calls.
+
+    If detection fails, a sentinel value is stored to prevent repeated
+    API calls on subsequent runs.
 
     Notes:
-        - Silently ignores network and file I/O errors.
+        - Network and file I/O errors are handled gracefully.
         - Mutates process environment state.
+        - Avoids unbounded staterc growth.
     """
-    if not os.getenv("WEATHER_LOCATION"):
-        try:
-            URL = "https://ipinfo.io/json"
-            response = requests.get(URL, timeout=10, headers={"User-Agent": "Mozilla/5.0"})
-            response.raise_for_status()  # raise for HTTP errors
-            data = response.json()
-            location = data.get("city", "").replace(" ", "_")
+    # Do nothing if already configured
+    current = os.getenv("WEATHER_LOCATION")
+    if current:
+        return
+    # Prevent infinite retry loop
+    if current == "__DETECTION_FAILED__":
+        return
+    url = "https://ipinfo.io/json"
+    staterc = os.path.join(
+        os.environ.get("HOME", ""),
+        ".local",
+        "state",
+        "hyde",
+        "staterc",
+    )
+    try:
+        response = requests.get(
+            url,
+            timeout=10,
+            headers={"User-Agent": "Mozilla/5.0"},
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        location = data.get("city")
+        if location:
+            location = location.replace(" ", "_")
             os.environ["WEATHER_LOCATION"] = location
-            # Persist so the next invocation skips the HTTP call entirely
-            staterc = os.path.join(os.environ.get("HOME", ""), ".local", "state", "hyde", "staterc")
             try:
                 with open(staterc, "a", encoding="utf-8") as f:
                     f.write(f'\nWEATHER_LOCATION="{location}"\n')
             except OSError:
+                # File persistence failure should not crash execution
                 pass
-        except Exception:
-            os.environ.setdefault("WEATHER_LOCATION", "")
+        else:
+            os.environ["WEATHER_LOCATION"] = "__DETECTION_FAILED__"
+    except requests.RequestException:
+        os.environ["WEATHER_LOCATION"] = "__DETECTION_FAILED__"
 
 ### Variables ###
 def_lang, def_temp, def_time, def_wind = get_default_locale() # default vals based on locale

--- a/Configs/.local/lib/hyde/weather.py
+++ b/Configs/.local/lib/hyde/weather.py
@@ -199,7 +199,7 @@ def set_default_weather_location(weather_lang="en"):
                 "User-Agent": "Mozilla/5.0",
                 "Accept-Language": weather_lang
             }
-            response = requests.get(URL, timeout=12, headers=headers)
+            response = requests.get(URL, timeout=10, headers=headers)
             response.raise_for_status()  # raise for HTTP errors
             data = response.json()
             location = data.get("city")
@@ -270,7 +270,7 @@ headers = {
     "User-Agent": "Mozilla/5.0",
     "Accept-Language": weather_lang
     }
-response = requests.get(URL, timeout=12, headers=headers)
+response = requests.get(URL, timeout=10, headers=headers)
 try:
     weather = response.json()
 except json.decoder.JSONDecodeError:

--- a/Configs/.local/lib/hyde/weather.py
+++ b/Configs/.local/lib/hyde/weather.py
@@ -191,6 +191,23 @@ def get_default_locale():
         pass
     return lang, temp, time, wind
 
+def set_default_weather_location(weather_lang="en"):
+    if not os.getenv("WEATHER_LOCATION"):
+        try:
+            URL = "https://ipinfo.io/json"
+            headers = {
+                "User-Agent": "Mozilla/5.0",
+                "Accept-Language": weather_lang
+            }
+            response = requests.get(URL, timeout=12, headers=headers)
+            response.raise_for_status()  # raise for HTTP errors
+            data = response.json()
+            location = data.get("city")
+            if location:
+                os.environ["WEATHER_LOCATION"] = location.replace(" ", "_")
+        except Exception:
+            os.environ["WEATHER_LOCATION"] = "" 
+
 ### Variables ###
 def_lang, def_temp, def_time, def_wind = get_default_locale() # default vals based on locale
 load_env_file(os.path.join(os.environ.get("HOME"), ".local", "state", "hyde", "staterc"))
@@ -228,6 +245,7 @@ try:
     )  # Number of days to show the forecast for (default: 3)
 except ValueError:
     FORECAST_DAYS = 3
+set_default_weather_location(weather_lang)
 get_location = os.getenv("WEATHER_LOCATION", "").replace(
     " ", "_"
 )  # Name of the location to get the weather from (default: '')
@@ -252,7 +270,7 @@ headers = {
     "User-Agent": "Mozilla/5.0",
     "Accept-Language": weather_lang
     }
-response = requests.get(URL, timeout=10, headers=headers)
+response = requests.get(URL, timeout=12, headers=headers)
 try:
     weather = response.json()
 except json.decoder.JSONDecodeError:

--- a/Configs/.local/lib/hyde/weather.py
+++ b/Configs/.local/lib/hyde/weather.py
@@ -191,7 +191,22 @@ def get_default_locale():
         pass
     return lang, temp, time, wind
 
-def set_default_weather_location(weather_lang="en"):
+def set_default_weather_location():
+    """
+    Set WEATHER_LOCATION using IP-based geolocation if not already defined.
+
+    If the WEATHER_LOCATION environment variable is unset or empty,
+    the function queries ipinfo.io to detect the user's city and stores
+    it in the process environment. The detected value is also appended
+    to HyDE's staterc file for persistence across sessions.
+
+    Args:
+        weather_lang (str): Language preference used in the HTTP request headers.
+
+    Notes:
+        - Silently ignores network and file I/O errors.
+        - Mutates process environment state.
+    """
     if not os.getenv("WEATHER_LOCATION"):
         try:
             URL = "https://ipinfo.io/json"
@@ -247,7 +262,7 @@ try:
     )  # Number of days to show the forecast for (default: 3)
 except ValueError:
     FORECAST_DAYS = 3
-set_default_weather_location(weather_lang)
+set_default_weather_location()
 get_location = os.getenv("WEATHER_LOCATION", "").replace(
     " ", "_"
 )  # Name of the location to get the weather from (default: '')

--- a/Configs/.local/lib/hyde/weather.py
+++ b/Configs/.local/lib/hyde/weather.py
@@ -200,9 +200,6 @@ def set_default_weather_location():
     it in the process environment. The detected value is also appended
     to HyDE's staterc file for persistence across sessions.
 
-    Args:
-        weather_lang (str): Language preference used in the HTTP request headers.
-
     Notes:
         - Silently ignores network and file I/O errors.
         - Mutates process environment state.


### PR DESCRIPTION
# Pull Request

## Description

Added a new function that sets the WEATHER_LOCATION process environment variables if not present.

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic weather location detection at startup when none is set; detected city is normalized and persisted so the choice is remembered across runs.

* **Bug Fixes**
  * Detection is attempted early to avoid repeated network calls; failures are handled gracefully so weather features remain functional even if detection or persistence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->