### PR TITLE
#1901 fix: quote the shell probe and treat an empty runtime dir as unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 - Hyprland: a session started without `XDG_CONFIG_HOME`, such as one launched from a TTY, no longer dies with a Lua error before the first window; the unset variable is treated as unset instead of being pasted into a path
+- Hyprland: a home directory containing an apostrophe no longer makes the session load its libraries from the system directory instead of the user's own, and an empty `XDG_RUNTIME_DIR` reads as unset rather than resolving against the working directory
 - Waybar: the theme module and the HyDE menu call `theme.switch` again; `themeswitch` was removed and the calls failed outright
 - Dolphin: the "Set As Wallpaper" service menu switches the theme again
 - Fish: `HYPRLAND_CONFIG` points at the deployed `hypr/hyde.lua` instead of a config the Lua release deleted, so a session started outside uwsm no longer comes up without a config

--- a/Configs/.local/share/hypr/lua/hyde/path.lua
+++ b/Configs/.local/share/hypr/lua/hyde/path.lua
@@ -22,15 +22,18 @@ local HOME = os.getenv("HOME")
 --- the fallback is derived from `HOME`.
 ---
 --- @param name string Environment variable holding the directory.
---- @param fallback string Path appended to `HOME` when the variable is unset.
---- @return string|nil path The directory, or nil when `HOME` is absent too.
+--- @param fallback string|nil Path appended to `HOME` when the variable is
+--- unset. Omit it for a directory that has no meaningful default.
+--- @return string|nil path The directory, or nil when there is no fallback to
+--- derive.
 ---
 --- Example:
 ---   env("XDG_CONFIG_HOME", "/.config") --> "/home/user/.config"
+---   env("XDG_RUNTIME_DIR")             --> nil when the session set nothing
 local function env(name, fallback)
     local value = os.getenv(name)
     if value == nil or value == "" then
-        return HOME and HOME .. fallback
+        return fallback and HOME and HOME .. fallback
     end
 
     return value
@@ -50,8 +53,24 @@ P.data = env("XDG_DATA_HOME", "/.local/share")
 
 --- @field runtime string|nil Runtime directory. It has no fallback: the spec
 --- requires the session to provide one, and inventing a path would put runtime
---- state somewhere that outlives the session.
-P.runtime = os.getenv("XDG_RUNTIME_DIR")
+--- state somewhere that outlives the session. An empty value is still unset,
+--- so it reads as nil rather than as the working directory.
+P.runtime = env("XDG_RUNTIME_DIR")
+
+--- Wraps a value so the shell reads it as one literal word.
+---
+--- Single quotes protect everything except a single quote itself, which has to
+--- leave the quoted run, contribute an escaped quote and open a new run. Values
+--- here are derived from HOME, and a home directory is free to contain one.
+---
+--- @param value string Value to pass to the shell.
+--- @return string quoted The value as a single quoted shell word.
+---
+--- Example:
+---   shell_quote("/home/o'brien") --> "'/home/o'\\''brien'"
+local function shell_quote(value)
+    return "'" .. value:gsub("'", "'\\''") .. "'"
+end
 
 --- Reports whether a path is a directory.
 ---
@@ -62,7 +81,7 @@ P.runtime = os.getenv("XDG_RUNTIME_DIR")
 --- @param path string Absolute path to test.
 --- @return boolean exists True when the path is a directory.
 local function is_directory(path)
-    local pipe = io.popen("[ -d '" .. path .. "' ] && echo 1 || echo 0")
+    local pipe = io.popen("[ -d " .. shell_quote(path) .. " ] && echo 1 || echo 0")
     if not pipe then
         return false
     end

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -58,6 +58,30 @@ nil) ;;
 *) fail "an absent HOME resolved a path out of nowhere: $config" ;;
 esac
 
