### PR TITLE
Fix/globalcontrol wallpaper validation

### DIFF
--- a/Configs/.local/lib/hyde/globalcontrol.sh
+++ b/Configs/.local/lib/hyde/globalcontrol.sh
@@ -333,7 +333,7 @@ get_hyprConf() {
         "CODE_THEME") echo "Wallbash" ;;
         "SDDM_THEME") echo "" ;;
         *) grep "^[[:space:]]*\$default.$hyVar\s*=" \
-            "XDG_DATA_HOME/hyde/hyde.conf" \
+            "$XDG_DATA_HOME/hyde/hyde.conf" \
             "$XDG_DATA_HOME/hyde/hyprland.conf" \
             "/usr/local/share/hyde/hyde.conf" \
             "/usr/local/share/hyde/hyprland.conf" \

--- a/Configs/.local/lib/hyde/wallpaper.sh
+++ b/Configs/.local/lib/hyde/wallpaper.sh
@@ -166,7 +166,7 @@ main() {
             Wall_Cache "${wallList[setIndex]}"
             ;;
         s)
-            if [ -z "$wallpaper_path" ] && [ ! -f "$wallpaper_path" ]; then
+            if [ -z "$wallpaper_path" ] || [ ! -f "$wallpaper_path" ]; then
                 print_log -err "wallpaper" "Wallpaper not found: $wallpaper_path"
                 exit 1
             fi


### PR DESCRIPTION
# Pull Request

## Description

Two small one-line bug fixes:

1. **`globalcontrol.sh`** — The first fallback config path in
   `get_hyprConf()` was the literal string `"XDG_DATA_HOME/hyde/hyde.conf"`
   (missing `$`), which never exists. User-level default theme values in
   `$XDG_DATA_HOME/hyde/hyde.conf` were silently skipped since the grep
   error is suppressed by `2>/dev/null`.

2. **`wallpaper.sh`** — The `--set` path validation used
   `[ -z "$wallpaper_path" ] && [ ! -f "$wallpaper_path" ]`, so a
   non-empty path to a missing file skipped validation entirely and
   failed later in `get_hashmap` with a confusing
   "No image found in any source" error. Changed `&&` to `||` so both
   empty and nonexistent paths report "Wallpaper not found" as intended.

   Reproduce: `wallpaper.sh -s /tmp/does_not_exist.png -b swww`
   - Before: `ERROR: wallpaper source does not exist ... No image found in any source`
   - After: `ERROR :: wallpaper Wallpaper not found: /tmp/does_not_exist.png`

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have tested my code locally and it works as expected (`bash -n` passes; reproduction case above now prints the correct error).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed configuration file resolution to properly expand environment variables when searching for default settings.
  * Enhanced wallpaper setting validation to reject empty or non-existent file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->