### PR TITLE
fix: finish the restore when a dot fails to deploy

### DIFF
--- a/Scripts/install.sh
+++ b/Scripts/install.sh
@@ -303,6 +303,7 @@ if has_operation "restore"; then
 EOF
 
 	deez_exe="${HOME}/.local/state/hyde/python_env/bin/deez"
+	deploy_failed=0
 
 	#------------------------------------------#
 	# rebuild transient TOML: core deps+nvidia  #
@@ -401,13 +402,26 @@ EOF
 			exit 1
 		}
 
+		# A failed deployment used to end the run here, which cost the user
+		# every step below it — the theme, the wallpaper cache, the migrations,
+		# the services. Those are what bring a partly deployed tree back into
+		# shape, so they are exactly what should still run. The failure is
+		# carried to the end of the restore and reported there.
 		print_log -g "[DEEZ-DOTS] " -b "deploy :: " "Installing core dotfiles..."
-		"${deez_exe}" --source "${cloneDir}" --config "${scrDir}/dots-groups/core.toml" dots --skip-git --deploy all || exit 1
+		"${deez_exe}" --source "${cloneDir}" --config "${scrDir}/dots-groups/core.toml" dots --skip-git --deploy all || {
+			print_log -err "[DEEZ-DOTS] " -crit "ERROR" "Core dotfiles deployed with failures"
+			deploy_failed=1
+		}
 
 		print_log -g "[DEEZ-DOTS] " -b "deploy :: " "Installing extra dotfiles..."
-		"${deez_exe}" --source "${cloneDir}" --config "${scrDir}/dots-groups/extra.toml" dots --skip-git --deploy || exit 1
+		"${deez_exe}" --source "${cloneDir}" --config "${scrDir}/dots-groups/extra.toml" dots --skip-git --deploy || {
+			print_log -err "[DEEZ-DOTS] " -crit "ERROR" "Extra dotfiles deployed with failures"
+			deploy_failed=1
+		}
 
-		print_log -g "[DEEZ-DOTS] " -b "complete :: " "Dotfiles deployed"
+		if [ "${deploy_failed}" -eq 0 ]; then
+			print_log -g "[DEEZ-DOTS] " -b "complete :: " "Dotfiles deployed"
+		fi
 	fi
 
 	"${scrDir}/restore_thm.sh"
@@ -473,6 +487,14 @@ if has_operation "services"; then
 EOF
 
 	"${scrDir}/restore_svc.sh"
+fi
+
+# Reported here rather than where it happened, so the theme, the migrations and
+# the services above still run against the dots that did land.
+if [ "${deploy_failed:-0}" -ne 0 ]; then
+	print_log -err "[DEEZ-DOTS] " -crit "ERROR" "Some dots were not deployed. Deal with the failures reported above and run the restore again."
+	print_log -b "Log" " :: " -y "View logs at ${cacheDir}/logs/${HYDE_LOG}"
+	exit 1
 fi
 
 if has_operation "install"; then

