### PR TITLE
fix: double slurp grimblast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - OCR: the language list in the result notification is no longer split across arguments
 - Wallpaper: the duplicate check in the kon backend compares against the whole hash list again
 - Repo: dropped two stray gitlinks that made `git submodule` fail on a fresh clone
+- Grimblast updated to latest version, double slurp fixed
+
 
 ## v26.7.4 | 4th Week of July 2026 Release
 

--- a/Configs/.local/lib/hyde/grimblast
+++ b/Configs/.local/lib/hyde/grimblast
@@ -1,274 +1,407 @@
 #!/usr/bin/env bash
-grimblastInstanceCheck="${XDG_RUNTIME_DIR:-$XDG_CACHE_DIR:-$HOME/.cache}/grimblast.lock"
-if [ -e "$grimblastInstanceCheck" ]; then
-    exit 2
-else
-    touch "$grimblastInstanceCheck"
-fi
-trap 'rm -f "$grimblastInstanceCheck"' EXIT
-getTargetDirectory() {
-    test -f "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs" && . "${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
-    echo "${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
+## Grimblast: a helper for screenshots within hyprland
+## Requirements:
+##  - `grim`: screenshot utility for wayland
+##  - `slurp`: to select an area
+##  - `hyprctl`: to read properties of current window (provided by Hyprland)
+##  - `hyprpicker`: to freeze the screen when selecting area
+##  - `wl-copy`: clipboard utility (provided by wl-clipboard)
+##  - `jq`: json utility to parse hyprctl output
+##  - `notify-send`: to show notifications (provided by libnotify)
+## Those are needed to be installed, if unsure, run `grimblast check`
+##
+## See `man 1 grimblast` or `grimblast usage` for further details.
+
+## Author: Misterio (https://github.com/misterio77)
+
+## This tool is based on grimshot, with swaymsg commands replaced by their
+## hyprctl equivalents.
+## https://github.com/OctopusET/sway-contrib/blob/master/grimshot/grimshot
+
+NAME="$(basename "$0")"
+
+# Check whether another instance is running
+GRIMBLASTLOCK="${XDG_RUNTIME_DIR:-${XDG_CACHE_DIR:-$HOME/.cache}}/$NAME.lock"
+
+killhyprpicker() {
+  pidof -q hyprpicker && pkill hyprpicker
 }
-tmp_editor_directory() {
-    echo "/tmp"
+
+cleanup() {
+  rm -f "$GRIMBLASTLOCK"
+  killhyprpicker
 }
-env_editor_confirm() {
-    if [ -n "$GRIMBLAST_EDITOR" ]; then
-        echo "GRIMBLAST_EDITOR is set. Continuing..."
-    else
-        echo "GRIMBLAST_EDITOR is not set. Defaulting to gimp"
-        GRIMBLAST_EDITOR=gimp
-    fi
+
+# Entry point
+[[ -e $GRIMBLASTLOCK ]] && exit 2
+trap cleanup EXIT
+touch "$GRIMBLASTLOCK"
+
+[[ $HYPRLAND_INSTANCE_SIGNATURE ]] || {
+  echo "Error: HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)" >&2
+  exit 1
 }
-NOTIFY=no
-OPENFILE_NOTIFICATION=no
-CURSOR=
-FREEZE=
-WAIT=no
-SCALE=
-pos=()
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -n | --notify)
-            NOTIFY=yes
-            shift
-            ;;
-        -o | --openfile)
-            OPENFILE_NOTIFICATION=yes
-            shift
-            ;;
-        -c | --cursor)
-            CURSOR=yes
-            shift
-            ;;
-        -f | --freeze)
-            FREEZE=yes
-            shift
-            ;;
-        -w | --wait)
-            if
-                [[ -n ${2-} && $2 =~ ^[0-9]+(\.[0-9]+)?$ ]]
-            then
-                WAIT=$2
-                shift 2
-            else
-                echo "Invalid or missing value for --wait" >&2
-                exit 3
-            fi
-            ;;
-        -s | --scale)
-            if
-                [[ -n ${2-} && $2 =~ ^[1-9][0-9]*(\.[0-9]+)?$ ]]
-            then
-                SCALE=$2
-                shift 2
-            else
-                echo "Invalid or missing argument for --scale" >&2
-                exit 1
-            fi
-            ;;
-        --)
-            shift
-            pos+=("$@")
-            break
-            ;;
-        -)
-            pos+=("$1")
-            shift
-            break
-            ;;
-        -*)
-            echo "Unknown option: $1" >&2
-            exit 1
-            ;;
-        *)
-            pos+=("$1")
-            shift
-            ;;
-    esac
-done
-set -- "${pos[@]:-}"
-ACTION=${1:-usage}
-SUBJECT=${2:-screen}
-FILE=${3:-$(getTargetDirectory)/$(date -Ins).png}
-FILE_EDITOR=${3:-$(tmp_editor_directory)/$(date -Ins).png}
-if [ "$ACTION" != "save" ] && [ "$ACTION" != "copy" ] && [ "$ACTION" != "edit" ] && [ "$ACTION" != "copysave" ] && [ "$ACTION" != "check" ]; then
-    echo "Usage:"
-    echo "  grimblast [--notify] [--openfile] [--cursor] [--freeze] [--wait N] [--scale <scale>] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]"
-    echo "  grimblast check"
-    echo "  grimblast usage"
-    echo ""
-    echo "Commands:"
-    echo "  copy: Copy the screenshot data into the clipboard."
-    echo "  save: Save the screenshot to a regular file or '-' to pipe to STDOUT."
-    echo "  copysave: Combine the previous 2 options."
-    echo "  edit: Open screenshot in the image editor of your choice (default is gimp). See man page for info."
-    echo "  check: Verify if required tools are installed and exit."
-    echo "  usage: Show this message and exit."
-    echo ""
-    echo "Targets:"
-    echo "  active: Currently active window."
-    echo "  screen: All visible outputs."
-    echo "  output: Currently active output."
-    echo "  area: Manually select a region or window."
-    exit
-fi
+
+# Globals
+# General settings. These can be set by the user. See man page for more details
+[[ $DEFAULT_TARGET_DIR ]] || {
+  USER_DIRS="${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dirs"
+  [[ -f $USER_DIRS ]] && source "$USER_DIRS"
+  DEFAULT_TARGET_DIR="${XDG_SCREENSHOTS_DIR:-${XDG_PICTURES_DIR:-$HOME}}"
+}
+: "${DEFAULT_TMP_EDITOR_DIR:=/tmp}" "${GRIMBLAST_EDITOR:=gimp}" "${DATE_FORMAT:=%Y%m%d_%H%M%S}"
+
+# Screenshot variables. In addition to these, there's:
+#   SCALE
+EXPIRE_TIME=3000
+FILETYPE=png
+
+# These have an effect depending on whether they're set
+#   CURSOR
+#   FREEZE
+NOTIFY=false
+SHOW_FILE_NOTIFY=false
+WAIT=0
+
+# Notification functions
 notify() {
-    notify-send -t 3000 -a grimblast "$@"
+  notify-send -t "$EXPIRE_TIME" -a "$NAME" "$@"
 }
