### PR TITLE
waybar: fix `on-scroll` behaviour of `hyprland/workspaces` module with Lua dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to 'HyDE' will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to _Modified_ [CalVer](https://calver.org/). See [Versioning](https://github.com/HyDE-Project/HyDE/blob/master/RELEASE_POLICY.md#versioning-yymq) For more info
  -->
 
+## Unreleased
+
+### Fixed
+- Waybar `hyprland/workspaces` module adapted to use lua dispatchers
+
 ## v26.7.28 | End of April Release
 
 **Alright** Looks like hyprland 0.56.1 warns user to use lua so here you go!
@@ -36,7 +41,7 @@ Life is tight as of the moment. Any help will do. 💓
     mangle with QT. But KDE apps uses ~/.config/kdeglobals which might break KDE apps for multi DE. (No fix for now)
 
 
-## Fixed
+### Fixed
 - Fix cantarell font
 - Some minor bugs
 

--- a/Configs/.local/share/waybar/modules/hyprland-workspaces.jsonc
+++ b/Configs/.local/share/waybar/modules/hyprland-workspaces.jsonc
@@ -2,10 +2,9 @@
     "hyprland/workspaces": {
         "all-outputs": true,
         "active-only": false,
-        "on-click": "activate",
         "disable-scroll": false,
-        "on-scroll-up": "hyprctl dispatch workspace -1",
-        "on-scroll-down": "hyprctl dispatch workspace +1",
+        "on-scroll-up": "hyprctl dispatch 'hl.dsp.focus({workspace=\"e-1\"})'",
+        "on-scroll-down": "hyprctl dispatch 'hl.dsp.focus({workspace=\"e+1\"})'",
         "persistent-workspaces": {}
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

Accordint to the commit https://github.com/Alexays/Waybar/commit/05945748dccce28bf96d26d8f64a9e69a8dd49ba `waybar-git` can correctly handle lua dispatch  commands.

This PR adapts workspace widget for `waybar-git` and waybar >= 0.16 in future

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Waybar Hyprland workspace scrolling to reliably move to the previous or next workspace.
  * Updated workspace dispatch behavior for compatibility with Lua-based dispatchers.

* **Documentation**
  * Added the changes to the unreleased changelog and corrected its section formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->