### PR TITLE
fix: retire the hyprlang configuration the Lua release left behind

### DIFF
--- a/Scripts/migrations/v26.8.2.sh
+++ b/Scripts/migrations/v26.8.2.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+
+# The Lua release deleted the hyprlang configuration from the repository, but
+# deployment overwrites files and never removes the ones that disappeared
+# upstream. The whole chain is therefore still on every upgraded machine, and
+# it is not inert: Hyprland falls back to "$XDG_CONFIG_HOME/hypr/hyprland.conf"
+# whenever no Lua config is found, and that file sources the rest. A session
+# that lands on it runs the pre-Lua configuration — the battery notification
+# still names a script that was moved aside, and the close-window binds still
+# call one that no longer exists.
+#
+# Nothing is deleted here. Everything is moved into a backup directory, which
+# for most of these files is the only copy of settings the user wrote.
+#
+# This runs only when the Lua entry point is in place. Moving hyprland.conf out
+# of the way while nothing else can be found would leave Hyprland to generate a
+# fresh default config, which is worse than the leftovers.
+
+config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
+data_home="${XDG_DATA_HOME:-${HOME}/.local/share}"
+backup_dir="${XDG_STATE_HOME:-${HOME}/.local/state}/hyde/migration/v26.8.2"
+
+entry_point="${data_home}/hypr/hyde.lua"
+user_config="${config_home}/hypr/hyprland.lua"
+
+# Readable, not merely present: the loader opens this file, and an unreadable
+# one would fail there with the fallback configuration already moved away.
+if [ ! -r "${entry_point}" ]; then
+    echo "  ${entry_point} is missing or unreadable, leaving the hyprlang configuration in place"
+    exit 0
+fi
+
+if [ ! -f "${user_config}" ] || ! grep -q '^if not hyde then$' "${user_config}"; then
+    echo "  ${user_config} does not load HyDE yet, leaving the hyprlang configuration in place"
+    exit 0
+fi
+
+# Paths are relative to the two roots below. The compositor configuration only:
+# hyprlock, hypridle and hyprsunset are still hyprlang and still shipped.
+config_leftovers="
+animations.conf
+hyprland.conf
+keybindings.conf
+monitors.conf
+nvidia.conf
+shaders.conf
+userprefs.conf
+windowrules.conf
+workflows.conf
+animations
+workflows
+"
+
+data_leftovers="
+hypr/defaults.conf
+hypr/dynamic.conf
+hypr/env.conf
+hypr/finale.conf
+hypr/hyprland.conf
+hypr/migration.conf
+hypr/startup.conf
+hypr/variables.conf
+hypr/windowrules.conf
+hyde/hyprland.conf
+hyde/keybindings.conf
+hyde/templates/hypr
+"
+
+moved=0
+failed=0
+
+move_leftover() {
+    src="$1"
+    rel="$2"
+
+    # A link that leads nowhere still occupies a retired path, and it is still
+    # a copy of what the user had. Both tests, or a dangling one is skipped and
+    # the path stays behind forever.
+    [ -e "${src}" ] || [ -L "${src}" ] || return 0
+
+    dst="${backup_dir}/${rel}"
+
+    # A rerun after the file was restored would otherwise destroy the copy kept
+    # by the first run, so an occupied destination is reported and left alone.
+    if [ -e "${dst}" ] || [ -L "${dst}" ]; then
+        echo "  skipped ${rel}, a backup already exists at ${dst}" >&2
+        failed=$((failed + 1))
+        return 0
+    fi
+
+    if ! mkdir -p "$(dirname "${dst}")"; then
+        echo "  failed to create the backup directory for ${rel}" >&2
+        failed=$((failed + 1))
+        return 0
+    fi
+
+    if mv "${src}" "${dst}"; then
+        echo "  moved ${rel}"
+        moved=$((moved + 1))
+    else
+        echo "  failed to move ${rel}" >&2
+        failed=$((failed + 1))
+    fi
+}
+
+for rel in ${config_leftovers}; do
+    move_leftover "${config_home}/hypr/${rel}" "config/hypr/${rel}"
+done
+
+for rel in ${data_leftovers}; do
+    move_leftover "${data_home}/${rel}" "data/${rel}"
+done
+
+if [ "${moved}" -gt 0 ]; then
+    echo "Moved ${moved} hyprlang leftover(s) to ${backup_dir}"
+    echo "They are the only copy of what you had configured before the Lua release."
+fi
+
+if [ "${failed}" -gt 0 ]; then
+    echo "Left ${failed} hyprlang leftover(s) in place" >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/test_hyprlang_leftovers.sh
+++ b/tests/test_hyprlang_leftovers.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# The hyprlang configuration the Lua release deleted is still on every upgraded
+# machine, because deployment overwrites files and never removes the ones that
+# disappeared upstream. It is not inert: Hyprland falls back to hyprland.conf
+# when no Lua config is found, and that file sources the rest, so a session can
+# land on the pre-Lua configuration entirely.
+#
+# The migration moves it aside, and only when the Lua entry point is in place —
+# taking the fallback away while nothing else can be found would leave Hyprland
+# to generate a default config, which is worse than the leftovers.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+migration="$REPO_ROOT/Scripts/migrations/v26.8.2.sh"
+
+if [ ! -f "$migration" ]; then
+    fail "no migration retires the hyprlang configuration"
+    finish
+fi
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+home_dir="$work_dir/home"
+config_home="$work_dir/config"
+data_home="$work_dir/data"
+state_home="$work_dir/state"
+
+leftovers_config="animations.conf hyprland.conf keybindings.conf monitors.conf nvidia.conf shaders.conf userprefs.conf windowrules.conf workflows.conf"
+leftovers_data="hypr/defaults.conf hypr/dynamic.conf hypr/env.conf hypr/finale.conf hypr/hyprland.conf hypr/migration.conf hypr/startup.conf hypr/variables.conf hypr/windowrules.conf hyde/hyprland.conf hyde/keybindings.conf"
+# Still hyprlang, still shipped: these must survive untouched.
+kept_config="hypridle.conf hyprlock.conf hyprsunset.conf"
+
+seed() {
+    rm -rf "$home_dir" "$config_home" "$data_home" "$state_home"
+    mkdir -p "$home_dir" "$config_home/hypr" "$data_home/hypr" "$data_home/hyde" "$state_home"
+
+    for rel in $leftovers_config $kept_config; do
+        printf 'old %s\n' "$rel" >"$config_home/hypr/$rel"
+    done
+    mkdir -p "$config_home/hypr/animations" "$config_home/hypr/workflows" "$config_home/hypr/shaders"
+    printf 'old animation\n' >"$config_home/hypr/animations/theme.conf"
+    printf 'old workflow\n' >"$config_home/hypr/workflows/default.conf"
+    printf 'still shipped\n' >"$config_home/hypr/shaders/wallbash.frag"
+
+    for rel in $leftovers_data; do
+        mkdir -p "$(dirname "$data_home/$rel")"
+        printf 'old %s\n' "$rel" >"$data_home/$rel"
+    done
+    mkdir -p "$data_home/hyde/templates/hypr"
+    printf 'old template\n' >"$data_home/hyde/templates/hypr/keybindings.conf"
+    printf 'still shipped\n' >"$data_home/hypr/hyprlock.conf"
+
+    # The gate: the entry point exists and the user's config loads it.
+    printf 'hyde = hyde or {}\n' >"$data_home/hypr/hyde.lua"
+    printf 'if not hyde then\nend\n' >"$config_home/hypr/hyprland.lua"
+}
+
+run_migration() {
+    (
+        HOME="$home_dir" XDG_CONFIG_HOME="$config_home" XDG_DATA_HOME="$data_home" \
+            XDG_STATE_HOME="$state_home" sh "$migration" </dev/null
+    ) >"$work_dir/out.log" 2>&1
+}
+
+backup="$state_home/hyde/migration/v26.8.2"
+
+# The whole chain is retired, the files still in use are not, and every moved
+# file is recoverable.
+seed
+run_migration
+status=$?
+
+[ "$status" -eq 0 ] || fail "the migration failed on a machine it should act on: $(cat "$work_dir/out.log")"
+
+for rel in $leftovers_config; do
+    [ -e "$config_home/hypr/$rel" ] && fail "$rel was left in place"
+    [ -f "$backup/config/hypr/$rel" ] || fail "$rel was not kept in the backup"
+done
+for rel in $leftovers_data; do
+    [ -e "$data_home/$rel" ] && fail "$rel was left in place"
+    [ -f "$backup/data/$rel" ] || fail "$rel was not kept in the backup"
+done
+[ -e "$config_home/hypr/animations" ] && fail "the animations directory was left in place"
+[ -e "$config_home/hypr/workflows" ] && fail "the workflows directory was left in place"
+[ -e "$data_home/hyde/templates/hypr" ] && fail "the hyprlang templates were left in place"
+
+for rel in $kept_config; do
+    [ -f "$config_home/hypr/$rel" ] || fail "$rel is still hyprlang and still shipped, but was moved"
+done
+[ -f "$config_home/hypr/shaders/wallbash.frag" ] || fail "the shader directory was moved"
+[ -f "$data_home/hypr/hyprlock.conf" ] || fail "the shipped hyprlock config was moved"
+[ -f "$config_home/hypr/hyprland.lua" ] || fail "the Lua config was moved"
+[ -f "$data_home/hypr/hyde.lua" ] || fail "the entry point was moved"
+
+# Nothing to do on a second pass.
+run_migration
+[ "$?" -eq 0 ] || fail "a second run failed"
+
+# No entry point: the fallback has to stay, or the machine is left with nothing
+# to load at all.
+seed
+rm -f "$data_home/hypr/hyde.lua"
+run_migration
+[ "$?" -eq 0 ] || fail "the migration failed instead of skipping without an entry point"
+[ -f "$config_home/hypr/hyprland.conf" ] ||
+    fail "the fallback config was moved with no entry point to replace it"
+
+# An unreadable entry point is no entry point: the loader opens it.
+seed
+chmod 000 "$data_home/hypr/hyde.lua"
+run_migration
+chmod 644 "$data_home/hypr/hyde.lua"
+[ -f "$config_home/hypr/hyprland.conf" ] ||
+    fail "the fallback config was moved while the entry point could not be read"
+
+# The user's config does not load HyDE yet: same reasoning.
+seed
+printf 'hl.config({})\n' >"$config_home/hypr/hyprland.lua"
+run_migration
+[ -f "$config_home/hypr/hyprland.conf" ] ||
+    fail "the fallback config was moved before the user's config could load HyDE"
+
+# A retired path left as a dangling symlink still has to go, or it stays
+# forever and the migration reports success.
+seed
+rm -f "$config_home/hypr/hyprland.conf"
+ln -s "$work_dir/nothing-here.conf" "$config_home/hypr/hyprland.conf"
+run_migration
+[ -e "$config_home/hypr/hyprland.conf" ] || [ -L "$config_home/hypr/hyprland.conf" ] &&
+    fail "a dangling symlink at a retired path was left behind"
+
+finish


