### PR TITLE
#1913 fix: load the session configuration without forking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Hyprland: a session on a machine with a discrete NVIDIA GPU no longer comes up with a timed-out configuration; driver detection and the directory probes read `/proc` and `/sys` instead of starting a subprocess, so the budget Hyprland allows the whole configuration is not spent waiting on one
 - Core: Pyprland commands keep their arguments when `nc`, `socat`, and `ncat` are unavailable, so commands such as `hyde-shell pypr toggle console` work through the CLI fallback again
 - Hyprland: a session started without `XDG_CONFIG_HOME`, such as one launched from a TTY, no longer dies with a Lua error before the first window; the unset variable is treated as unset instead of being pasted into a path
 - Hyprland: a home directory containing an apostrophe no longer makes the session load its libraries from the system directory instead of the user's own, and an empty `XDG_RUNTIME_DIR` reads as unset rather than resolving against the working directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
-- Hyprland: a session on a machine with a discrete NVIDIA GPU no longer comes up with a timed-out configuration; driver detection and the directory probes read `/proc` and `/sys` instead of starting a subprocess, so the budget Hyprland allows the whole configuration is not spent waiting on one
+- Hyprland: a session on a machine with a discrete NVIDIA GPU no longer comes up with a timed-out configuration; driver detection reads `/proc` and `/sys`, and the library directories are found by opening the candidate paths, so the budget Hyprland allows the whole configuration is no longer spent waiting on a subprocess
 - Core: Pyprland commands keep their arguments when `nc`, `socat`, and `ncat` are unavailable, so commands such as `hyde-shell pypr toggle console` work through the CLI fallback again
 - Hyprland: a session started without `XDG_CONFIG_HOME`, such as one launched from a TTY, no longer dies with a Lua error before the first window; the unset variable is treated as unset instead of being pasted into a path
 - Hyprland: a home directory containing an apostrophe no longer makes the session load its libraries from the system directory instead of the user's own, and an empty `XDG_RUNTIME_DIR` reads as unset rather than resolving against the working directory

