### PR TITLE
fix: deploy the core dots before the archives

### DIFF
--- a/Scripts/dots-groups/core.toml
+++ b/Scripts/dots-groups/core.toml
@@ -8,14 +8,19 @@
     version     = "0.1.0"
     # dots = ["kitty", "hyprland"] # List of dots to be used in the configuration file
     # We can call it core packages!
+    # Order matters: dots are deployed in the order they are listed here. The
+    # archives download over the network and write into /usr/local under sudo,
+    # which is the most likely thing in this group to fail and the least
+    # important thing in it to have. Everything that makes up the desktop is
+    # deployed before them.
     include = [
         "../dots/deps.toml",
-        "../dots/archives.toml",
         "../dots/hyde.toml",
         "../dots/hyprland.toml",
         "../dots/wallbash.toml",
         "../dots/waybar.toml",
         "../dots/rofi.toml",
+        "../dots/archives.toml",
     ]
 
 # Loads an array of package manager commands

--- a/tests/test_dots.sh
+++ b/tests/test_dots.sh
@@ -20,4 +20,30 @@ if grep -q 'feature-grimblast-toplevel-handle' "$hyde_metafile"; then
     fail "grimblast still uses the double-selection experimental branch"
 fi
 
+# Dots are deployed in the order the group lists them. The archives download
+# over the network and write into /usr/local under sudo, so they are the most
+# likely member of the core group to fail and the least important one to have.
+# Everything the desktop is made of has to be deployed before them.
+core_group="$REPO_ROOT/Scripts/dots-groups/core.toml"
+core_order=$(sed -n '/include = \[/,/^ *\]/p' "$core_group" |
+    sed -n 's|.*"\.\./dots/\([A-Za-z0-9_-]*\)\.toml".*|\1|p')
+
+position_in_core() {
+    printf '%s\n' "$core_order" | grep -nxF "$1" | head -n 1 | cut -d: -f1
+}
+
+archives_at=$(position_in_core archives)
+if [ -z "$archives_at" ]; then
+    fail "the core group no longer includes archives.toml, or the include list could not be read"
+else
+    for required in hyde hyprland; do
+        required_at=$(position_in_core "$required")
+        if [ -z "$required_at" ]; then
+            fail "the core group no longer includes $required.toml"
+        elif [ "$required_at" -gt "$archives_at" ]; then
+            fail "$required.toml is deployed after archives.toml in the core group"
+        fi
+    done
+fi
+
 finish

--- a/tests/test_dots.sh
+++ b/tests/test_dots.sh
@@ -33,6 +33,15 @@ position_in_core() {
 }
 
 archives_at=$(position_in_core archives)
+# The packages the rest of the group needs are installed by the first entry,
+# so it is the one member whose position is fixed rather than merely early.
+deps_at=$(position_in_core deps)
+if [ -z "$deps_at" ]; then
+    fail "the core group no longer includes deps.toml"
+elif [ "$deps_at" -ne 1 ]; then
+    fail "deps.toml is no longer the first entry in the core group"
+fi
+
 if [ -z "$archives_at" ]; then
     fail "the core group no longer includes archives.toml, or the include list could not be read"
 else


### PR DESCRIPTION
Dots are deployed in the order the group lists them, and `core.toml` put `archives.toml` second — ahead of `hyde.toml` and `hyprland.toml`. The archives are the one member of this group that downloads over the network and writes into `/usr/local` under `sudo`, so they are the most likely thing here to fail and the least important thing to have. Everything the desktop is made of was queued behind them.

That ordering is how the `cursor-bibata-modern-ice` failure in #1878 and #1897 cost people their entire configuration: the deployment stopped at the second entry, and `~/.local/lib/hyde`, `~/.config/hypr`, the theme and `lua_state` were never written. HyDE-Project/deez-dots#5 stops one dot from taking the others with it; this puts the important ones first regardless.

`deps.toml` stays where it is — it installs packages the rest of the group needs.

## Checked

No dot in the group declares a dependency on another, and nothing outside `archives.toml` references the cursor or font entries, so the order is free to change. The dependency declarations in `hyprland.toml`, `waybar.toml` and `rofi.toml` are package-manager entries, not dot references.

`tests/test_dots.sh` reads the include list and fails if `hyde.toml` or `hyprland.toml` is listed after `archives.toml`, or if any of the three stops being included at all. Against `dev` the case fails on both files; on this branch the suite is 14 cases, 0 failed.

Part of #1878 and #1897.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved core installation reliability by deploying required desktop components before archives.
  * Reduced potential setup failures caused by premature archive installation.

* **Tests**
  * Added validation to ensure the installation sequence remains correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->