-notifyOk() {
-    [ "$NOTIFY" = "no" ] && return
+
+notify::ok() {
+  if $NOTIFY; then
     notify "$@"
+  fi
 }
-notifyOpen() {
-    if [ "$OPENFILE_NOTIFICATION" = "no" ]; then
-        notifyOk "$@"
-    else
-        outt=$(notifyOk -A "default=open_folder" "$@")
-        if [ "$outt" == "default" ]; then
-            if dbus-send --session --print-reply --dest=org.freedesktop.FileManager1 --type=method_call /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems array:string:"file://$4" string:""; then
-                :
-            else
-                notify-send -t 3000 -a grimblast "Error displaying folder with dbus-send"
-                echo "Displayed: Error displaying folder with dbus-send"
-            fi
-        fi
-    fi
+
+notify::error() {
+  if $NOTIFY; then
+    TITLE=${2:-"Screenshot"}
+    MESSAGE=${1:-"Error taking screenshot with grim"}
+    notify -u critical "$TITLE" "$MESSAGE"
+  fi
+  echo "$1" >&2
 }
-notifyError() {
-    if [ $NOTIFY = "yes" ]; then
-        TITLE=${2:-"Screenshot"}
-        MESSAGE=${1:-"Error taking screenshot with grim"}
-        notify -u critical "$TITLE" "$MESSAGE"
-    else
-        echo "$1"
-    fi
-}
-killHyprpicker() {
-    if pidof hyprpicker > /dev/null; then
-        pkill hyprpicker
-    fi
-}
+
+# If invoked with -h, print usage before dying
 die() {
-    killHyprpicker
-    MSG=${1:-Bye}
-    notifyError "Error: $MSG"
-    exit 2
+  killhyprpicker
+  local msg OPTIND option
+  while getopts 'h' option; do
+    case "$option" in
+    h) usage >&2 ;;
+    ?) echo "die: Usage: die [-h] MESSAGE" >&2 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+  msg=${1:-Bye}
+  notify::error "Error: $msg"
+  exit 2
 }
