### PR TITLE
#1904 fix: declare the lgi build dependency and skip an unbuildable optional rock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Core: an install no longer ends at the Lua step on a machine that cannot build `lgi`; the introspection headers it compiles against are declared as a dependency, and an optional rock that still fails is reported and skipped instead of taking the run down before any dotfile is deployed
 - Core: Pyprland commands keep their arguments when `nc`, `socat`, and `ncat` are unavailable, so commands such as `hyde-shell pypr toggle console` work through the CLI fallback again
 - Hyprland: a session started without `XDG_CONFIG_HOME`, such as one launched from a TTY, no longer dies with a Lua error before the first window; the unset variable is treated as unset instead of being pasted into a path
 - Hyprland: a home directory containing an apostrophe no longer makes the session load its libraries from the system directory instead of the user's own, and an empty `XDG_RUNTIME_DIR` reads as unset rather than resolving against the working directory

--- a/Configs/.local/lib/hyde/pyutils/lua_env.json
+++ b/Configs/.local/lib/hyde/pyutils/lua_env.json
@@ -5,7 +5,7 @@
     {"name": "dkjson", "version": "2.11-1"},
     {"name": "luasocket", "version": "3.1.0-1"},
     {"name": "luafilesystem", "version": "1.9.0-1"},
-    "https://raw.githubusercontent.com/lgi-devs/lgi/master/lgi-scm-1.rockspec"
+    {"name": "https://raw.githubusercontent.com/lgi-devs/lgi/master/lgi-scm-1.rockspec", "optional": true}
   ],
   "snapshot_exclude": [
     {"name": "luasec", "version": "1.3.2-1"},

--- a/Configs/.local/lib/hyde/pyutils/lua_env.py
+++ b/Configs/.local/lib/hyde/pyutils/lua_env.py
@@ -64,10 +64,16 @@ def load_bootstrap_config():
             return install, snapshot_exclude
 
     def _parse_pkg_entry(entry):
+        """Reads one package entry as (name, version, optional).
+
+        An entry may mark itself optional, which decides what happens when the
+        rock refuses to build: a required one stops the caller, an optional one
+        is reported and skipped.
+        """
         if isinstance(entry, dict) and "name" in entry:
-            return (entry["name"], entry.get("version"))
+            return (entry["name"], entry.get("version"), bool(entry.get("optional")))
         elif isinstance(entry, str):
-            return (entry, None)
+            return (entry, None, False)
         return None
 
     if isinstance(config, dict):
@@ -79,7 +85,7 @@ def load_bootstrap_config():
         if exclude_cfg is None:
             exclude_cfg = config.get("exclude")
 
-        # install: list of (name, version) tuples
+        # install: list of (name, version, optional) tuples
         if isinstance(install_cfg, list):
             install = []
             for item in install_cfg:
@@ -97,7 +103,7 @@ def load_bootstrap_config():
         else:
             snapshot_exclude = set()
         # Always exclude bootstrap_install names
-        snapshot_exclude = set([name for name, _ in install]) | snapshot_exclude
+        snapshot_exclude = set([entry[0] for entry in install]) | snapshot_exclude
 
     return install, snapshot_exclude
 
@@ -201,6 +207,33 @@ def install_rock(name, version=None, force=False):
     run(args)
 
 
+def install_bootstrap(bootstrap_install, force=False):
+    """Installs the bootstrap rocks, skipping the optional ones that fail.
+
+    A rock that refuses to build stops the caller only when the bootstrap
+    config declares it required. lgi is the reason this distinction exists: it
+    is compiled against the GObject introspection headers, and a system without
+    them used to take the whole installation down at the Lua step, before a
+    single dotfile had been deployed.
+    """
+    skipped = []
+
+    for name, version, optional in bootstrap_install:
+        try:
+            install_rock(name, version, force=force)
+        except subprocess.CalledProcessError:
+            if not optional:
+                raise
+            skipped.append(name)
+            print(f"[lua_env] {name} did not build; it is optional, continuing without it")
+
+    if skipped:
+        print(f"[lua_env] {len(skipped)} optional package(s) skipped: {', '.join(skipped)}")
+        print("[lua_env] install their build dependencies and run 'hyde-shell luainit' to retry")
+
+    return skipped
+
+
 def create_env(force=False):
     ensure_system_tools()
     print(f"[lua_env] Using system Lua: {LUA_BIN}")
@@ -209,8 +242,7 @@ def create_env(force=False):
 
     bootstrap_install, _ = load_bootstrap_config()
     ensure_state_dir()
-    for name, version in bootstrap_install:
-        install_rock(name, version, force=force)
+    install_bootstrap(bootstrap_install, force=force)
 
     restore_saved_rocks(force=force)
 
@@ -236,8 +268,7 @@ def sync_env():
     ensure_state_dir()
     # Reinstall all bootstrap_install packages to latest or pinned version
     bootstrap_install, _ = load_bootstrap_config()
-    for name, version in bootstrap_install:
-        install_rock(name, version, force=True)
+    install_bootstrap(bootstrap_install, force=True)
     # Now snapshot only user-installed rocks
     snapshot_installed_rocks()
 

--- a/Scripts/dots/deps.toml
+++ b/Scripts/dots/deps.toml
@@ -4,6 +4,7 @@ pacman = [
   # System
   "lua", # for lua runtime
   "luarocks", # Core scripts lib
+  "libgirepository", # headers and pkg-config data the lgi rock is built against
   "uwsm", # A standalone Wayland session manager
   "pipewire", # audio/video server
   "pipewire-alsa", # pipewire alsa client

--- a/tests/test_lua_env.sh
+++ b/tests/test_lua_env.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+# The Lua environment is bootstrapped from a list of rocks, and one of them —
+# lgi — is compiled against the GObject introspection headers. A machine
+# without them cannot build it, and that used to end the whole installation at
+# the Lua step, before a single dotfile was deployed.
+#
+# An optional rock that fails is reported and skipped; a required one still
+# stops the run.
+
+# shellcheck source=tests/lib/common.sh
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 is not installed"
+    finish
+fi
+
+module="$REPO_ROOT/Configs/.local/lib/hyde/pyutils/lua_env.py"
+[ -f "$module" ] || {
+    fail "lua_env.py is missing"
+    finish
+}
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+cp "$module" "$work_dir/lua_env.py"
+
+# Stands in for luarocks: every install of the package named below fails, the
+# rest succeeds. `list` answers with nothing, so the snapshot stays empty.
+cat > "$work_dir/luarocks" <<'STUB'
+#!/usr/bin/env sh
+for arg in "$@"; do
+    case $arg in
+    list) exit 0 ;;
+    *unbuildable*) exit 1 ;;
+    esac
+done
+exit 0
+STUB
+chmod +x "$work_dir/luarocks"
+
+printf '#!/usr/bin/env sh\nexit 0\n' > "$work_dir/lua"
+chmod +x "$work_dir/lua"
+
+# Runs `create` against a bootstrap list written for the case at hand.
+create_with() {
+    printf '%s\n' "$1" > "$work_dir/lua_env.json"
+    XDG_STATE_HOME="$work_dir/state" \
+        LUA="$work_dir/lua" \
+        LUAROCKS="$work_dir/luarocks" \
+        python3 "$work_dir/lua_env.py" create >"$work_dir/out" 2>&1
+}
+
+create_with '{"bootstrap_install": [{"name": "dkjson", "version": "2.11-1"}, {"name": "unbuildable", "optional": true}]}' ||
+    fail "an optional package that failed to build ended the run: $(cat "$work_dir/out")"
+
+grep -q 'unbuildable' "$work_dir/out" ||
+    fail "the skipped optional package was not reported"
+
+create_with '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
+    fail "a required package that failed to build did not end the run"
+
+# The shipped list has to mark lgi optional, otherwise the guard above protects
+# nothing on a real installation.
+python3 - "$REPO_ROOT/Configs/.local/lib/hyde/pyutils/lua_env.json" <<'CHECK' || fail "the shipped bootstrap list does not mark lgi optional"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+
+entries = config.get("bootstrap_install", [])
+lgi = [e for e in entries if isinstance(e, dict) and "lgi" in e.get("name", "")]
+sys.exit(0 if lgi and lgi[0].get("optional") else 1)
+CHECK
+
+printf '    %d bootstrap case(s) checked\n' 3
+
+finish

