### PR TITLE
fix: Preserve Pyprland command arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Core: Pyprland commands keep their arguments when `nc`, `socat`, and `ncat` are unavailable, so commands such as `hyde-shell pypr toggle console` work through the CLI fallback again
 - Hyprland: a session started without `XDG_CONFIG_HOME`, such as one launched from a TTY, no longer dies with a Lua error before the first window; the unset variable is treated as unset instead of being pasted into a path
 - Hyprland: a home directory containing an apostrophe no longer makes the session load its libraries from the system directory instead of the user's own, and an empty `XDG_RUNTIME_DIR` reads as unset rather than resolving against the working directory
 - Waybar: the theme module and the HyDE menu call `theme.switch` again; `themeswitch` was removed and the calls failed outright

--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -377,11 +377,12 @@ run_pypr() {
         fi
 
         if [[ -S "$socket_path" ]] && pgrep -u "$USER" pypr >/dev/null 2>&1; then
-            message="${*:-"help"}"
-            if ! printf "%s" "${message[@]}" | nc -N -U "$socket_path" 2>/dev/null; then
-                if ! printf "%s" "${message[@]}" | socat - UNIX-CONNECT:"$socket_path" 2>/dev/null; then
-                    if ! printf "%s" "${message[@]}" | ncat -U "$socket_path" 2>/dev/null; then
-                        if ! pypr "${message[@]}"; then
+            local -a msg=("$@")
+            ((${#msg[@]} == 0)) && msg=("help")
+            if ! printf '%s\n' "${msg[*]}" | nc -N -U "$socket_path" 2>/dev/null; then
+                if ! printf '%s\n' "${msg[*]}" | socat - UNIX-CONNECT:"$socket_path" 2>/dev/null; then
+                    if ! printf '%s\n' "${msg[*]}" | ncat -U "$socket_path" 2>/dev/null; then
+                        if ! pypr "${msg[@]}"; then
                             print_log -sec "pypr" "Error communicating with socket: $socket_path"
                             exit 1
                         fi

--- a/tests/test_pypr_wrapper.sh
+++ b/tests/test_pypr_wrapper.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# The Pyprland wrapper must preserve command arguments when socket helper
+# programs are unavailable and it falls back to the Pyprland CLI.
+
+# shellcheck source=tests/lib/common.sh
+. "$(dirname -- "$0")/lib/common.sh"
+
+hyde_shell="$REPO_ROOT/Configs/.local/bin/hyde-shell"
+fixture=$(mktemp -d)
+server_pid=
+
+cleanup() {
+    if [[ -n "$server_pid" ]]; then
+        kill "$server_pid" 2>/dev/null || true
+        wait "$server_pid" 2>/dev/null || true
+    fi
+    rm -rf "$fixture"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p \
+    "$fixture/bin" \
+    "$fixture/config/pypr" \
+    "$fixture/runtime/hypr/test-instance" \
+    "$fixture/state/hyde/python_env/bin"
+: >"$fixture/config/pypr/config.toml"
+: >"$fixture/state/hyde/python_env/bin/activate"
+
+for helper in nc socat ncat; do
+    cat >"$fixture/bin/$helper" <<'EOF'
+#!/usr/bin/env sh
+exit 1
+EOF
+done
+
+cat >"$fixture/bin/pgrep" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+
+cat >"$fixture/bin/pypr" <<'EOF'
+#!/usr/bin/env sh
+printf '<%s>\n' "$@"
+EOF
+chmod +x "$fixture/bin/"*
+
+socket_path="$fixture/runtime/hypr/test-instance/.pyprland.sock"
+python3 - "$socket_path" <<'PY' &
+import socket
+import sys
+import time
+
+server = socket.socket(socket.AF_UNIX)
+server.bind(sys.argv[1])
+time.sleep(30)
+PY
+server_pid=$!
+
+for _ in {1..100}; do
+    [[ -S "$socket_path" ]] && break
+    sleep 0.01
+done
+
+if [[ ! -S "$socket_path" ]]; then
+    fail "test Pyprland socket was not created"
+    finish
+fi
+
+output=$(
+    PATH="$fixture/bin:/usr/bin:/bin" \
+        XDG_CONFIG_HOME="$fixture/config" \
+        XDG_RUNTIME_DIR="$fixture/runtime" \
+        XDG_STATE_HOME="$fixture/state" \
+        HYPRLAND_INSTANCE_SIGNATURE=test-instance \
+        "$hyde_shell" pypr toggle console 2>"$fixture/hyde-shell.stderr"
+)
+status=$?
+
+if [[ "$status" -ne 0 ]]; then
+    fail "Pyprland CLI fallback exited with $status: $(<"$fixture/hyde-shell.stderr")"
+fi
+
+if [[ "$output" != $'<toggle>\n<console>' ]]; then
+    fail "Pyprland CLI fallback did not preserve command arguments: $output"
+fi
+
+finish


### PR DESCRIPTION
# Pull Request

## Description

Restore the array-based Pyprland argument forwarding from #1741 after it was
overwritten during the Hyprland/Lua migration.

On systems without `nc`, `socat`, or `ncat`, the command:

```sh
hyde-shell pypr toggle console
```

falls back to the Pyprland CLI. The current scalar expansion passes
`toggle console` as one argument, which Pyprland normalizes to the invalid
command `toggle_console`.

This change:

- preserves command arguments in a Bash array for the CLI fallback;
- terminates direct Unix socket messages with a newline;
- adds a regression test that disables all three socket helpers and verifies
  that `toggle` and `console` remain separate arguments;
- documents the user-visible fix in the changelog.

Installing `openbsd-netcat` masks the fallback bug, but it should not be a
required dependency. No new dependencies are introduced by this change.

Regression of #1741.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Testing

- `tests/run.sh`: 12 cases, 0 failed
- `tests/test_pypr_wrapper.sh`: passed
- `uvx pre-commit run --files CHANGELOG.md Configs/.local/bin/hyde-shell tests/test_pypr_wrapper.sh`: passed
- `uvx pre-commit run --all-files`: blocked by the pre-existing broken
  `Source/assets/hyde.png` symlink and repository-wide EOF/trailing-whitespace
  findings unrelated to this change

## Screenshots

Not applicable.

## Additional context

The regression test covers the exact fallback path that failed after #1741 was
overwritten, so future large configuration migrations cannot silently restore
the scalar argument handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Pyprland command argument handling when socket utilities are unavailable.
  * Preserved command arguments correctly during CLI fallback.
  * Added a default `help` command when no arguments are provided.
  * Ensured commands sent through socket clients are properly terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->