+
+notify::showparentdir() {
+  if $SHOW_FILE_NOTIFY; then
+    if [[ $(notify::ok -A 'Show file="Show file"' "$@") == "Show file" ]]; then
+      gdbus call --session --dest org.freedesktop.FileManager1 --object-path /org/freedesktop/FileManager1 --method org.freedesktop.FileManager1.ShowItems "['file://$4']" "" || die "Could not display parent directory with gdbus"
+    fi
+  else
+    notify::ok "$@"
+  fi
+}
+
+# Miscellaneous functions
+grimblast::wait() {
+  [[ $WAIT == 0 ]] || sleep "$WAIT"
+}
+
+get-mime-type() {
+  case $FILETYPE in
+  png | jpeg) echo "image/$FILETYPE" ;;
+  ppm) echo "image/x-portable-pixmap" ;;
+  esac
+}
+
+freezescreen() {
+  hyprpicker -rz &
+  sleep 0.2
+}
+
+# Checks whether an individual tool is available
+# If invoked with -q (quiet), no output is printed, useful for use in tests
+# Exits with 0 if the tool is available, non-zero otherwise
+grimblast::check() {
+  local cmd result OPTIND option status quiet=false
+  while getopts 'q' option; do
+    case "$option" in
+    q) quiet=true ;;
+    ?) echo 'check: Usage: check [-q] COMMAND' >&2 ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+  cmd=$1
+  command -v "$cmd" >/dev/null 2>&1
+  status=$?
+  if ((status == 0)); then
+    result="OK"
+  else
+    result="NOT FOUND"
+  fi
+  $quiet || echo "   $cmd: $result"
+  return $status
+}
+
+# The actual grim command used is printed to stderr
+screenshot() {
+  local file="$1" output="$2"
+  xargs --verbose grim <<<"${CURSOR:+-c} ${SCALE:+-s \"$SCALE\"} -t \"$FILETYPE\" ${output:+-o \"$output\"} ${GEOM:+-g \"$GEOM\"} ${WINDOW:+-T \"$WINDOW\"} \"$file\""
+}
+
+# Special actions: usage and check. These are special because they allow to exit early
+usage() {
+  cat <<EOF
+Usage:
+  $NAME [-n|--notify] [-o|--openparentdir] [-e|--expire-time <ms>] [-c|--cursor] [-f|--freeze] [-w N|--wait N] [-s N|--scale N] [-t TYPE|--filetype TYPE] (copy|save|copysave|edit) [active|screen|output|area] [FILE|-]
+  $NAME check
+  $NAME usage
+
+Commands:
+  copy: Copy the screenshot data into the clipboard.
+  save: Save the screenshot to a regular file or '-' to pipe to STDOUT.
+  copysave: Combine the previous 2 options.
+  edit: Open screenshot in the image editor of your choice (default is gimp). See man page for info.
+  check: Verify if required tools are installed and exit.
+  usage: Show this message and exit.
+
+Targets:
+  active: Currently active window.
+  screen: All visible outputs.
+  output: Currently active output.
+  area: Manually select a region or window.
+EOF
+}
+
 check() {
-    COMMAND=$1
-    if command -v "$COMMAND" > /dev/null 2>&1; then
-        RESULT="OK"
-    else
-        RESULT="NOT FOUND"
-    fi
-    echo "   $COMMAND: $RESULT"
+  local status
+  echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
+  for t in grim slurp hyprctl hyprpicker wl-copy jq notify-send; do
+    grimblast::check "$t" || status=$?
+  done
+  exit $status
 }
-takeScreenshot() {
-    FILE=$1
-    GEOM=$2
-    OUTPUT=$3
-    if [ -n "$OUTPUT" ]; then
-        grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -o "$OUTPUT" "$FILE" || die "Unable to invoke grim"
-    elif [ -z "$GEOM" ]; then
-        grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} "$FILE" || die "Unable to invoke grim"
-    else
-        if ! grim ${CURSOR:+-c} ${SCALE:+-s "$SCALE"} -g "$GEOM" "$FILE"; then
-            die "Unable to invoke grim"
-        fi
-    fi
+
+# Target functions. These calculate global variables depending on the target.
+# Specifically: GEOM, WHAT and OUTPUT. Not all would be set by all targets.
+# These would later be used by the action functions.
+active() {
+  local focused app_id
+  grimblast::wait
+  focused="$(hyprctl activewindow -j)" app_id=$(jq -r '.class' <<<"$focused")
+  WINDOW=$(jq -r '.stableId' <<<"$focused")
+  WHAT="$app_id window"
 }