--- a/tests/test_install_restore.sh
+++ b/tests/test_install_restore.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# A dot that fails to deploy must not cost the user the rest of the restore.
+#
+# The theme, the wallpaper cache, the migrations and the services are what put
+# a partly deployed tree back into shape, so they are exactly the steps that
+# have to keep running when a deployment reports failures. The run still has to
+# end non-zero and say so, or a half-migrated install looks like a clean one.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+clone_dir="$work_dir/clone"
+home_dir="$work_dir/home"
+mkdir -p "$clone_dir" "$home_dir"
+cp -a "$REPO_ROOT/Scripts" "$clone_dir/Scripts"
+
+ran_log="$work_dir/ran.log"
+deez_log="$work_dir/deez.log"
+
+# Everything the restore hands off to is a stub that records the fact, so a
+# case can only fail on the flow under test and nothing reaches the machine
+# running the suite.
+for stub in install_env install_pre install_aur install_pst restore_thm restore_svc; do
+    printf '#!/usr/bin/env sh\nprintf "%%s\\n" "%s" >>"%s"\n' "$stub" "$ran_log" \
+        >"$clone_dir/Scripts/$stub.sh"
+    chmod +x "$clone_dir/Scripts/$stub.sh"
+done
+rm -f "$clone_dir/Scripts/migrations"/*.sh
+printf '#!/usr/bin/env sh\nprintf "%%s\\n" "migration" >>"%s"\n' "$ran_log" \
+    >"$clone_dir/Scripts/migrations/v99.9.9.sh"
+chmod +x "$clone_dir/Scripts/migrations/v99.9.9.sh"
+
+mkdir -p "$clone_dir/Configs/.local/lib/hyde/pyutils"
+printf 'import sys\nsys.exit(0)\n' >"$clone_dir/Configs/.local/lib/hyde/pyutils/lua_env.py"
+
+mkdir -p "$home_dir/.local/state/hyde/python_env/bin" "$home_dir/.local/lib/hyde/wallpaper"
+for helper in "wallpaper/cache.sh" "theme.switch.sh" "waybar.py"; do
+    printf '#!/usr/bin/env sh\nexit 0\n' >"$home_dir/.local/lib/hyde/$helper"
+    chmod +x "$home_dir/.local/lib/hyde/$helper"
+done
+
+deez_exe="$home_dir/.local/state/hyde/python_env/bin/deez"
+
+# The stub records every invocation and can be told to fail the core deploy,
+# which is the call that used to end the run.
+write_deez_stub() {
+    {
+        printf '#!/usr/bin/env sh\n'
+        printf 'printf "%%s\\n" "$*" >>"%s"\n' "$deez_log"
+        if [ "$1" = "fail-core" ]; then
+            printf 'case "$*" in\n'
+            printf '    *dots-groups/core.toml*dots*) exit 1 ;;\n'
+            printf 'esac\n'
+        fi
+        printf 'exit 0\n'
+    } >"$deez_exe"
+    chmod +x "$deez_exe"
+}
+
+run_restore() {
+    : >"$ran_log"
+    : >"$deez_log"
+    # A fresh state directory per run: the migration runner records what it
+    # applied, so a shared one would make the second run look like it skipped
+    # the step it was told to repeat.
+    rm -rf "$work_dir/state"
+    (
+        # The run ends by asking about a reboot. Answering keeps the question
+        # from reading EOF, which would end the script on its own.
+        env -u HYPRLAND_INSTANCE_SIGNATURE \
+            HOME="$home_dir" \
+            XDG_STATE_HOME="$work_dir/state" \
+            XDG_CACHE_HOME="$work_dir/cache" \
+            CLONE_DIR="$clone_dir" \
+            "$clone_dir/Scripts/install.sh" -r -s <<<"n"
+    ) >"$work_dir/out.log" 2>&1
+}
+
+ran() { grep -qxF "$1" "$ran_log" 2>/dev/null; }
+
+# A clean deployment: everything runs and the run succeeds.
+write_deez_stub ok
+run_restore
+status=$?
+
+[ "$status" -eq 0 ] || fail "a clean restore exited with $status: $(tail -n 5 "$work_dir/out.log")"
+grep -q 'dots-groups/core.toml' "$deez_log" || fail "a clean restore never deployed the core dots"
+ran restore_thm || fail "a clean restore did not apply the theme"
+ran migration || fail "a clean restore did not run the migrations"
+ran restore_svc || fail "a clean restore did not enable the services"
+
+# The core deployment fails: the remaining steps still run, and the run ends
+# non-zero saying what happened.
+write_deez_stub fail-core
+run_restore
+status=$?
+
+[ "$status" -ne 0 ] || fail "a restore whose core deployment failed reported success"
+grep -q 'dots-groups/extra.toml' "$deez_log" ||
+    fail "a failed core deployment stopped the extra dots from being deployed"
+ran restore_thm || fail "a failed deployment stopped the theme from being applied"
+ran migration || fail "a failed deployment stopped the migrations from running"
+ran restore_svc || fail "a failed deployment stopped the services from being enabled"
+grep -q 'Some dots were not deployed' "$work_dir/out.log" ||
+    fail "a failed deployment did not say so at the end of the run"
+grep -q 'COMPLETED' "$work_dir/out.log" &&
+    fail "a failed deployment still reported the run as completed"
+
+finish


### PR DESCRIPTION
A restore ran the two deploy commands with `|| exit 1`, so any deployment failure ended the run on the spot. What it ended before was the theme, the wallpaper cache, the migrations and the services — the steps that bring a partly deployed tree back into shape. Losing those to one bad dot is a large part of how the installs in #1878 ended up half migrated: the cursor archive failed, and the migration that moves the superseded shell scripts aside never ran.

This is the installer half of HyDE-Project/deez-dots#5. With that change a failing dot is reported by name and the rest of the deployment continues, so what reaches the installer is "some dots did not land", not "nothing happened". The right response to that is to finish the restore and say so at the end, which is what this does:

| | Before | After |
| --- | --- | --- |
| core deployment fails | run ends immediately | reported, extra dots still deployed |
| extra deployment fails | run ends immediately | reported |
| theme, wallpaper cache | skipped | run |
| migrations, services | skipped | run |
| exit status | 1 | 1 |
| final message | none | names the failure and asks for the restore to be run again |
| `COMPLETED!` | not reached | still not printed |

The exit status is unchanged, so anything driving `install.sh` from a script sees the same result. What changes is how much of the restore has happened by then.

## Tests

`tests/test_install_restore.sh` runs the restore twice against a copy of `Scripts/` where every hand-off is a stub — including `deez` itself, so nothing reaches the machine running the suite:

- a clean deployment: core dots deployed, theme applied, migrations run, services enabled, exit 0
- a failing core deployment: extra dots still deployed, theme applied, migrations run, services enabled, exit non-zero, the failure named at the end, and `COMPLETED` absent

Against `dev` the second case fails on all five counts. Suite: 15 cases, 0 failed, `shellcheck --severity=error` clean.

Part of #1878.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restore operations now continue through theme generation, migrations, and service restoration even when a dotfile deployment fails.
  * A final error is reported after the restore completes, with a failure status when any deployment did not succeed.
  * Completion is no longer reported for unsuccessful restores.

* **Tests**
  * Added end-to-end coverage for successful and failed restore scenarios, including continued processing and accurate status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->