### PR TITLE
fix: provision lua runtime and repair fish activation

### DIFF
--- a/Configs/.local/lib/hyde/shell/activate
+++ b/Configs/.local/lib/hyde/shell/activate
@@ -7,6 +7,24 @@ HYDE_ACTIVATED=1
 HYDE_MODE=""
 HYPRLAND_CONFIG=""
 
+# A per-user runtime directory. Falling back to a shared directory would put
+# sockets from every session into one namespace, so the fallback is private and
+# only readable by its owner.
+hyde_runtime_dir() {
+    _uid=$(id -u 2>/dev/null) || _uid=''
+
+    if [ -n "$_uid" ] && [ -d "/run/user/$_uid" ] && [ -w "/run/user/$_uid" ]; then
+        printf '%s\n' "/run/user/$_uid"
+        unset _uid
+        return 0
+    fi
+
+    _dir="${TMPDIR:-/tmp}/hyde-${_uid:-$$}"
+    mkdir -p "$_dir" 2>/dev/null && chmod 700 "$_dir" 2>/dev/null
+    printf '%s\n' "$_dir"
+    unset _uid _dir
+}
+
 setup_xdg() {
     : "${XDG_CONFIG_HOME:=$HOME/.config}"
     : "${XDG_CACHE_HOME:=$HOME/.cache}"
@@ -14,7 +32,7 @@ setup_xdg() {
     : "${XDG_STATE_HOME:=$HOME/.local/state}"
 
     # fallback only
-    : "${XDG_RUNTIME_DIR:=/tmp}"
+    [ -n "${XDG_RUNTIME_DIR:-}" ] || XDG_RUNTIME_DIR=$(hyde_runtime_dir)
 
     export XDG_CONFIG_HOME XDG_CACHE_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_RUNTIME_DIR
 }
@@ -69,10 +87,34 @@ hyprland_has_lua() {
     return 1
 }
 
+# Mirrors the resolution order in pyutils/lua_env.py, so a runtime that is good
+# enough to provision the environment is not rejected here.
+hyde_find_bin() {
+    for _candidate in "$@"; do
+        [ -n "$_candidate" ] || continue
+        if command -v "$_candidate" >/dev/null 2>&1; then
+            printf '%s\n' "$_candidate"
+            unset _candidate
+            return 0
+        fi
+    done
+
+    unset _candidate
+    return 1
+}
+
+hyde_find_lua() {
+    hyde_find_bin "${LUA:-}" lua lua5.5 lua5.4 lua5.3
+}
+
+hyde_find_luarocks() {
+    hyde_find_bin "${LUAROCKS:-}" luarocks luarocks-5.5 luarocks-5.4 luarocks-5.3
+}
+
 check_lua_runtime() {
     _missing=''
-    hyde_has lua || _missing='lua'
-    hyde_has luarocks || _missing="${_missing:+$_missing }luarocks"
+    hyde_find_lua >/dev/null || _missing='lua'
+    hyde_find_luarocks >/dev/null || _missing="${_missing:+$_missing }luarocks"
 
     [ -z "$_missing" ] || {
         printf 'Lua runtime incomplete, missing: %s\n' "$_missing" >&2

--- a/Configs/.local/lib/hyde/shell/activate
+++ b/Configs/.local/lib/hyde/shell/activate
@@ -70,17 +70,24 @@ hyprland_has_lua() {
 }
 
 check_lua_runtime() {
-    hyde_has lua || return 1
-    hyde_has luarocks || return 1
+    _missing=''
+    hyde_has lua || _missing='lua'
+    hyde_has luarocks || _missing="${_missing:+$_missing }luarocks"
+
+    [ -z "$_missing" ] || {
+        printf 'Lua runtime incomplete, missing: %s\n' "$_missing" >&2
+        unset _missing
+        return 1
+    }
+
+    unset _missing
+    return 0
 }
 
 setup_lua_mode() {
     HYPRLAND_CONFIG=$(find_hyde_lua)
 
-    check_lua_runtime || {
-        printf 'Lua runtime incomplete\n' >&2
-        return 1
-    }
+    check_lua_runtime || return 1
 
     hyprland_has_lua || {
         printf 'Hyprland lacks Lua support\n' >&2

--- a/Configs/.local/lib/hyde/shell/activate.fish
+++ b/Configs/.local/lib/hyde/shell/activate.fish
@@ -9,12 +9,30 @@ set -x HYDE_ACTIVATED 1
 set -x HYDE_MODE ""
 set -x HYPRLAND_CONFIG ""
 
+# A per-user runtime directory. Falling back to a shared directory would put
+# sockets from every session into one namespace, so the fallback is private and
+# only readable by its owner.
+function hyde_runtime_dir
+    set -l uid (id -u 2>/dev/null)
+    if test -n "$uid" -a -d "/run/user/$uid" -a -w "/run/user/$uid"
+        echo "/run/user/$uid"
+        return 0
+    end
+    set -l tmp $TMPDIR
+    test -n "$tmp"; or set tmp /tmp
+    set -l dir "$tmp/hyde-$uid"
+    mkdir -p $dir 2>/dev/null; and chmod 700 $dir 2>/dev/null
+    echo $dir
+end
+
+# Assignment is unconditional so a value that already exists in a non-exported
+# scope still reaches child processes.
 function setup_xdg
-    set -q XDG_CONFIG_HOME; or set -gx XDG_CONFIG_HOME "$HOME/.config"
-    set -q XDG_CACHE_HOME; or set -gx XDG_CACHE_HOME "$HOME/.cache"
-    set -q XDG_DATA_HOME; or set -gx XDG_DATA_HOME "$HOME/.local/share"
-    set -q XDG_STATE_HOME; or set -gx XDG_STATE_HOME "$HOME/.local/state"
-    set -q XDG_RUNTIME_DIR; or set -gx XDG_RUNTIME_DIR "/tmp"
+    set -gx XDG_CONFIG_HOME (test -n "$XDG_CONFIG_HOME"; and echo $XDG_CONFIG_HOME; or echo "$HOME/.config")
+    set -gx XDG_CACHE_HOME (test -n "$XDG_CACHE_HOME"; and echo $XDG_CACHE_HOME; or echo "$HOME/.cache")
+    set -gx XDG_DATA_HOME (test -n "$XDG_DATA_HOME"; and echo $XDG_DATA_HOME; or echo "$HOME/.local/share")
+    set -gx XDG_STATE_HOME (test -n "$XDG_STATE_HOME"; and echo $XDG_STATE_HOME; or echo "$HOME/.local/state")
+    set -gx XDG_RUNTIME_DIR (test -n "$XDG_RUNTIME_DIR"; and echo $XDG_RUNTIME_DIR; or hyde_runtime_dir)
 end
 
 function hyde_die
@@ -61,10 +79,31 @@ function hyprland_has_lua
     return 1
 end
 
+# Mirrors the resolution order in pyutils/lua_env.py, so a runtime that is good
+# enough to provision the environment is not rejected here.
+function hyde_find_bin
+    for candidate in $argv
+        test -n "$candidate"; or continue
+        if hyde_has $candidate
+            echo $candidate
+            return 0
+        end
+    end
+    return 1
+end
+
+function hyde_find_lua
+    hyde_find_bin $LUA lua lua5.5 lua5.4 lua5.3
+end
+
+function hyde_find_luarocks
+    hyde_find_bin $LUAROCKS luarocks luarocks-5.5 luarocks-5.4 luarocks-5.3
+end
+
 function check_lua_runtime
     set -l missing
-    hyde_has lua; or set -a missing lua
-    hyde_has luarocks; or set -a missing luarocks
+    hyde_find_lua >/dev/null; or set -a missing lua
+    hyde_find_luarocks >/dev/null; or set -a missing luarocks
     if test (count $missing) -gt 0
         echo "Lua runtime incomplete, missing: $missing" >&2
         return 1
@@ -84,9 +123,9 @@ function setup_lua_mode
 end
 
 function setup_session
-    set -q XDG_CURRENT_DESKTOP; or set -gx XDG_CURRENT_DESKTOP "HyDE"
-    set -q XDG_SESSION_DESKTOP; or set -gx XDG_SESSION_DESKTOP "HyDE"
-    set -q XDG_SESSION_TYPE; or set -gx XDG_SESSION_TYPE "wayland"
+    set -gx XDG_CURRENT_DESKTOP (test -n "$XDG_CURRENT_DESKTOP"; and echo $XDG_CURRENT_DESKTOP; or echo "HyDE")
+    set -gx XDG_SESSION_DESKTOP (test -n "$XDG_SESSION_DESKTOP"; and echo $XDG_SESSION_DESKTOP; or echo "HyDE")
+    set -gx XDG_SESSION_TYPE (test -n "$XDG_SESSION_TYPE"; and echo $XDG_SESSION_TYPE; or echo "wayland")
 end
 
 function hyde_activate

--- a/Configs/.local/lib/hyde/shell/activate.fish
+++ b/Configs/.local/lib/hyde/shell/activate.fish
@@ -10,11 +10,11 @@ set -x HYDE_MODE ""
 set -x HYPRLAND_CONFIG ""
 
 function setup_xdg
-    set -q XDG_CONFIG_HOME; or set -x XDG_CONFIG_HOME "$HOME/.config"
-    set -q XDG_CACHE_HOME; or set -x XDG_CACHE_HOME "$HOME/.cache"
-    set -q XDG_DATA_HOME; or set -x XDG_DATA_HOME "$HOME/.local/share"
-    set -q XDG_STATE_HOME; or set -x XDG_STATE_HOME "$HOME/.local/state"
-    set -q XDG_RUNTIME_DIR; or set -x XDG_RUNTIME_DIR "/tmp"
+    set -q XDG_CONFIG_HOME; or set -gx XDG_CONFIG_HOME "$HOME/.config"
+    set -q XDG_CACHE_HOME; or set -gx XDG_CACHE_HOME "$HOME/.cache"
+    set -q XDG_DATA_HOME; or set -gx XDG_DATA_HOME "$HOME/.local/share"
+    set -q XDG_STATE_HOME; or set -gx XDG_STATE_HOME "$HOME/.local/state"
+    set -q XDG_RUNTIME_DIR; or set -gx XDG_RUNTIME_DIR "/tmp"
 end
 
 function hyde_die
@@ -62,17 +62,19 @@ function hyprland_has_lua
 end
 
 function check_lua_runtime
-    hyde_has lua; or return 1
-    hyde_has luarocks; or return 1
+    set -l missing
+    hyde_has lua; or set -a missing lua
+    hyde_has luarocks; or set -a missing luarocks
+    if test (count $missing) -gt 0
+        echo "Lua runtime incomplete, missing: $missing" >&2
+        return 1
+    end
 end
 
 function setup_lua_mode
     set -l cfg (find_hyde_lua)
     and set -gx HYPRLAND_CONFIG $cfg
-    check_lua_runtime; or begin
-        echo "Lua runtime incomplete" >&2
-        return 1
-    end
+    check_lua_runtime; or return 1
     hyprland_has_lua; or begin
         echo "Hyprland lacks Lua support" >&2
         return 1
@@ -82,9 +84,9 @@ function setup_lua_mode
 end
 
 function setup_session
-    set -q XDG_CURRENT_DESKTOP; or set -x XDG_CURRENT_DESKTOP "HyDE"
-    set -q XDG_SESSION_DESKTOP; or set -x XDG_SESSION_DESKTOP "HyDE"
-    set -q XDG_SESSION_TYPE; or set -x XDG_SESSION_TYPE "wayland"
+    set -q XDG_CURRENT_DESKTOP; or set -gx XDG_CURRENT_DESKTOP "HyDE"
+    set -q XDG_SESSION_DESKTOP; or set -gx XDG_SESSION_DESKTOP "HyDE"
+    set -q XDG_SESSION_TYPE; or set -gx XDG_SESSION_TYPE "wayland"
 end
 
 function hyde_activate

--- a/Scripts/pkg_core.lst
+++ b/Scripts/pkg_core.lst
@@ -41,6 +41,7 @@ wl-clip-persist                                        # Keep Wayland clipboard 
 hyprsunset                                             # blue light filter
 
 # --------------------------------------------------- // Dependencies
+lua                                                    # lua interpreter, required by the hyprland configuration
 hyprpolkitagent                                        # authentication agent
 xdg-desktop-portal-hyprland                            # xdg desktop portal for hyprland
 xdg-desktop-portal-gtk                                 # file picker and dbus  integration


### PR DESCRIPTION
# Pull Request

## Description

Closes #1852.

Rebased onto dev after `fd70502f` and `9db7cf1d` landed. Everything those two
already cover is gone from this branch, so what follows describes the diff as
it stands now, not the original scope.

### What upstream now covers

| Was in this PR | Status |
| --- | --- |
| Lua environment setup in `install_pre.sh` | dropped, provisioning moved into `install.sh` |
| `lua` and `luarocks` in `deps.toml` | dropped, already declared |
| `luarocks` in `pkg_core.lst` | dropped, already listed |

### What is left

**Activation no longer rejects a runtime the environment manager accepts.**
`check_lua_runtime` looks for `lua` and `luarocks` by those exact names:

```sh
check_lua_runtime() {
    hyde_has lua || return 1
    hyde_has luarocks || return 1
}
```

`pyutils/lua_env.py` resolves versioned binaries too. On a distribution that
ships `lua5.4` and `luarocks-5.4` without unversioned symlinks, the
environment provisions correctly and activation then refuses it, leaving
`HYPRLAND_CONFIG` unset with only `No valid HyDE configuration found` to go
on. Both shell variants now use the same order as `lua_env.py`: `$LUA`, then
`lua`, `lua5.5`, `lua5.4`, `lua5.3`, and `$LUAROCKS`, then `luarocks`,
`luarocks-5.5`, `luarocks-5.4`, `luarocks-5.3`. When something really is
missing, the message names it.

**A private runtime directory instead of a shared one.** Both variants fell
back to `XDG_RUNTIME_DIR=/tmp`, which puts sockets from every session into one
namespace. The fallback now prefers `/run/user/$(id -u)` when it exists and is
writable, and otherwise creates `${TMPDIR:-/tmp}/hyde-$(id -u)` with mode 700.

**`pkg_core.lst` gains `lua`.** Only `luarocks` was listed there; the
interpreter itself was missing.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have added necessary comments/documentation to my code.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Testing

Syntax: `sh -n activate`, `fish -n activate.fish` — both clean. `activate` is
clean under shellcheck at error severity.

Behaviour, in an isolated environment with a stubbed `PATH`:

| Setup | POSIX activate | activate.fish |
| --- | --- | --- |
| only `lua5.4` and `luarocks-5.4` present | accepted | accepted |
| unversioned absent, `$LUA` and `$LUAROCKS` set | accepted | accepted |
| neither present | `Lua runtime incomplete, missing: lua luarocks` | same |

Runtime directory: with `/run/user` present both shells report
`/run/user/1000`; with a stubbed `id` returning an unused uid both fall back to
the private directory, created `drwx------`.

Verified against Hyprland 0.56.1 on Arch Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved runtime directory selection to prefer a writable per-user runtime folder, with a safer fallback when unavailable.
  - Enhanced Lua/LuaRocks detection by checking for multiple executable candidates and environment overrides.
  - Added more precise Lua runtime error reporting that lists exactly what’s missing.

- **Bug Fixes**
  - Made environment (XDG and session) variables set consistently and exported by default across shell types.
  - Updated Lua-mode setup to fail cleanly with the improved missing-component details.

- **Chores**
  - Added Lua to the core dependency list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->