-wait() {
-    if [ "$WAIT" != "no" ]; then
-        sleep "$WAIT"
-    fi
+
+screen() {
+  grimblast::wait
+  GEOM=""
+  WHAT="Screen"
 }
-if [ -z "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
-    echo "Error: HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)"
+
+output() {
+  grimblast::wait
+  GEOM=""
+  OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
+  WHAT="$OUTPUT"
+}
+
+area() {
+  local fullscreen_workspaces workspaces windows choice rects
+  [[ $CURSOR ]] && die "'-c|--cursor' cannot be used with TARGET 'area'"
+
+  if [[ $FREEZE ]] && grimblast::check -q hyprpicker; then
+    freezescreen
+  fi
+
+  # disable animation for layer namespace "selection" (slurp)
+  # this removes the black border seen around screenshots
+  hyprctl keyword layerrule "match:namespace ^selection$, no_anim on" >/dev/null
+
+  if [[ -n "${SLURP_RECTS+x}" ]]; then
+    # user may supply custom rectangles via SLURP_RECTS
+    rects="$SLURP_RECTS"
+  else
+    # by default, resolve all windows on all workspaces for input rectangles
+    fullscreen_workspaces="$(hyprctl workspaces -j | jq -r 'map(select(.hasfullscreen) | .id)')"
+    workspaces="$(hyprctl monitors -j | jq -r '[(foreach .[] as $monitor (0; if $monitor.specialWorkspace.name == "" then $monitor.activeWorkspace else $monitor.specialWorkspace end)).id]')"
+    windows="$(hyprctl clients -j | jq -r --argjson workspaces "$workspaces" --argjson fullscreenWorkspaces "$fullscreen_workspaces" 'map((select(([.workspace.id] | inside($workspaces)) and ([.workspace.id] | inside($fullscreenWorkspaces) | not) or .fullscreen > 0)))')"
+    rects=$(jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1]) \(.stableId)"' <<<"$windows")
+  fi
+
+  # convert SLURP_ARGS to a bash array
+  IFS=' ' read -ra SLURP_ARGS <<<"$SLURP_ARGS"
+  # use `|` as separator for stableId label
+  choice="$(echo -n "$rects" | slurp -o "${SLURP_ARGS[@]}" -f "%x,%y %wx%h|%l")"
+
+  WINDOW="$(jq -r --arg c "$choice" '.[] | select("\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])|\(.stableId)" == $c) | .stableId' <<<"$windows")"
+  [[ -z "$WINDOW" ]] && GEOM="${choice%|*}"
+
+  grimblast::wait
+
+  # Check if user exited slurp without selecting the area
+  [[ $GEOM || $WINDOW ]] || {
+    killhyprpicker
     exit 1
-fi
-if [ "$ACTION" = "check" ]; then
-    echo "Checking if required tools are installed. If something is missing, install it to your system and make it available in PATH..."
-    check grim
-    check slurp
-    check hyprctl
-    check hyprpicker
-    check wl-copy
-    check jq
-    check notify-send
-    exit
-elif [ "$SUBJECT" = "active" ]; then
-    wait
-    FOCUSED=$(hyprctl activewindow -j)
-    GEOM=$(echo "$FOCUSED" | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
-    APP_ID=$(echo "$FOCUSED" | jq -r '.class')
-    WHAT="$APP_ID window"
-elif [ "$SUBJECT" = "screen" ]; then
-    wait
-    GEOM=""
-    WHAT="Screen"
-elif [ "$SUBJECT" = "output" ]; then
-    wait
-    GEOM=""
-    OUTPUT=$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')
-    WHAT="$OUTPUT"
-elif [ "$SUBJECT" = "area" ]; then
-    if [ "$CURSOR" = "yes" ]; then
-        die "Error: '--cursor' cannot be used with subject 'area'"
-    fi
-    if [ "$FREEZE" = "yes" ] && [ "$(command -v "hyprpicker")" ] > /dev/null 2>&1; then
-        hyprpicker -r -z &
-        sleep 0.2
-    fi
-    hyprctl keyword layerrule "noanim,selection" > /dev/null
-    FULLSCREEN_WORKSPACES="$(hyprctl workspaces -j | jq -r 'map(select(.hasfullscreen) | .id)')"
-    WORKSPACES="$(hyprctl monitors -j | jq -r '[(foreach .[] as $monitor (0; if $monitor.specialWorkspace.name == "" then $monitor.activeWorkspace else $monitor.specialWorkspace end)).id]')"
-    WINDOWS="$(hyprctl clients -j | jq -r --argjson workspaces "$WORKSPACES" --argjson fullscreenWorkspaces "$FULLSCREEN_WORKSPACES" 'map((select(([.workspace.id] | inside($workspaces)) and ([.workspace.id] | inside($fullscreenWorkspaces) | not) or .fullscreen > 0)))')"
-    IFS=' ' read -r -a _slurp_args <<< "$SLURP_ARGS"
-    GEOM=$(echo "$WINDOWS" | jq -r '.[] | "\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"' | slurp "${_slurp_args[@]}")
-    if [ -z "$GEOM" ]; then
-        killHyprpicker
+  }
+  WHAT="Area"
+}
+
+# Action functions.
+# These take the global variables set by target functions and take the screenshot.
+copy() {
+  [[ $FILETYPE == "png" ]] || die "Clipboard operations only support PNG format. Use --filetype png or omit the option."
+  screenshot - "$OUTPUT" | wl-copy --type "$(get-mime-type)" || die "Clipboard error"
+  notify::ok "$WHAT copied to buffer"
+}
+
+save() {
+  local file title message
+  file="${1:-$DEFAULT_TARGET_DIR/$(date +"$DATE_FORMAT").$FILETYPE}"
+  screenshot "$file" "$OUTPUT" || die "Could not take screenshot with grim"
+  title="Screenshot of $WHAT" message="$(basename "$file")"
+  killhyprpicker
+  notify::showparentdir "$title" "$message" -i "$file"
+  echo "$file"
+}
+
+edit() {
+  local editor="${GRIMBLAST_EDITOR%% *}"
+  grimblast::check -q "$editor" || die "$editor is not installed"
+  local file title message
+  file="${1:-$DEFAULT_TMP_EDITOR_DIR/$(date +"$DATE_FORMAT").$FILETYPE}"
+  screenshot "$file" "$OUTPUT" || die "Could not take screenshot"
+  title="Screenshot of $WHAT" message="Open screenshot in $editor"
+  notify::ok "$title" "$message" -i "$file"
+  $GRIMBLAST_EDITOR "$file"
+  echo "$file"
+}
+
+copysave() {
+  [[ $FILETYPE == "png" ]] || die "Clipboard operations only support PNG format. Use --filetype png or omit the option."
+  local file title message
+  file="${1:-$DEFAULT_TARGET_DIR/$(date +"$DATE_FORMAT").$FILETYPE}"
+  if [[ $file = "-" ]]; then
+    screenshot - "$OUTPUT" | tee >(wl-copy --type "$(get-mime-type)") || die "Clipboard error"
+    notify::ok "$WHAT copied to buffer and piped to stdout"
+  else
+    screenshot - "$OUTPUT" | tee "$file" | wl-copy --type "$(get-mime-type)" || die "Clipboard error"
+    title="Screenshot of $WHAT"
+    message="$WHAT copied to buffer and saved to $file"
+    notify::showparentdir "$title" "$message" -i "$file"
+    echo "$file"
+  fi
+}
+
+parse-action() {
+  local action="$1" file="$2"
+  case "$action" in
+  copy) copy ;;
+  save) save "$file" ;;
+  edit) edit "$file" ;;
+  copysave) copysave "$file" ;;
+  *) die -h "Unknown action $action" ;;
+  esac
+}
+
+parse-target() {
+  case "$1" in
+  active) active ;;
+  screen) screen ;;
+  output) output ;;
+  area) area ;;
+  window) die "$(echo -e "Target 'window' is now included in 'area'.\nSimply run with 'area' and single click over the window you want.")" ;;
+  *) die -h "Unknown target to take a screen shot from $1" ;;
+  esac
+}
+
+main() {
+  local parsed_args
+
+  parsed_args="$(getopt --name "$NAME" --options 'nocfe:w:s:t:' --longoptions 'notify,openparentdir,cursor,freeze,expire-time:,wait:,scale:,filetype:' -- "$@")" || {
+    usage >&2
+    exit 1
+  }
+  eval "set -- $parsed_args"
+
+  while true; do
+    case $1 in
+    -n | --notify)
+      NOTIFY=true
+      shift
+      ;;
+    -o | --openparentdir)
+      SHOW_FILE_NOTIFY=true
+      shift
+      ;;
+    -e | --expire-time)
+      [[ $2 =~ ^[0-9]+$ ]] || {
+        echo "$NAME: ERROR: Invalid or missing argument for '-e|--expire-time'" >&2
         exit 1
-    fi
-    WHAT="Area"
-    wait
-elif [ "$SUBJECT" = "window" ]; then
-    die "Subject 'window' is now included in 'area'"
-else
-    die "Unknown subject to take a screen shot from" "$SUBJECT"
-fi
-if [ "$ACTION" = "copy" ]; then
-    takeScreenshot - "$GEOM" "$OUTPUT" | wl-copy --type image/png || die "Clipboard error"
-    notifyOk "$WHAT copied to buffer"
-elif [ "$ACTION" = "save" ]; then
-    if takeScreenshot "$FILE" "$GEOM" "$OUTPUT"; then
-        TITLE="Screenshot of $SUBJECT"
-        MESSAGE=$(basename "$FILE")
-        killHyprpicker
-        notifyOpen "$TITLE" "$MESSAGE" -i "$FILE"
-        echo "$FILE"
-    else
-        notifyError "Error taking screenshot with grim"
-    fi
-elif [ "$ACTION" = "edit" ]; then
-    env_editor_confirm
-    if takeScreenshot "$FILE_EDITOR" "$GEOM" "$OUTPUT"; then
-        TITLE="Screenshot of $SUBJECT"
-        MESSAGE="Open screenshot in image editor"
-        notifyOk "$TITLE" "$MESSAGE" -i "$FILE_EDITOR"
-        $GRIMBLAST_EDITOR "$FILE_EDITOR"
-        echo "$FILE_EDITOR"
-    else
-        notifyError "Error taking screenshot"
-    fi
-else
-    if [ "$ACTION" = "copysave" ]; then
-        takeScreenshot - "$GEOM" "$OUTPUT" | tee "$FILE" | wl-copy --type image/png || die "Clipboard error"
-        notifyOk "$WHAT copied to buffer and saved to $FILE" -i "$FILE"
-        echo "$FILE"
-    else
-        notifyError "Error taking screenshot with grim"
-    fi
-fi
-killHyprpicker
+      }
+      EXPIRE_TIME=$2
+      shift 2
+      ;;
+    -c | --cursor)
+      CURSOR=1
+      shift
+      ;;
+    -f | --freeze)
+      FREEZE=1
+      shift
+      ;;
+    -w | --wait)
+      [[ $2 =~ ^[0-9]*(\.[0-9]+)?$ ]] || {
+        echo "$NAME: ERROR: Invalid value for '-w|--wait'" >&2
+        exit 1
+      }
+      WAIT=$2
+      shift 2
+      ;;
+    -s | --scale)
+      [[ "$2" =~ ^[0-9]*(\.[0-9]+)?$ ]] || {
+        echo "$NAME: ERROR: Invalid or missing argument for '-s|--scale'" >&2
+        exit 1
+      }
+      SCALE=$2
+      shift 2
+      ;;
+    -t | --filetype)
+      [[ "$2" =~ ^(png|ppm|jpeg)$ ]] || {
+        echo "$NAME: ERROR: Invalid filetype '$2'. Must be png, ppm, or jpeg" >&2
+        exit 1
+      }
+      FILETYPE=$2
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "$NAME: ERROR: Invalid option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    esac
+  done
+
+  ACTION="${1:-usage}"
+  if [[ $1 =~ ^(usage|check)$ ]]; then
+    "$1"
+    exit
+  fi
+  shift
+  parse-target "${1:-screen}"
+  shift
+  parse-action "$ACTION" "$@"
+}
+
+main "$@"


### PR DESCRIPTION
# Pull Request

## Description

Update `grimblast` to latest version to [fix double slurp](https://github.com/hyprwm/contrib/commit/3dcbce715ae8b93107fa8632db15bf976862a573)

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multiple screenshot output formats, including appropriate clipboard MIME types.
  - Added an option to open the parent directory after saving a screenshot.
  - Improved area selection behavior and handling when selection is canceled.

- **Bug Fixes**
  - Fixed an issue causing double slurp behavior.
  - Updated Grimblast for more reliable screenshot and cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->