### PR TITLE
#1911 fix: lock deez-dots at a revision that contains the tarball extraction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Core: an install deploys the cursor dots again instead of aborting on an existing theme file; the locked `deez-dots` revision predated the extraction fix, so every install kept running the defect the fix had already closed
 - Hyprland: a session started without `XDG_CONFIG_HOME`, such as one launched from a TTY, no longer dies with a Lua error before the first window; the unset variable is treated as unset instead of being pasted into a path
 - Hyprland: a home directory containing an apostrophe no longer makes the session load its libraries from the system directory instead of the user's own, and an empty `XDG_RUNTIME_DIR` reads as unset rather than resolving against the working directory
 - Waybar: the theme module and the HyDE menu call `theme.switch` again; `themeswitch` was removed and the calls failed outright

--- a/Configs/.local/lib/hyde/uv.lock
+++ b/Configs/.local/lib/hyde/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 [[package]]
 name = "deez-dots"
 version = "0.1.0"
-source = { git = "https://github.com/HyDE-Project/deez-dots.git#406d5602cd60600bd05e9d1139bc5ec0dd5eaa44" }
+source = { git = "https://github.com/HyDE-Project/deez-dots.git#e514a3215d4d0a691ac532accfa12e982d41160e" }
 
 [[package]]
 name = "frozenlist"


### PR DESCRIPTION
# Pull Request

## Description

Fixes #1911.

`Configs/.local/lib/hyde/uv.lock` pinned `deez-dots` at `406d5602` (14 June). The dependency is declared as a bare git source with no revision, so the lock is the only thing that decides which code an install runs — and that revision still carries the `FileExistsError` closed in HyDE-Project/deez-dots#1 (merged 29 July). In the pinned revision `deez_dots/core.py:1905` is `destination_path.mkdir(parents=True, exist_ok=True)`, the exact file and line reported in HyDE-Project/deez-dots#4 and, before it, in #1855.

The lock entry now resolves `e514a321`, where `_extract_tarball_payload` extracts into `_tarball_extraction_root(...)` and no longer calls `mkdir` on the recorded destination. No other package moved: the refresh was scoped with `--upgrade-package deez-dots`, and the diff is one line.

Verified by installing the newly locked revision into a throwaway environment and reading the shipped module: the fixed call site is present at `core.py:1951`, and the `mkdir` on the destination is gone.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

A dependency declared without a revision leaves the lock as the single point that decides what users run, so a closed defect can keep shipping for as long as the lock is not refreshed. Renovate covers versioned dependencies, not this git source; if that gap is worth closing, pinning an explicit revision in `pyproject.toml` would make each bump deliberate and reviewable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installation now redeploys cursor dots when a theme file already exists instead of aborting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->