### PR TITLE
fix(volume): use [[ ]] for VOLUME_PIPEWIRE_ENABLE comparison

### DIFF
--- a/Configs/.local/lib/hyde/volumecontrol.sh
+++ b/Configs/.local/lib/hyde/volumecontrol.sh
@@ -197,7 +197,7 @@ toggle_output() {
 iconsDir="${iconsDir:-$XDG_DATA_HOME/icons}"
 icodir="$iconsDir/Wallbash-Icon/media"
 step=${VOLUME_STEPS:-5}
-if pactl info | grep -q "PipeWire" || $VOLUME_PIPEWIRE_ENABLE == true; then
+if pactl info | grep -q "PipeWire" || [[ "${VOLUME_PIPEWIRE_ENABLE:-false}" == "true" ]]; then
     use_pipewire=true
 else
     use_pipewire=false


### PR DESCRIPTION
# Pull Request

## Description

The PipeWire detection fallback in `volumecontrol.sh` was written as:

    if pactl info | grep -q "PipeWire" || $VOLUME_PIPEWIRE_ENABLE == true; then

The right-hand side of `||` is not a comparison — it executes the value
of `$VOLUME_PIPEWIRE_ENABLE` as a command with `==` and `true` as its
arguments. On PipeWire systems the grep short-circuits so the bug is
hidden, but on PulseAudio-only systems:

- variable unset → every invocation prints `==: command not found`
- `VOLUME_PIPEWIRE_ENABLE=true` → only "works" by accident of running
  `/usr/bin/true`
- any other value (e.g. `enabled`) → `enabled: command not found`,
  condition always false

This PR wraps the check in `[[ ]]` so it is an actual string comparison:

    if pactl info | grep -q "PipeWire" || [[ "${VOLUME_PIPEWIRE_ENABLE:-false}" == "true" ]]; then

Reproduce: put a fake `pactl` reporting PulseAudio in `PATH`, then run
`volumecontrol.sh` with the variable unset — before the fix it prints
`line 200: ==: command not found`; after the fix it does not.
Also flagged by shellcheck as SC2284 (error severity).

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.comr/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have tested my code locally and it works as expected (verified witor unset/`true`/other values; `shellcheck -S error` passes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PipeWire audio backend detection with proper fallback logic, ensuring volume and device controls function reliably across different audio system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->