### PR TITLE
fix: `NoOpLogger` caused exception if no `log_level` env is set

### DIFF
--- a/Configs/.local/lib/hyde/pyutils/logger.py
+++ b/Configs/.local/lib/hyde/pyutils/logger.py
@@ -12,7 +12,7 @@ def get_logger():
     if not log_level:
 
         class NoOpLogger:
-            def __getattr__(self):
+            def __getattr__(self, name):
                 def no_op():
                     pass
 

--- a/Configs/.local/lib/hyde/pyutils/logger.py
+++ b/Configs/.local/lib/hyde/pyutils/logger.py
@@ -13,7 +13,7 @@ def get_logger():
 
         class NoOpLogger:
             def __getattr__(self, name):
-                def no_op():
+                def no_op(*args, **kwargs):
                     pass
 
                 return no_op


### PR DESCRIPTION
# Pull Request

## Description

This is one-line fix for pyutils/logger.py if `log_level` env var is not set.

Example of a problem
```
❯ “$HOME/.local/lib/hyde/waybar.py” --update
Traceback (most recent call last):
File “/home/zee/.local/lib/hyde/waybar.py”, line 1494, in <module>
main()
~~~~^^
File “/home/zee/.local/lib/hyde/waybar.py”, line 1285, in main
logger.debug(“Starting [waybar.py](http://waybar.py/)”)
^^^^^^^^^^^^
TypeError: get_logger.<locals>.NoOpLogger.getattr() takes 1 positional argument but 2 were given
```

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior when no log level is set to avoid attribute errors and ensure safe no-op logging calls, reducing rare runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->