### PR TITLE
fix: 1824 keybind shortcut was throwing initilization issue and after…

### DIFF
--- a/Configs/.config/hypr/windowrules.conf
+++ b/Configs/.config/hypr/windowrules.conf
@@ -92,6 +92,7 @@ windowrule = float true,match:title ^(Friends List)$ # Steam Friends List
 windowrule = float true,match:title ^(Steam Settings)$ # Steam Settings
 windowrule = float true,match:initial_title ^(Image Editor)$,match:class ^(blender)$ # Blender Render
 windowrule = size (monitor_w*0.5) (monitor_h*0.5),match:initial_title ^(Image Editor)$,match:class ^(blender)$
+windowrule = float true, match:initial_title ^(Ghidra: NO ACTIVE PROJECT) #Ghidra Project manager
 
 # workaround for jetbrains IDEs dropdowns/popups cause flickering
 windowrule = no_initial_focus true,match:class ^(.*jetbrains.*)$,match:title ^(win[0-9]+)$

--- a/Configs/.local/lib/hyde/keybinds/hint-hyprland.py
+++ b/Configs/.local/lib/hyde/keybinds/hint-hyprland.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python3
+import re
 import subprocess
 import json
 import argparse
@@ -13,16 +14,12 @@ def get_hyprctl_binds():
             result = subprocess.run(
                 ["hyprctl", "binds", "-j"], capture_output=True, text=True, check=True
             )
-            while result.returncode != 0:
-                print("Waiting for hyprctl command to succeed...")
-                time.sleep(1)
-                result = subprocess.run(
-                    ["hyprctl", "binds", "-j"],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-            binds = json.loads(result.stdout)
+
+            clean_json = result.stdout
+            clean_json = re.sub(r'("keycode":\s*)([^"\s,\}]+)(\s*[,}])', r'\1"\2"\3', clean_json)
+            clean_json = re.sub(r'("allow_input_capture":\s*)([^"\n]+?)(,\s*\n)', r'\1"\2"\3', clean_json)
+
+            binds = json.loads(clean_json)
             return binds
         except subprocess.CalledProcessError as e:
             print(f"Error executing hyprctl: {e}")
@@ -72,7 +69,7 @@ def map_codeDisplay(keycode, key):
         81: "KP_9",
         90: "KP_0",
     }
-    return code_map.get(keycode, key)
+    return code_map.get(keycode, keycode)
 
 
 def map_modDisplay(modmask):
@@ -353,7 +350,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--format",
         choices=["json", "md", "dmenu", "rofi"],
-        default="json",
+        default="rofi",
         help="Output format",
     )
     args = parser.parse_args()


### PR DESCRIPTION
… few retrys was dumping entire json (each line as new entry)

# Pull Request

## Description
 - Fix for issue #1824 

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [X] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [X] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [X] I have tested my code locally and it works as expected.
- [X] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic floating behavior for Ghidra’s “No Active Project” window.
  * Improved keyboard shortcut hint handling, including support for cleaner keycode display.

* **Bug Fixes**
  * Improved reliability when reading Hyprland keybinding data.
  * Updated the default keybinding hint output format to Rofi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->