### PR TITLE
fix: enable hardware cursors for NVIDIA

### DIFF
--- a/Configs/.config/hypr/nvidia.conf
+++ b/Configs/.config/hypr/nvidia.conf
@@ -12,8 +12,8 @@ env = __GLX_VENDOR_LIBRARY_NAME,nvidia # Disable this if you have issues with sc
 # If you want to try hardware cursors,
 # you can enable them by setting `cursor:no_hardware_cursors = false` ,
 # but it will also require enabling `cursor:use_cpu_buffer`
-cursor:no_hardware_cursors = true # Set to true to avoid hitches
-# cursor:use_cpu_buffer = true
+cursor:no_hardware_cursors = false
+cursor:use_cpu_buffer = true
 
 # https://wiki.hypr.land/Nvidia/#va-api-hardware-video-acceleration
 # Hardware video acceleration on Nvidia and Wayland is


### PR DESCRIPTION
## Description

`no_hardware_cursors = true` (software cursors) breaks XWayland pointer confinement on Hyprland 0.56+ (aquamarine backend). Games relying on edge-pan (Dota 2, etc.) stop working.

The original setting predates `use_cpu_buffer` — the old "hitches" were from the `allow_dumb_copy` era. Per the Hyprland wiki, `use_cpu_buffer` is required on NVIDIA for HW cursors and is safe. PR #1581 already documented this shift for HYDE docs; this PR implements the actual config.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have added a changelog entry.
- [x] I have tested my code locally and it works as expected.