### PR DESCRIPTION
The Lua release deleted the hyprlang configuration from the repository, but deployment overwrites files and never removes the ones that disappeared upstream. The whole chain is still on every upgraded machine, and it is not inert — Hyprland falls back to `$XDG_CONFIG_HOME/hypr/hyprland.conf` whenever no Lua config is found, and that file sources the rest.

That is what @realronak is running in #1878. Three of the four symptoms reported there come from it and nothing else:

| Symptom | Where it comes from |
| --- | --- |
| `Executable not found: batterynotify.sh` | `$XDG_DATA_HOME/hypr/variables.conf` line 41 still names the shell script the `v26.7.4` migration moved aside |
| `SUPER + Q` and `ALT + F4` do nothing | `~/.local/share/hyde/keybindings.conf` lines 33-34 still bind them to `hyde-shell dontkillsteam` |
| `hyprctl systeminfo` reports `configProvider: hyprlang` | `~/.config/hypr/hyprland.conf` is what the session loaded |

`v26.7.4` moved the superseded *scripts* aside. Nothing moved the *configuration* that names them, which is why the scripts are gone and the references are not.

## What the migration does

Everything below is moved into `$XDG_STATE_HOME/hyde/migration/v26.8.2`, nothing is deleted — for most of these files that backup is the only copy of settings the user wrote.