+# An empty value is unset, and a directory with no meaningful default stays
+# unresolved rather than becoming "" — paths built on that resolve against the
+# working directory instead of failing where they can be seen.
+runtime=$(HOME="$work_dir/home" XDG_RUNTIME_DIR='' resolve runtime)
+[ "$runtime" = "nil" ] ||
+    fail "an empty XDG_RUNTIME_DIR did not read as unset: [$runtime]"
+
+runtime=$(HOME="$work_dir/home" XDG_RUNTIME_DIR="$work_dir/run" resolve runtime)
+[ "$runtime" = "$work_dir/run" ] ||
+    fail "a set XDG_RUNTIME_DIR was not honoured: $runtime"
+
+# The directory probe shells out, so a home directory is allowed to contain a
+# quote: it has to be found, and it must not be able to run anything.
+quoted_home="$work_dir/qu'ote"
+mkdir -p "$quoted_home/.local/lib"
+lib=$(HOME="$quoted_home" resolve lib)
+[ "$lib" = "$quoted_home/.local/lib" ] ||
+    fail "a home directory containing a quote was skipped: $lib"
+
+marker="$work_dir/executed"
+HOME="$work_dir/x'; touch \"$marker\"; echo '" resolve lib >/dev/null 2>&1
+[ -e "$marker" ] &&
+    fail "a crafted HOME executed a command through the directory probe"
+
 # The consumer has to be prepared for that, otherwise the guard above buys
 # nothing: dynamic.lua must not concatenate the config path unconditionally.
 dynamic="$REPO_ROOT/Configs/.local/share/hypr/lua/dynamic.lua"
@@ -69,6 +93,6 @@ grep -q 'os.getenv("XDG_CONFIG_HOME") \.\.' "$dynamic" &&
 grep -qE '^[[:space:]]*if io\.open\(' "$dynamic" &&
     fail "dynamic.lua tests a file with io.open without closing the handle"
 
-printf '    %d path field(s) checked\n' 3
+printf '    %d path field(s) checked\n' 5
 
 finish


### PR DESCRIPTION
Closes #1901

Both defects were raised on #1900 and merged unaddressed after @kRHYME7 approved it in https://github.com/HyDE-Project/HyDE/pull/1900#pullrequestreview-4823981063. Original threads: https://github.com/HyDE-Project/HyDE/pull/1900#discussion_r3686880382 and https://github.com/HyDE-Project/HyDE/pull/1900#discussion_r3686880381.

## Shell quoting

`is_directory` pasted its argument between single quotes without escaping. The argument derives from `HOME`, which is free to contain one:

| `HOME` | Before | After |
| --- | --- | --- |
| `/home/o'brien` | probe fails to parse, `hyde.path.lib` silently falls through to `/usr/local/lib` | resolves to `/home/o'brien/.local/lib` |
| `/tmp/x'; touch /tmp/marker; echo '` | `/tmp/marker` is created | nothing runs |

A `shell_quote` helper closes the quoted run, contributes an escaped quote and opens a new one, which is the only sequence single quotes allow.

## Empty runtime directory

`P.runtime` read `XDG_RUNTIME_DIR` with a bare `os.getenv`, so an empty value became `""`. The file already documents that an empty variable counts as unset and applies it to every other field. `env` now takes an optional fallback, so a directory with no meaningful default resolves to `nil` instead of a path relative to the working directory.

## Tests

`tests/test_paths.sh` gains four assertions: an empty `XDG_RUNTIME_DIR` reads as unset, a set one is honoured, a home directory containing a quote is found rather than skipped, and a crafted `HOME` creates no marker file.

Verified against the merged revision of `path.lua`: it fails three of them, including the marker file being created. Full suite: 11 cases, 0 failed, run twice.

## Not in this pull request

The same unquoted interpolation exists in `Configs/.local/lib/hyde/color/dconf.lua:66` and `Configs/.local/lib/hyde/batterynotify.lua:62`, and `Configs/.local/lib/hyde/altab.lua:136` quotes without escaping. They are recorded in #1901 and left alone to keep this change to the file it belongs to.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Hyprland session handling for home directories containing apostrophes.
  * Improved behavior when `XDG_RUNTIME_DIR` is empty or unavailable.
  * Added safer path handling to prevent errors during directory checks.

* **Tests**
  * Expanded coverage for runtime directory fallbacks, quoted home paths, and secure directory validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->