### PR TITLE
fix: hyde-shell pypr subcommand passes args as single string to pypr CLI

### DIFF
--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -526,12 +526,12 @@ run_pypr() {
 		fi
 
 		if [[ -S "$socket_path" ]] && pgrep -u "$USER" pypr >/dev/null 2>&1; then
-			message="${*:-"help"}"
-			# Send the message to the socket and print the response
-			if ! printf "%s" "${message[@]}" | nc -N -U "$socket_path" 2>/dev/null; then #! openbsd netcat only
-				if ! printf "%s" "${message[@]}" | socat - UNIX-CONNECT:"$socket_path" 2>/dev/null; then
-					if ! printf "%s" "${message[@]}" | ncat -U "$socket_path" 2>/dev/null; then
-						if ! pypr "${message[@]}"; then
+			local -a msg=("$@")
+			((${#msg[@]} == 0)) && msg=("help")
+			if ! printf '%s\n' "${msg[*]}" | nc -N -U "$socket_path" 2>/dev/null; then #! openbsd netcat only
+				if ! printf '%s\n' "${msg[*]}" | socat - UNIX-CONNECT:"$socket_path" 2>/dev/null; then
+					if ! printf '%s\n' "${msg[*]}" | ncat -U "$socket_path" 2>/dev/null; then
+						if ! pypr "${msg[@]}"; then
 							print_log -sec "pypr" "Error communicating with socket: $socket_path"
 							exit 1
 						fi


### PR DESCRIPTION
When running `hyde-shell pypr toggle console`, the `run_pypr()` function used `${*:-help}` to capture arguments into a scalar variable. When passed to `pypr "${message[@]}"`, the scalar expands as a single string "toggle console" instead of two separate args. The pypr client then normalizes spaces to underscores, looking up "toggle_console" instead of the "toggle" command with "console" as its argument.

Additionally, socket direct writes via nc/socat/ncat lacked a trailing newline, which the pyprland daemon's readline() expects.

Fix by using a bash array (`local -a msg=("$@")`) to preserve proper word-splitting, and adding `\n` to socket writes.

# Pull Request

## Description

Please read these instructions and remove unnecessary text.

- Try to include a summary of the changes and which issue is fixed.
- Also include relevant motivation and context (if applicable).
- Make sure to make PR against dev and not the master
- List any dependencies that are required for this change. (e.g., packages or other PRs)
- Provide a link if there is an issue related to this pull request. e.g., Fixes # (issue)
- Please add Reviewers, Assignees, Labels, Projects, and Milestones to the PR. (if applicable)

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ ] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced socket message handling for more reliable and consistent command argument processing across all operations.
  * Improved default command behavior to automatically display helpful information when commands are executed without any arguments provided.
  * Optimized internal message formatting and delivery while maintaining complete compatibility with existing fallback communication mechanisms for continued system reliability and operational stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HyDE-Project/HyDE/pull/1741)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->