### PR TITLE
fix: respect configured terminal for system updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to 'HyDE' will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to _Modified_ [CalVer](https://calver.org/). See [Versioning](https://github.com/HyDE-Project/HyDE/blob/master/RELEASE_POLICY.md#versioning-yymq) For more info
  -->
 
+## Unreleased
+
+### Fixed
+- System updates now use the terminal configured by the user, including Ghostty.
+
 ## v26.4.5 | End of April Release
 
 ### Changed

--- a/Configs/.local/lib/hyde/system.update.sh
+++ b/Configs/.local/lib/hyde/system.update.sh
@@ -26,7 +26,15 @@ if [ "$1" == "up" ]; then
         $fpk_exup
         read -n 1 -p 'Press any key to continue...'
         "
-        kitty --title systemupdate sh -c "$command"
+	read -r -a terminal_cmd <<< "${TERMINAL:-kitty}"
+	case "$(basename "${terminal_cmd[0]}")" in
+		ghostty)
+			"${terminal_cmd[@]}" --title=systemupdate -e sh -c "$command"
+			;;
+		*)
+			"${terminal_cmd[@]}" --title systemupdate sh -c "$command"
+			;;
+	esac
     else
         echo "No upgrade info found. Please run the script without parameters first."
     fi


### PR DESCRIPTION
## Summary

- make `hyde-shell systemupdate` use the configured terminal instead of invoking Kitty directly
- support Ghostty's `-e` command argument and title syntax
- document the user-visible fix in the changelog

## Root cause

The system update script invoked `kitty` directly, bypassing HyDE's configured `TERMINAL` value.

## Validation

- `bash -n Configs/.local/lib/hyde/system.update.sh`
- `git diff --check`
- `pre-commit run --files Configs/.local/lib/hyde/system.update.sh CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System updates now open in your configured terminal instead of a fixed default.
  * Improved support for Ghostty and other terminal apps when launching updates.

* **Documentation**
  * Updated release notes to reflect the terminal handling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->