### PR TITLE
fix: Fix hyprquery package install hangs restore

### DIFF
--- a/Scripts/restore_cfg.sh
+++ b/Scripts/restore_cfg.sh
@@ -195,21 +195,19 @@ ensure_hyq() {
 
 	hyq_exec="$(command -v hyq 2>/dev/null || true)"
 	if [[ -n "${hyq_exec}" && -x "${hyq_exec}" ]]; then
-		echo "${hyq_exec}"
 		return 0
 	fi
 
 	print_log -y "[hook] " -b "hyprland :: " "'hyq' not found in PATH, trying package install..."
 
 	if [[ -x "${pacmanCmd}" ]]; then
-		"${pacmanCmd}" install hyprquery-git || "${pacmanCmd}" install hyprquery || true
+		"${pacmanCmd}" install --noconfirm hyprquery-git || "${pacmanCmd}" install --noconfirm hyprquery || true
 	elif command -v pacman >/dev/null 2>&1; then
-		sudo pacman -S --needed hyprquery-git || sudo pacman -S --needed hyprquery || true
+		sudo pacman -S --needed --noconfirm hyprquery-git || sudo pacman -S --needed --noconfirm hyprquery || true
 	fi
 
 	hyq_exec="$(command -v hyq 2>/dev/null || true)"
 	if [[ -n "${hyq_exec}" && -x "${hyq_exec}" ]]; then
-		echo "${hyq_exec}"
 		return 0
 	fi
 
@@ -223,7 +221,8 @@ hyprland_hook() {
 	local hyprland_default_config="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/hyprland.conf"
 	local hyq_exec
 
-	hyq_exec="$(ensure_hyq)" || return 1
+	ensure_hyq || return 1
+	hyq_exec="$(command -v hyq 2>/dev/null || true)"
 
 	if ! "${hyq_exec}" "${hyprland_default_config}" --query "\$HYDE_HYPRLAND"; then
 		mkdir -p "$(dirname "${hyprland_default_config}")" "${BkpDir}/.config/hypr"


### PR DESCRIPTION
# Pull Request

## Description

The Pull Request fixes a bug that causes the config restore to "hang" when the installation of the `hyprquery` packages is attempted. Previous approach calls the function `ensure_hyq` through command substitution, causing prints and interactive prompts caused by the package manager and `sudo` to not reach the user. The restore silently "fails" right after the last config deploy step, as the user has never been told that he is supposed to confirm the installation of the package.

The pull request:
- removes the need for confirmation from the package installation.
  - `hyprquery` seems required for HyDE to function properly moving forward, so there is no point in giving the user this choice in the first place
- calls the `ensure_hyq` function directly and gets the path towards the hyq executable inside `hyprland_hook`
  - This turns the prints and output visible for the user and may still be required in the case of an `sudo` interactive prompt (timeout)

I am not sure if there is a neater solution to this that can make use of command substitution again by ensuring the prints/targetted terminals in `ensure_hyq` work properly. But for the time being, this solution at least fixes the restore process.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c0de45d3-6fa0-434c-bfb5-e222a4873ce8" />

## Additional context

I have been unsure under which prefix to create the changelog Entry (Core?).
I apologize for any inconveniences this may causes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined executable detection and installation workflow.

* **Improvements**
  * Package installations now proceed without confirmation prompts.
  * Reduced script output verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->