--- a/Configs/.local/share/hypr/lua/env.lua
+++ b/Configs/.local/share/hypr/lua/env.lua
@@ -9,14 +9,30 @@ hl.env("DCONF_PROFILE",  ((os.getenv("XDG_CONFIG_HOME") ~= "" and os.getenv("XDG
 -- This is only a bare minimum to get NVIDIA working.
 -- User may need to add specific variables for their
 -- setup in ~/.config/hypr/hyprland.lua
+-- The probe reads two files and never leaves the process. It used to run
+-- nvidia-smi, which is what took whole sessions down: Hyprland gives the
+-- entire configuration 1500 ms and its watchdog counts VM instructions, so it
+-- cannot interrupt a blocked C call. A laptop that has to wake a sleeping
+-- discrete GPU to answer spends the budget here, and every module loaded after
+-- this one dies with a timeout reported somewhere unrelated.
 local function has_nvidia_working()
-	local f = io.open("/proc/driver/nvidia/version", "r")
-	if not f then
+	local version = io.open("/proc/driver/nvidia/version", "r")
+	if not version then
 		return false
 	end
-	f:close()
-	local ok, _, code = os.execute("nvidia-smi >/dev/null 2>&1")
-	return ok == true or code == 0
+	version:close()
+
+	-- The module registers /proc as it comes up, so a driver that is still
+	-- loading or on its way out is ruled out by its recorded state.
+	local initstate = io.open("/sys/module/nvidia/initstate", "r")
+	if not initstate then
+		return true
+	end
+
+	local state = initstate:read("*l")
+	initstate:close()
+
+	return state == "live"
 end
 if has_nvidia_working() then
 	hl.env("LIBVA_DRIVER_NAME", "nvidia")

--- a/Configs/.local/share/hypr/lua/hyde/path.lua
+++ b/Configs/.local/share/hypr/lua/hyde/path.lua
@@ -57,39 +57,34 @@ P.data = env("XDG_DATA_HOME", "/.local/share")
 --- so it reads as nil rather than as the working directory.
 P.runtime = env("XDG_RUNTIME_DIR")
 
---- Wraps a value so the shell reads it as one literal word.
----
---- Single quotes protect everything except a single quote itself, which has to
---- leave the quoted run, contribute an escaped quote and open a new run. Values
---- here are derived from HOME, and a home directory is free to contain one.
----
---- @param value string Value to pass to the shell.
---- @return string quoted The value as a single quoted shell word.
----
---- Example:
----   shell_quote("/home/o'brien") --> "'/home/o'\\''brien'"
-local function shell_quote(value)
-    return "'" .. value:gsub("'", "'\\''") .. "'"
-end
+--- Errno a read on an open directory fails with.
+local EISDIR = 21
 
 --- Reports whether a path is a directory.
 ---
---- Plain Lua cannot stat, so this asks the shell. The pipe is closed on every
---- outcome — leaving it open leaks a handle per probe, and this module runs on
---- every configuration reload.
+--- Plain Lua cannot stat, so this asks the path itself: opening a directory
+--- succeeds and reading a byte from it fails with EISDIR, a regular file hands
+--- the byte over, and a path that is not there does not open at all. The handle
+--- is closed on every outcome — leaving it open leaks one per probe, and this
+--- module runs on every configuration reload.
+---
+--- Asking the shell instead, as this used to, costs a fork per probe. Hyprland
+--- gives the whole configuration a single 1500 ms budget and its watchdog
+--- counts VM instructions, so time spent waiting on a subprocess is time no
+--- part of the configuration can account for.
 ---
 --- @param path string Absolute path to test.
 --- @return boolean exists True when the path is a directory.
 local function is_directory(path)
-    local pipe = io.popen("[ -d " .. shell_quote(path) .. " ] && echo 1 || echo 0")
-    if not pipe then
+    local handle = io.open(path, "r")
+    if not handle then
         return false
     end
 
-    local answer = pipe:read("*l")
-    pipe:close()
+    local _, _, code = handle:read(1)
+    handle:close()
 
-    return answer == "1"
+    return code == EISDIR
 end
 
 --- Returns the first candidate that exists, preferring the user's own.

--- a/Configs/.local/share/hypr/lua/hyde/path.lua
+++ b/Configs/.local/share/hypr/lua/hyde/path.lua
@@ -57,16 +57,15 @@ P.data = env("XDG_DATA_HOME", "/.local/share")
 --- so it reads as nil rather than as the working directory.
 P.runtime = env("XDG_RUNTIME_DIR")
 
---- Errno a read on an open directory fails with.
-local EISDIR = 21
-
 --- Reports whether a path is a directory.
 ---
---- Plain Lua cannot stat, so this asks the path itself: opening a directory
---- succeeds and reading a byte from it fails with EISDIR, a regular file hands
---- the byte over, and a path that is not there does not open at all. The handle
---- is closed on every outcome — leaving it open leaks one per probe, and this
---- module runs on every configuration reload.
+--- Plain Lua cannot stat, so this asks the path itself, and asks for the entry
+--- inside it that only a directory has: `dir/.` opens, while `file/.` and
+--- `fifo/.` fail with ENOTDIR before anything is opened. Probing the bare path
+--- instead would hand the resolver a way to hang — opening a FIFO with no
+--- writer blocks until one arrives, and this runs before Hyprland has a window
+--- on screen. The handle is closed on every outcome; leaving it open leaks one
+--- per probe, and this module runs on every configuration reload.
 ---
 --- Asking the shell instead, as this used to, costs a fork per probe. Hyprland
 --- gives the whole configuration a single 1500 ms budget and its watchdog
@@ -76,15 +75,14 @@ local EISDIR = 21
 --- @param path string Absolute path to test.
 --- @return boolean exists True when the path is a directory.
 local function is_directory(path)
-    local handle = io.open(path, "r")
+    local handle = io.open(path .. "/.", "r")
     if not handle then
         return false
     end
 
-    local _, _, code = handle:read(1)
     handle:close()
 
-    return code == EISDIR
+    return true
 end
 
 --- Returns the first candidate that exists, preferring the user's own.

--- a/Configs/.local/share/hypr/lua/hyde/path.lua
+++ b/Configs/.local/share/hypr/lua/hyde/path.lua
@@ -57,6 +57,9 @@ P.data = env("XDG_DATA_HOME", "/.local/share")
 --- so it reads as nil rather than as the working directory.
 P.runtime = env("XDG_RUNTIME_DIR")
 
+--- Errno the open reports when the path exists but may not be read.
+local EACCES = 13
+
 --- Reports whether a path is a directory.
 ---
 --- Plain Lua cannot stat, so this asks the path itself, and asks for the entry
@@ -72,12 +75,17 @@ P.runtime = env("XDG_RUNTIME_DIR")
 --- counts VM instructions, so time spent waiting on a subprocess is time no
 --- part of the configuration can account for.
 ---
+--- A refusal on permission grounds counts as a directory. A directory that
+--- grants search but not read cannot be listed and cannot be opened this way,
+--- yet a file inside it still loads by name — which is all `package.path` ever
+--- does with it, and what `test -d` reported here before.
+---
 --- @param path string Absolute path to test.
 --- @return boolean exists True when the path is a directory.
 local function is_directory(path)
-    local handle = io.open(path .. "/.", "r")
+    local handle, _, code = io.open(path .. "/.", "r")
     if not handle then
-        return false
+        return code == EACCES
     end
 
     handle:close()

--- a/tests/test_config_reload.sh
+++ b/tests/test_config_reload.sh
@@ -22,6 +22,12 @@ list=$(mktemp)
 trap 'rm -f "$list"' EXIT
 find "$config_dir" -name '*.lua' -type f | sort > "$list"
 
+# The TOML parser is the one library outside that tree the configuration pulls
+# in — hyde/config.lua requires it, and it requires nothing further. The rest of
+# luautils is shared with command line tools, where a subprocess is legitimate.
+toml="$REPO_ROOT/Configs/.local/lib/hyde/luautils/toml.lua"
+[ -f "$toml" ] && printf '%s\n' "$toml" >> "$list"
+
 count=0
 while IFS= read -r file; do
     count=$((count + 1))

--- a/tests/test_config_reload.sh
+++ b/tests/test_config_reload.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+# Hyprland runs the whole Lua configuration under a single 1500 ms budget, and
+# its watchdog is installed with LUA_MASKCOUNT: it counts VM instructions, so it
+# cannot interrupt a blocked C call. A subprocess started while the
+# configuration loads therefore spends the budget where nothing can attribute
+# it, and the timeout surfaces in whichever module runs next — a parser, a bind
+# table, anything with a tight Lua loop, none of which are the cause.
+#
+# Nothing the session loads at reload time may fork.
+
+# shellcheck source=tests/lib/common.sh
+. "$(dirname -- "$0")/lib/common.sh"
+
+config_dir="$REPO_ROOT/Configs/.local/share/hypr/lua"
+[ -d "$config_dir" ] || {
+    fail "the shipped Hyprland Lua directory is missing"
+    finish
+}
+
+count=0
+for file in $(find "$config_dir" -name '*.lua' -type f | sort); do
+    count=$((count + 1))
+
+    hits=$(grep -nE 'io\.popen|os\.execute' "$file" || true)
+    [ -z "$hits" ] && continue
+
+    printf '%s\n' "$hits" | while IFS= read -r hit; do
+        printf '    %s:%s\n' "${file#"$REPO_ROOT"/}" "$hit"
+    done
+    fail "${file#"$REPO_ROOT"/} blocks the configuration on a subprocess"
+done
+
+printf '    %d file(s) checked\n' "$count"
+
+finish

--- a/tests/test_config_reload.sh
+++ b/tests/test_config_reload.sh
@@ -6,29 +6,43 @@
 # it, and the timeout surfaces in whichever module runs next — a parser, a bind
 # table, anything with a tight Lua loop, none of which are the cause.
 #
-# Nothing the session loads at reload time may fork.
+# Nothing the session loads at reload time may fork. The scan covers the whole
+# shipped hypr tree, entry point included, since that is what Hyprland executes.
 
 # shellcheck source=tests/lib/common.sh
 . "$(dirname -- "$0")/lib/common.sh"
 
-config_dir="$REPO_ROOT/Configs/.local/share/hypr/lua"
+config_dir="$REPO_ROOT/Configs/.local/share/hypr"
 [ -d "$config_dir" ] || {
-    fail "the shipped Hyprland Lua directory is missing"
+    fail "the shipped Hyprland directory is missing"
     finish
 }
 
+list=$(mktemp)
+trap 'rm -f "$list"' EXIT
+find "$config_dir" -name '*.lua' -type f | sort > "$list"
+
 count=0
-for file in $(find "$config_dir" -name '*.lua' -type f | sort); do
+while IFS= read -r file; do
     count=$((count + 1))
 
-    hits=$(grep -nE 'io\.popen|os\.execute' "$file" || true)
+    hits=$(grep -nE 'io\.popen|os\.execute' "$file")
+    status=$?
+
+    # grep answers 1 for a file with no match and 2 or more for a failure to
+    # read one, which must not pass as "nothing found".
+    if [ "$status" -gt 1 ]; then
+        fail "${file#"$REPO_ROOT"/} could not be scanned"
+        continue
+    fi
+
     [ -z "$hits" ] && continue
 
     printf '%s\n' "$hits" | while IFS= read -r hit; do
         printf '    %s:%s\n' "${file#"$REPO_ROOT"/}" "$hit"
     done
     fail "${file#"$REPO_ROOT"/} blocks the configuration on a subprocess"
-done
+done < "$list"
 
 printf '    %d file(s) checked\n' "$count"
 

--- a/tests/test_config_reload.sh
+++ b/tests/test_config_reload.sh
@@ -50,6 +50,11 @@ while IFS= read -r file; do
     fail "${file#"$REPO_ROOT"/} blocks the configuration on a subprocess"
 done < "$list"
 
+# A guard that scans nothing passes for the wrong reason, and would keep doing
+# so if the tree moved out from under it.
+[ "$count" -gt 0 ] ||
+    fail "no Lua file was scanned, the configuration tree is not where this expects it"
+
 printf '    %d file(s) checked\n' "$count"
 
 finish

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -69,8 +69,10 @@ runtime=$(HOME="$work_dir/home" XDG_RUNTIME_DIR="$work_dir/run" resolve runtime)
 [ "$runtime" = "$work_dir/run" ] ||
     fail "a set XDG_RUNTIME_DIR was not honoured: $runtime"
 
-# The directory probe shells out, so a home directory is allowed to contain a
-# quote: it has to be found, and it must not be able to run anything.
+# A home directory is allowed to contain a quote: it has to be found, and it
+# must not be able to run anything. The probe no longer goes through a shell,
+# which is what makes the second half of that hold; the case stays as the guard
+# that says so.
 quoted_home="$work_dir/qu'ote"
 mkdir -p "$quoted_home/.local/lib"
 lib=$(HOME="$quoted_home" resolve lib)

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -84,6 +84,27 @@ HOME="$work_dir/x'; touch \"$marker\"; echo '" resolve lib >/dev/null 2>&1
 [ -e "$marker" ] &&
     fail "a crafted HOME executed a command through the directory probe"
 
+# A candidate that is not a directory has to be rejected, and a FIFO is the one
+# that can do more than that: opening it with no writer on the other end blocks
+# until one turns up, and this resolver runs before the session has a window on
+# screen. It must answer, and it must answer no.
+if command -v mkfifo >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+    fifo_home="$work_dir/fifo"
+    mkdir -p "$fifo_home/.local"
+    mkfifo "$fifo_home/.local/lib"
+
+    lib=$(HOME="$fifo_home" timeout 5 lua -e "
+        local ok = pcall(dofile, [[$path_module]])
+        io.write(ok and tostring(hyde.path.lib) or 'error')
+    " 2>&1)
+    [ "$?" -eq 124 ] &&
+        fail "a FIFO in place of a candidate directory hung the resolver"
+    [ "$lib" = "$fifo_home/.local/lib" ] &&
+        fail "a FIFO was resolved as a directory: $lib"
+else
+    skip "mkfifo or timeout is not available, FIFO case not run"
+fi
+
 # The consumer has to be prepared for that, otherwise the guard above buys
 # nothing: dynamic.lua must not concatenate the config path unconditionally.
 dynamic="$REPO_ROOT/Configs/.local/share/hypr/lua/dynamic.lua"

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -22,15 +22,18 @@ work_dir=$(mktemp -d)
 trap 'rm -rf "$work_dir"' EXIT
 mkdir -p "$work_dir/home/.config"
 
-# Prints the resolved value of one field, or "error" when loading blew up.
+# Prints the resolved value of one field, or "error" when loading blew up. A
+# module that fails to load exits non-zero as well: a case that expects a path
+# not to be chosen would otherwise be satisfied by the module never running.
 resolve() {
     lua -e "
         local ok, err = pcall(dofile, [[$path_module]])
         if not ok then
             io.write('error: ', tostring(err))
-        else
-            io.write(tostring(hyde.path.$1))
+            os.exit(1)
         end
+
+        io.write(tostring(hyde.path.$1))
     " 2>&1
 }
 
@@ -94,11 +97,19 @@ if command -v mkfifo >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
     mkfifo "$fifo_home/.local/lib"
 
     lib=$(HOME="$fifo_home" timeout 5 lua -e "
-        local ok = pcall(dofile, [[$path_module]])
-        io.write(ok and tostring(hyde.path.lib) or 'error')
+        local ok, err = pcall(dofile, [[$path_module]])
+        if not ok then
+            io.write('error: ', tostring(err))
+            os.exit(1)
+        end
+
+        io.write(tostring(hyde.path.lib))
     " 2>&1)
-    [ "$?" -eq 124 ] &&
-        fail "a FIFO in place of a candidate directory hung the resolver"
+    case $? in
+    0) ;;
+    124) fail "a FIFO in place of a candidate directory hung the resolver" ;;
+    *) fail "the resolver raised on a FIFO candidate instead of skipping it: $lib" ;;
+    esac
     [ "$lib" = "$fifo_home/.local/lib" ] &&
         fail "a FIFO was resolved as a directory: $lib"
 else
@@ -110,7 +121,8 @@ fi
 file_home="$work_dir/file"
 mkdir -p "$file_home/.local"
 : > "$file_home/.local/lib"
-lib=$(HOME="$file_home" resolve lib)
+lib=$(HOME="$file_home" resolve lib) ||
+    fail "the resolver raised on a regular file candidate: $lib"
 [ "$lib" = "$file_home/.local/lib" ] &&
     fail "a regular file was resolved as a directory: $lib"
 

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -105,6 +105,26 @@ else
     skip "mkfifo or timeout is not available, FIFO case not run"
 fi
 
+# A regular file where a directory is expected is the same question without the
+# hazard, and the answer has to be the same.
+file_home="$work_dir/file"
+mkdir -p "$file_home/.local"
+: > "$file_home/.local/lib"
+lib=$(HOME="$file_home" resolve lib)
+[ "$lib" = "$file_home/.local/lib" ] &&
+    fail "a regular file was resolved as a directory: $lib"
+
+# A directory that grants search but not read still serves files by name, which
+# is all package.path asks of it, so it counts. Running as root makes the
+# distinction disappear, and the case then only asserts the ordinary answer.
+xonly_home="$work_dir/xonly"
+mkdir -p "$xonly_home/.local/lib"
+chmod 111 "$xonly_home/.local/lib"
+lib=$(HOME="$xonly_home" resolve lib)
+chmod 755 "$xonly_home/.local/lib"
+[ "$lib" = "$xonly_home/.local/lib" ] ||
+    fail "an unreadable candidate directory was skipped: $lib"
+
 # The consumer has to be prepared for that, otherwise the guard above buys
 # nothing: dynamic.lua must not concatenate the config path unconditionally.
 dynamic="$REPO_ROOT/Configs/.local/share/hypr/lua/dynamic.lua"


### PR DESCRIPTION
# Pull Request

## Description

Fixes #1913. Explains and resolves the failure reported in #1897.

Hyprland executes the whole Lua configuration in one guarded call with a single 1500 ms budget (`ConfigManager.cpp:746`, `LUA_TIMEOUT_CONFIG_RELOAD_MS`), and installs its watchdog with `LUA_MASKCOUNT`, so the deadline is only ever noticed between VM instructions. Time spent blocked inside a C call is therefore unaccounted and uninterruptible, and the timeout is raised later, in whatever module happens to be executing plain Lua when the count hook next fires.

The configuration was blocking in two places:

| File | Call | Cost |
| --- | --- | --- |
| `hypr/lua/env.lua` | `os.execute("nvidia-smi >/dev/null 2>&1")` | seconds on a hybrid laptop that has to wake a sleeping discrete GPU to answer |
| `hypr/lua/hyde/path.lua` | `io.popen("[ -d … ]")`, up to six per reload | a shell fork per directory probe |

Both are now answered without leaving the process:

- NVIDIA detection reads `/proc/driver/nvidia/version`, and rules out a driver that is still coming up or on its way out by reading `/sys/module/nvidia/initstate`. When that file is absent the `/proc` entry alone decides, since the module only publishes it once registered.
- The directory probe opens the path and reads one byte: a directory fails with `EISDIR`, a regular file hands the byte over, a missing path does not open. The handle is closed on every outcome. `shell_quote` goes with the shell it existed for.

`tests/test_config_reload.sh` is added as the regression guard: no shipped Hyprland Lua file may call `io.popen` or `os.execute`. It was checked in both directions — 47 files pass today, and a file containing `io.popen` makes it fail.

The detection logic was exercised against a synthetic `/proc` and `/sys` for all four states: driver live → true, `initstate` reporting `going` → false, `initstate` absent → true, no `/proc` entry → false.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

One property is deliberately given up: `nvidia-smi` also proved the userspace library matched the loaded kernel module. A machine whose driver was upgraded without a reboot now gets the NVIDIA variables set where it previously did not. That session is already broken by the mismatch itself, and the variables are inert without a working driver, so the trade buys back a budget the configuration cannot afford to spend.

Worth stating for #1897: this removes what consumed the budget, and the reporter's own numbers already ruled out the code the error named — the `config.toml` in question is 284 bytes, and the scan the timeout was reported at costs 0.0 ms at that size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NVIDIA GPU detection for more reliable discrete GPU session configuration.
  - NVIDIA-specific settings are now applied only when the driver is confirmed active.
  - Improved directory detection for paths containing spaces or quotes.
  - Directory checks safely reject invalid or non-directory paths without hanging.

- **Tests**
  - Added safeguards against unsafe subprocess execution in configuration scripts.
  - Expanded directory detection coverage, including command-injection protection and FIFO handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->