--- a/tests/test_lua_env.sh
+++ b/tests/test_lua_env.sh
@@ -52,14 +52,32 @@ run_with() {
         python3 "$work_dir/lua_env.py" "$1" >"$work_dir/out" 2>&1
 }
 
+# The package name alone proves nothing — the failing command line carries it
+# too. What has to appear is the handler's own account of the skip, so these
+# look for the words only it writes.
+expect_skip_report() {
+    grep -q 'it is optional, continuing without it' "$work_dir/out" ||
+        fail "$1 did not report the skipped optional package"
+    grep -q 'optional package(s) skipped' "$work_dir/out" ||
+        fail "$1 did not summarise what was skipped"
+    grep -q 'hyde-shell luainit' "$work_dir/out" ||
+        fail "$1 did not name the command that retries it"
+}
+
+# A non-zero status on its own would also be satisfied by a broken stub or a
+# misspelled subcommand, so the reason has to be the package that failed.
+expect_required_failure() {
+    grep -q 'CalledProcessError' "$work_dir/out" ||
+        fail "$1 ended for a reason other than the failed package: $(cat "$work_dir/out")"
+}
+
 run_with create '{"bootstrap_install": [{"name": "dkjson", "version": "2.11-1"}, {"name": "unbuildable", "optional": true}]}' ||
     fail "an optional package that failed to build ended the run: $(cat "$work_dir/out")"