| Root | Moved |
| --- | --- |
| `$XDG_CONFIG_HOME/hypr` | `animations.conf`, `hyprland.conf`, `keybindings.conf`, `monitors.conf`, `nvidia.conf`, `shaders.conf`, `userprefs.conf`, `windowrules.conf`, `workflows.conf`, `animations/`, `workflows/` |
| `$XDG_DATA_HOME/hypr` | `defaults.conf`, `dynamic.conf`, `env.conf`, `finale.conf`, `hyprland.conf`, `migration.conf`, `startup.conf`, `variables.conf`, `windowrules.conf` |
| `$XDG_DATA_HOME/hyde` | `hyprland.conf`, `keybindings.conf`, `templates/hypr/` |

The compositor configuration only. `hyprlock.conf`, `hypridle.conf` and `hyprsunset.conf` are still hyprlang and still shipped, as is `hypr/shaders/`.

## The gate

It runs only when the Lua entry point is in place: `$XDG_DATA_HOME/hypr/hyde.lua` readable, and `$XDG_CONFIG_HOME/hypr/hyprland.lua` carrying the loader from #1922. Taking the fallback away while nothing else can be found would leave Hyprland to generate a fresh default config, which is worse than the leftovers. Readable rather than merely present, because the loader opens it.

Depends on #1922 — without the loader the gate never opens.

## Tests

`tests/test_hyprlang_leftovers.sh` builds a machine in the shape described above and checks:

- every retired path is moved and recoverable from the backup
- `hyprlock.conf`, `hypridle.conf`, `hyprsunset.conf`, `hypr/shaders/`, the shipped `hypr/hyprlock.conf`, the Lua config and the entry point are untouched
- a second run does nothing
- no entry point, an unreadable entry point, or a user config that does not load HyDE yet: the fallback stays
- a retired path left as a dangling symlink is moved rather than skipped

Checked in both directions: the case fails against `dev`, and against a copy with the gate removed and the dangling-symlink test dropped it fails on exactly those three points.

Suite: 15 cases, 0 failed. `shellcheck --severity=error` clean.

Part of #1878.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated migration for obsolete Hyprland configuration files.
  * Preserves existing backups and safely handles dangling symbolic links.
  * Reports incomplete migrations and returns a failure status when items cannot be moved.

* **Bug Fixes**
  * Prevents migration from running when required Lua configuration is missing, unreadable, or inactive.
  * Ensures shipped configuration and Lua files remain intact.
  * Supports safe, repeatable migration runs without overwriting backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->