### PR TITLE
fix(pm): restore module header position in zypper.py

### DIFF
--- a/Configs/.local/lib/hyde/pm/zypper.py
+++ b/Configs/.local/lib/hyde/pm/zypper.py
@@ -1,14 +1,3 @@
-def count_updates(ctx) -> int:
-    # zypper list-updates returns a table, skip header lines
-    output = ctx.capture(["zypper", "list-updates"])
-    count = 0
-    for line in output.splitlines():
-        if line.strip() and not line.startswith("#") and not line.startswith("Loading") and not line.startswith("Repository") and not line.startswith("S |"):
-            count += 1
-    return count
-
-def list_updates(ctx) -> None:
-    ctx.run(["zypper", "list-updates"])
 """Zypper manager implementation for pm.py."""
 
 from __future__ import annotations
@@ -80,3 +69,15 @@ def is_installed(ctx, package: str) -> bool:
 
 def file_query(ctx, target: str) -> None:
     ctx.run(["zypper", "wp", target])
+
+def count_updates(ctx) -> int:
+    # zypper list-updates returns a table, skip header lines
+    output = ctx.capture(["zypper", "list-updates"])
+    count = 0
+    for line in output.splitlines():
+        if line.strip() and not line.startswith("#") and not line.startswith("Loading") and not line.startswith("Repository") and not line.startswith("S |"):
+            count += 1
+    return count
+
+def list_updates(ctx) -> None:
+    ctx.run(["zypper", "list-updates"])


### PR DESCRIPTION
# Pull Request

## Description

`count_updates` and `list_updates` in `Configs/.local/lib/hyde/pm/zypper.py`
were placed above the module docstring and the
`from __future__ import annotations` line. Python requires `__future__`
imports at the top of the file, so the module raised `SyntaxError` on
import, breaking `hyde-shell pm` on openSUSE.

This PR moves both functions to the end of the file, matching the layout
of the other manager modules (`dnf.py`, `apt.py`, `paru.py`, `yay.py`).
No functional changes to the functions themselves.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have tested my code locally and it works as expected (`python -m py_compile` passes on all files).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->