-
-grep -q 'unbuildable' "$work_dir/out" ||
-    fail "the skipped optional package was not reported"
+expect_skip_report create
 
 run_with create '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
     fail "a required package that failed to build did not end the run"
+expect_required_failure create
 
 # `hyde-shell luainit` reinstalls through sync rather than create, and falls
 # back to a full rebuild when it fails. Without the same tolerance there, an
@@ -67,9 +85,11 @@ run_with create '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
 # refresh of the environment.
 run_with sync '{"bootstrap_install": [{"name": "dkjson", "version": "2.11-1"}, {"name": "unbuildable", "optional": true}]}' ||
     fail "sync ended the run over an optional package: $(cat "$work_dir/out")"
+expect_skip_report sync
 
 run_with sync '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
     fail "sync did not end the run over a required package"
+expect_required_failure sync
 
 # The shipped list has to mark lgi optional, otherwise the guard above protects
 # nothing on a real installation.

--- a/tests/test_lua_env.sh
+++ b/tests/test_lua_env.sh
@@ -43,23 +43,33 @@ chmod +x "$work_dir/luarocks"
 printf '#!/usr/bin/env sh\nexit 0\n' > "$work_dir/lua"
 chmod +x "$work_dir/lua"
 
-# Runs `create` against a bootstrap list written for the case at hand.
-create_with() {
-    printf '%s\n' "$1" > "$work_dir/lua_env.json"
+# Runs one command against a bootstrap list written for the case at hand.
+run_with() {
+    printf '%s\n' "$2" > "$work_dir/lua_env.json"
     XDG_STATE_HOME="$work_dir/state" \
         LUA="$work_dir/lua" \
         LUAROCKS="$work_dir/luarocks" \
-        python3 "$work_dir/lua_env.py" create >"$work_dir/out" 2>&1
+        python3 "$work_dir/lua_env.py" "$1" >"$work_dir/out" 2>&1
 }
 
-create_with '{"bootstrap_install": [{"name": "dkjson", "version": "2.11-1"}, {"name": "unbuildable", "optional": true}]}' ||
+run_with create '{"bootstrap_install": [{"name": "dkjson", "version": "2.11-1"}, {"name": "unbuildable", "optional": true}]}' ||
     fail "an optional package that failed to build ended the run: $(cat "$work_dir/out")"
 
 grep -q 'unbuildable' "$work_dir/out" ||
     fail "the skipped optional package was not reported"
 
-create_with '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
+run_with create '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
     fail "a required package that failed to build did not end the run"
+
+# `hyde-shell luainit` reinstalls through sync rather than create, and falls
+# back to a full rebuild when it fails. Without the same tolerance there, an
+# unbuildable optional rock would tear the rocks tree down on every routine
+# refresh of the environment.
+run_with sync '{"bootstrap_install": [{"name": "dkjson", "version": "2.11-1"}, {"name": "unbuildable", "optional": true}]}' ||
+    fail "sync ended the run over an optional package: $(cat "$work_dir/out")"
+
+run_with sync '{"bootstrap_install": [{"name": "unbuildable"}]}' &&
+    fail "sync did not end the run over a required package"
 
 # The shipped list has to mark lgi optional, otherwise the guard above protects
 # nothing on a real installation.
@@ -75,6 +85,6 @@ lgi = [e for e in entries if isinstance(e, dict) and "lgi" in e.get("name", "")]
 sys.exit(0 if lgi and lgi[0].get("optional") else 1)
 CHECK
 
-printf '    %d bootstrap case(s) checked\n' 3
+printf "    %d bootstrap case(s) checked\n" 5
 
 finish


### PR DESCRIPTION
# Pull Request

## Description

Fixes #1904.

The install fails at the Lua step with `Failed to create Lua environment`. The output in the report names the cause: `luarocks` builds `lgi` from the upstream rockspec, and the build stops at

```
pkg-config --exists 'gobject-introspection-1.0 >= 0.10.8' --print-errors
Package 'gobject-introspection-1.0' not found
make[1]: *** [Makefile:55: .depcheck] Error 1
Error: Build error: Failed building.
```

Two separate defects meet there.

The build inputs are not declared. `Scripts/dots/deps.toml` lists `lua` and `luarocks`, and nothing that provides `gobject-introspection-1.0.pc` — which is why the dependency step reports "nothing to install" and the Lua step then fails on a system that has every declared package. On Arch that file and the matching headers live in `libgirepository`, which is now declared.

A single rock also decides the fate of the whole install. `install_rock` raises, `create_env` lets it through, and `install.sh` exits, so a machine that cannot build one optional binding never gets its dotfiles — even though `lgi` is already treated as special elsewhere in the same config through `snapshot_exclude`. Bootstrap entries can now mark themselves optional; an optional rock that fails is reported, named in a summary with the command to retry, and skipped, while a required one still stops the run.

`tests/test_lua_env.sh` covers all three statements, driving the module against a stub `luarocks`: an optional failure must not end `create`, it has to be reported, a required failure must still end it, and the shipped bootstrap list has to mark `lgi` optional. Checked in both directions — against this branch it passes, and against the current `dev` module it fails with exactly the traceback from the report.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

Only the Arch list is touched, since that is the platform the report and the package name apply to. The equivalent on Debian and Fedora is `libgirepository1.0-dev` and `gobject-introspection-devel`; if the other package lists should carry it too, say so and it goes in.

A machine that skips `lgi` loses what depends on it — the battery notifier, the dconf colour writer and the notification helper — and keeps everything else. That is the trade the skip is for: a missing optional binding is a degraded desktop, an aborted install is none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability when optional Lua packages, including `lgi`, cannot be built.
  * Failed optional packages are reported and skipped while deployment continues.
  * Required package failures still stop installation as expected.
  * Added support for packages requiring introspection headers.

* **Documentation**
  * Added a changelog entry describing the updated installation behavior.

* **Tests**
  * Added coverage for optional and required package installation failures during environment setup and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->