### PR TITLE
fix(zsh,hyde-shell): prevent PATH duplication on repeated source

### DIFF
--- a/Configs/.config/zsh/conf.d/hyde/env.zsh
+++ b/Configs/.config/zsh/conf.d/hyde/env.zsh
@@ -10,8 +10,8 @@
 # Hyde's Shell Environment Initialization Script
 # If users used UWSM, uwsm will override any variables set anywhere in your shell configurations
 
-# Basic PATH prepending (user local bin)
-PATH="$HOME/.local/bin:$PATH"
+# Basic PATH prepending (user local bin) - only if not already present
+[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && PATH="$HOME/.local/bin:$PATH"
 
 # XDG Base Directory Specification variables with defaults
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -45,6 +45,9 @@ PYTHON_HISTORY="$XDG_STATE_HOME/python_history"
 
 # HyDEs Compositor Configuration
 export HYPRLAND_CONFIG="${XDG_DATA_HOME:-$HOME/.local/share}/hypr/hyprland.conf"
+
+# Deduplicate PATH while preserving order
+typeset -U PATH
 
 # Export all variables
 export PATH \

--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -671,7 +671,11 @@ fi
 BIN_DIR=$(dirname "$(which "${EXECUTABLE:-hyde-shell}")")
 LIB_DIR=$(realpath "${BIN_DIR}/../lib")
 SHARE_DIR=$(realpath "${BIN_DIR}/../share")
-PATH="${XDG_CONFIG_HOME:-$HOME/.config}/hyde/scripts:$BIN_DIR:$LIB_DIR/hyde:$PATH" #! I added this to the PATH to make sure that the hyde commands are available in the shell
+# Prepend hyde paths to PATH only if not already present
+for _p in "${XDG_CONFIG_HOME:-$HOME/.config}/hyde/scripts" "$BIN_DIR" "$LIB_DIR/hyde"; do
+    [[ ":$PATH:" != *":$_p:"* ]] && PATH="$_p:$PATH"
+done
+unset _p
 # Define hyde scripts search paths (colon-separated, user configurable)
 HYDE_SCRIPTS_PATH="${HYDE_SCRIPTS_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/hyde/scripts:${LIB_DIR}/hyde}:${XDG_DATA_HOME:-$HOME/.local/share}/waybar/scripts:${XDG_CONFIG_HOME:-$HOME/.config}/waybar/scripts"
 

--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -672,7 +672,7 @@ BIN_DIR=$(dirname "$(which "${EXECUTABLE:-hyde-shell}")")
 LIB_DIR=$(realpath "${BIN_DIR}/../lib")
 SHARE_DIR=$(realpath "${BIN_DIR}/../share")
 # Prepend hyde paths to PATH only if not already present
-for _p in "${XDG_CONFIG_HOME:-$HOME/.config}/hyde/scripts" "$BIN_DIR" "$LIB_DIR/hyde"; do
+for _p in "$LIB_DIR/hyde" "$BIN_DIR" "${XDG_CONFIG_HOME:-$HOME/.config}/hyde/scripts"; do
     [[ ":$PATH:" != *":$_p:"* ]] && PATH="$_p:$PATH"
 done
 unset _p


### PR DESCRIPTION
## Summary

The `env.zsh` config unconditionally prepends ~/.local/bin to $PATH on every source, causing massive duplication when the file is sourced multiple times (i.e. login + interactive shell). Similarly, hyde-shell prepends hyde directories each time it is sourced by wallbash scripts.

## Changes

**Configs/.config/zsh/conf.d/hyde/env.zsh**
- Only prepend $HOME/.local/bin if not already in $PATH
- Added typeset -U PATH to deduplicate entries (standard zsh practice)

**Configs/.local/bin/hyde-shell**
- Only prepend hyde script/bin/lib directories if not already in $PATH

Fixes repeated PATH entries when configurations are sourced more than once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell startup PATH handling for both Zsh environment initialization and the Hyde shell launcher.
  * Now adds local and Hyde-related directories only when they’re missing, preventing duplicate PATH entries.
  * Preserves the existing PATH order while avoiding unexpected PATH overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->