### PR TITLE
add missing dashes to ozone-platform flag in electron-flags.conf

### DIFF
--- a/Configs/.config/electron-flags.conf
+++ b/Configs/.config/electron-flags.conf
@@ -1,2 +1,2 @@
 --ozone-platform-hint=auto
-ozone-platform=wayland
+--ozone-platform=wayland


### PR DESCRIPTION
otherwise electron apps cant be started through terminal or application finder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration issue where a platform-specific display flag was not being properly recognized by the application, improving compatibility with certain display server environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->