### PR TITLE
Unset HL_INITIAL_WORKSPACE_TOKEN before dbus import to prevent lock

### DIFF
--- a/Configs/.local/share/hypr/startup.conf
+++ b/Configs/.local/share/hypr/startup.conf
@@ -4,7 +4,6 @@
 # ? Assuming exec-once are launched in order as declared here
 
 # Core
-exec-once = dbus-update-activation-environment --systemd --all #? Might fail so we hardcode the variables below
 exec-once = $start.DBUS_SHARE_PICKER    # dbus-update-activation-environment (one-time setup)
 exec-once = $start.SYSTEMD_SHARE_PICKER # systemctl --user import-environment (one-time setup)
 exec-once = $start.XDG_PORTAL_RESET     # resetxdgportal.sh (one-time setup)


### PR DESCRIPTION
Description

Fixes #1766

Since Hyprland 0.55, `exec-once` commands inherit `HL_INITIAL_WORKSPACE_TOKEN` (previously they did not in 0.54). HyDE runs `dbus-update-activation-environment --systemd --all` at startup, which imports this token into the systemd user environment. Subsequent app launches via `hyde-shell app` → `systemd-run` inherit the stale token, causing all windows to open on workspace 1.

This PR adds `env -u HL_INITIAL_WORKSPACE_TOKEN` to strip the token before the dbus import, while keeping the original `--all` behavior.

See [issue #1766 analysis](https://github.com/HyDE-Project/HyDE/issues/1766#issuecomment-4681168047) for detailed root cause.

### Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated system startup configuration to handle one-time environment setup for DBus more flexibly.
  * Replaced a hardcoded startup action with a configurable variable, improving maintainability and allowing safer environment handling during session start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->