### PR TITLE
fix(hypr): complete #1743 - idle_inhibit template file missed

### DIFF
--- a/Configs/.local/share/hyde/templates/hypr/windowrules.conf
+++ b/Configs/.local/share/hyde/templates/hypr/windowrules.conf
@@ -12,9 +12,9 @@
 # hyprlang if WINDOWRULES_HYPRLAND_V_0_53
 
 # idle_inhibit rules
-windowrule = idle_inhibit fullscreen true, match:class ^(.*celluloid.*)$|^(.*mpv.*)$|^(.*vlc.*)$
-windowrule = idle_inhibit fullscreen true, match:class ^(.*[Ss]potify.*)$
-windowrule = idle_inhibit fullscreen true, match:class ^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*brave-browser.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
+windowrule = idle_inhibit fullscreen, match:class ^(.*celluloid.*)$|^(.*mpv.*)$|^(.*vlc.*)$
+windowrule = idle_inhibit fullscreen, match:class ^(.*[Ss]potify.*)$
+windowrule = idle_inhibit fullscreen, match:class ^(.*LibreWolf.*)$|^(.*floorp.*)$|^(.*brave-browser.*)$|^(.*firefox.*)$|^(.*chromium.*)$|^(.*zen.*)$|^(.*vivaldi.*)$
 
 # Picture-in-Picture
 windowrule {


### PR DESCRIPTION
## Description

Completes the fix from #1743 — `Configs/.local/share/hyde/templates/hypr/windowrules.conf`
was missed in that PR and still contained the deprecated `idle_inhibit fullscreen true`
syntax that breaks on Hyprland v0.55.0.

Removed `true` from lines 15-17 of the template file to match the fixes already applied
to `Configs/.config/hypr/windowrules.conf` in #1743.

Fixes #1742 (or whichever issue tracks the v0.55 breaking changes)

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [x] I have tested my code locally and it works as expected.

## Additional context

`idle_inhibit fullscreen true` is invalid syntax in Hyprland v0.55.0.
The `true` argument was removed upstream. The template file is used during
fresh installs / resets, so leaving it broken would affect new users even
after #1743 was merged.

**File changed:** `Configs/.local/share/hyde/templates/hypr/windowrules.conf` — lines 15, 16, 17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated window idle inhibit rules configuration syntax for Hyprland 0.53+ compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HyDE-Project/HyDE/pull/1747)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->