### PR TITLE
fix: Fix Hyprland 0.55 breaking changes in configuration files

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -12,9 +12,9 @@
 # hyprlang if WINDOWRULES_HYPRLAND_V_0_53
 
 # idle_inhibit rules
-windowrule = idle_inhibit fullscreen true, match:class ^(.*celluloid.*)$|^(.*mpv.*)$|^(.*vlc.*)$
-windowrule = idle_inhibit fullscreen true, match:class ^(.*[Ss]potify.*)$
-windowrule = idle_inhibit fullscreen true, match:class ^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*brave-browser.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
+windowrule = idle_inhibit fullscreen, match:class ^(.*celluloid.*)$|^(.*mpv.*)$|^(.*vlc.*)$
+windowrule = idle_inhibit fullscreen, match:class ^(.*[Ss]potify.*)$
+windowrule = idle_inhibit fullscreen, match:class ^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*brave-browser.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
 
 # Picture-in-Picture
 windowrule {

--- a/Configs/.local/share/hypr/defaults.conf
+++ b/Configs/.local/share/hypr/defaults.conf
@@ -62,7 +62,6 @@ gesture = 3, pinchout,float, float
 # See https://wiki.hypr.land/Configuring/Dwindle-Layout/
 
 dwindle {
-    pseudotile = yes
     preserve_split = yes
 }
 


### PR DESCRIPTION
# Pull Request

## Description

The Pull Request aims to fix breaking changes in the configuration files caused by the Hyprland v0.55.0 Update.

Specifically:

- Removed `pseudotile` from `.local/share/hypr/defaults.conf` as Hyprland removes it ("it wasn't doing anything")
https://github.com/hyprwm/Hyprland/releases/tag/v0.55.0

- `idle_inhibit` modes set in `.config/hypr/windowrules.conf` no longer seem to require a boolean to set. This has caused `fullscreen true` to be received as it's own mode that doesn't exist. The pull request removes the boolean.
  - Since this change is inside a user configuration file, this likely requires **manual intervention** by the user.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Hyprland v0.55.0 is the first update to require `togglesplit` through the `layoutmsg` dispatcher in `.config/hypr/keybindings.conf` by changing
```
# Toggle focused window split
$d=[$wm]
bindd = $mainMod, J, $d toggle split, togglesplit
```

into

```
# Toggle focused window split
$d=[$wm]
bindd = $mainMod, J, $d toggle split, layoutmsg, togglesplit
```

This change already happened in upstream, but I felt like adding this here in case someone stumbles over this pull request as part of manually attempting to fix their installation as this changes also requires **manual intervention** by the user for being inside an user configuration file.