### PR TITLE
made ghidra project manager to float

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -92,7 +92,7 @@ windowrule = float true,match:title ^(Friends List)$ # Steam Friends List
 windowrule = float true,match:title ^(Steam Settings)$ # Steam Settings
 windowrule = float true,match:initial_title ^(Image Editor)$,match:class ^(blender)$ # Blender Render
 windowrule = size (monitor_w*0.5) (monitor_h*0.5),match:initial_title ^(Image Editor)$,match:class ^(blender)$
-windowrule = float on, match:initial_title ^(Ghidra: NO ACTIVE PROJECT) #Ghidra Project manager
+windowrule = float true, match:initial_title ^(Ghidra: NO ACTIVE PROJECT) #Ghidra Project manager
 
 # workaround for jetbrains IDEs dropdowns/popups cause flickering
 windowrule = no_initial_focus true,match:class ^(.*jetbrains.*)$,match:title ^(win[0-9]+)$

--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -92,6 +92,7 @@ windowrule = float true,match:title ^(Friends List)$ # Steam Friends List
 windowrule = float true,match:title ^(Steam Settings)$ # Steam Settings
 windowrule = float true,match:initial_title ^(Image Editor)$,match:class ^(blender)$ # Blender Render
 windowrule = size (monitor_w*0.5) (monitor_h*0.5),match:initial_title ^(Image Editor)$,match:class ^(blender)$
+windowrule = float on, match:initial_title ^(Ghidra: NO ACTIVE PROJECT) #Ghidra Project manager
 
 # workaround for jetbrains IDEs dropdowns/popups cause flickering
 windowrule = no_initial_focus true,match:class ^(.*jetbrains.*)$,match:title ^(win[0-9]+)$


### PR DESCRIPTION
# Pull Request

## Description

made ghidra project manager to float , even though there is active project it seems initial_title won't change so added it 

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ x] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x ] I have added necessary comments/documentation to my code.
- [ x] I have added tests to cover my changes.
- [x ] I have tested my code locally and it works as expected.
- [ x] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated window management so Ghidra's project manager window opens as a floating window when it shows the "NO ACTIVE PROJECT" state, improving visibility and placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HyDE-Project/HyDE/pull/1762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->