### PR TITLE
fix(gamemode): persist state via workflows so reloads don't break it

### DIFF
--- a/Configs/.local/lib/hyde/gamemode.sh
+++ b/Configs/.local/lib/hyde/gamemode.sh
@@ -1,13 +1,34 @@
 #!/usr/bin/env bash
-LOCK_FILE="${XDG_RUNTIME_DIR}/hyde/gamemode.lck"
+# Toggle the 'gaming' workflow, returning to the previously active
+# workflow when toggled off.
+#
+# State is persisted through the workflows mechanism (workflows.conf is
+# sourced by hyprland.conf) plus staterc, so it survives any
+# 'hyprctl reload' — unlike the previous implementation that injected
+# gaming.conf as a volatile runtime keyword, which every reload
+# (wallpaper change, theme switch, ...) silently wiped while its lock
+# file kept claiming gamemode was still on.
+[[ $HYDE_SHELL_INIT -ne 1 ]] && eval "$(hyde-shell init)"
 
-if [ -f "$LOCK_FILE" ]; then
-    # Gamemode is ON → turn it OFF
-    hyprctl reload config-only -q
-    rm -f "$LOCK_FILE"
+confDir="${XDG_CONFIG_HOME:-$HOME/.config}"
+staterc="${XDG_STATE_HOME:-$HOME/.local/state}/hyde/staterc"
+# shellcheck disable=SC1090
+[ -f "$staterc" ] && source "$staterc"
+
+if [ "${HYPR_WORKFLOW:-default}" = "gaming" ]; then
+    restore="${GAMEMODE_RETURN_WORKFLOW:-default}"
+    # Fall back to default if the saved workflow was removed/renamed,
+    # or if stale state points back at gaming itself
+    if [ "$restore" = "gaming" ] || [ ! -f "$confDir/hypr/workflows/${restore}.conf" ]; then
+        restore="default"
+    fi
+    "$LIB_DIR/hyde/workflows.sh" --set "$restore"
 else
-    # Gamemode is OFF → turn it ON
-    mkdir -p "${XDG_RUNTIME_DIR}/hyde"
-    hyprctl keyword source "${XDG_CONFIG_HOME}/hypr/workflows/gaming.conf"
-    touch "$LOCK_FILE"
+    set_conf "GAMEMODE_RETURN_WORKFLOW" "${HYPR_WORKFLOW:-default}"
+    "$LIB_DIR/hyde/workflows.sh" --set gaming
 fi
+# Apply immediately instead of relying on autoreload, which may be
+# temporarily disabled by other scripts (e.g. color.set.sh)
+hyprctl reload config-only -q
+# Clean up the lock file left behind by the old implementation
+rm -f "${XDG_RUNTIME_DIR}/hyde/gamemode.lck"


### PR DESCRIPTION
## Description

**User-facing bug:** while gamemode is ON, changing the wallpaper
($mainMod+Alt+Right/Left), switching themes, or anything else that causes a
`hyprctl reload` silently turns gamemode OFF — blur/shadows/animations/gaps
all come back. Worse, the toggle key then gets out of sync: the next press of
$mainMod+Alt+G appears to do nothing (it runs the "turn off" branch on an
already-off gamemode), so **you have to press the gamemode key twice to get
back into gamemode**.

**Root cause:** `gamemode.sh` injects `gaming.conf` as a volatile runtime
keyword (`hyprctl keyword source ...`) and tracks state in a private lock
file. Runtime keywords are dropped by every `hyprctl reload` — and
`color.set.sh` has an EXIT trap that reloads on every wallpaper change — but
the lock file keeps claiming gamemode is on, so the script's state and
Hyprland's actual state diverge.

**Fix:** reuse the existing workflows mechanism instead of a parallel one.
`workflows.conf` lives in the config tree sourced by `hyprland.conf`, so
reloads re-apply the gaming workflow rather than wiping it. The previously
active workflow is remembered in `staterc` (`GAMEMODE_RETURN_WORKFLOW`) and
restored when gamemode is toggled off — so if you were in e.g. the `editing`
workflow, you return to `editing`, not `default` (with a fallback to
`default` if the saved workflow no longer exists). As a bonus, the waybar
workflow indicator now stays in sync for free (`workflows.sh` signals
RTMIN+7), which the old implementation never updated.

**Reproduce on current dev:**
1. `hyprctl getoption animations:enabled` → 1
2. Press $mainMod+Alt+G (gamemode ON) → `animations:enabled` is 0, gaps gone
3. Press $mainMod+Alt+Right to change wallpaper, wait a few seconds
4. `animations:enabled` is back to 1 (gamemode silently dropped), while
   `$XDG_RUNTIME_DIR/hyde/gamemode.lck` still exists (stale state)
5. Press $mainMod+Alt+G → nothing visible happens; only the second press
   re-enables gamemode

No new dependencies; only `Configs/.local/lib/hyde/gamemode.sh` is changed.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [ ] I have tested my code locally and it works as expected.

## Additional context

The same volatility issue affects anything stored as a runtime keyword:
`color.set.sh`'s `trap "hyprctl reload config-only -q" EXIT` fires on every
global wallpaper change (`wallpaper/core.sh` calls it from `Wall_Cache`), so
storing long-lived state outside the sourced config tree can never survive
normal usage. This PR moves gamemode onto the same persistence path the
workflow selector already uses, rather than patching individual reload sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Game mode now persists correctly across reloads and application restarts
- Your previously selected workflow is automatically restored when gaming is re-enabled
- Improved workflow validation with automatic fallback to default configuration if needed
- Enhanced system reliability with improved toggle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->