### PR TITLE
#1925 fix: stop requiring an editor HyDE never runs

### DIFF
--- a/Configs/.config/fish/functions/_hyde_editor.fish
+++ b/Configs/.config/fish/functions/_hyde_editor.fish
@@ -1,0 +1,13 @@
+# The editor a selection opens in, discovered rather than chosen. Mirrors
+# Configs/.config/zsh/functions/fzf.zsh: the user's own answer first, then an
+# order of discovery over what this machine already has. HyDE installs none of
+# them.
+function _hyde_editor -d "Print the first usable editor on this machine"
+    for candidate in $EDITOR $VISUAL nvim vim helix hx nano micro emacs
+        if test -n "$candidate"; and type -q -- $candidate
+            echo $candidate
+            return 0
+        end
+    end
+    return 1
+end

--- a/Configs/.config/fish/functions/fzf/ffe.fish
+++ b/Configs/.config/fish/functions/fzf/ffe.fish
@@ -18,8 +18,13 @@ function ffe -d "Find file with fzf and open in Editor"
     set selected_file (find . -maxdepth $max_depth -type f 2>/dev/null | fzf $fzf_options)
 
     if test -n "$selected_file"; and test -f "$selected_file"
+        set editor (_hyde_editor)
+        if test -z "$editor"
+            echo "No editor found. Install one, or set EDITOR in ~/.config/fish/user.fish."
+            return 1
+        end
         cd (dirname $selected_file)
-        nvim (basename $selected_file)
+        $editor (basename $selected_file)
     else
         return 1
     end

--- a/Configs/.config/fish/functions/fzf/ffec.fish
+++ b/Configs/.config/fish/functions/fzf/ffec.fish
@@ -20,8 +20,13 @@ function ffec -d "Fuzzy search by file content and open in Editor"
     set selected_file (grep -irl -- "$grep_pattern" ./ 2>/dev/null | fzf $fzf_options)
 
     if test -n "$selected_file"
+        set editor (_hyde_editor)
+        if test -z "$editor"
+            echo "No editor found. Install one, or set EDITOR in ~/.config/fish/user.fish."
+            return 1
+        end
         cd (dirname $selected_file)
-        nvim (basename $selected_file)
+        $editor (basename $selected_file)
     else
         echo "No file selected or search returned no results."
     end

--- a/Configs/.config/fish/user.fish
+++ b/Configs/.config/fish/user.fish
@@ -35,7 +35,7 @@
 # Add your configurations here
 
 # set EDITOR nvim
-set EDITOR code
+# set EDITOR code
 
 # set aurhelper yay
 set aurhelper yay

--- a/Configs/.config/zsh/.zshrc
+++ b/Configs/.config/zsh/.zshrc
@@ -38,6 +38,6 @@
 #  This is your file 
 # Add your configurations here
 # export EDITOR=nvim
-export EDITOR=code
+# export EDITOR=code
 
 # unset -f command_not_found_handler # Uncomment to prevent searching for commands not found in package manager

--- a/Configs/.config/zsh/functions/fzf.zsh
+++ b/Configs/.config/zsh/functions/fzf.zsh
@@ -55,7 +55,7 @@ _fuzzy_edit_search_file_content() {
         if editor=$(_hyde_editor); then
             "$editor" "$selected_file"
         else
-            echo "No editor found. Install one, or export EDITOR from \$ZDOTDIR/user.zsh."
+            echo "No editor found. Install one, or export EDITOR from \$ZDOTDIR/user.zsh or \$HOME/.user.zsh."
             return 1
         fi
 
@@ -83,7 +83,7 @@ _fuzzy_edit_search_file() {
         if editor=$(_hyde_editor); then
             "$editor" "$selected_file"
         else
-            echo "No editor found. Install one, or export EDITOR from \$ZDOTDIR/user.zsh."
+            echo "No editor found. Install one, or export EDITOR from \$ZDOTDIR/user.zsh or \$HOME/.user.zsh."
             return 1
         fi
     else

--- a/Configs/.config/zsh/functions/fzf.zsh
+++ b/Configs/.config/zsh/functions/fzf.zsh
@@ -1,4 +1,21 @@
 # best fzf aliases ever
+
+# The editor a selection opens in, discovered rather than chosen. The user's own
+# answer comes first; the rest is an order of discovery over what this machine
+# already has. HyDE installs none of them, so a machine with no editor gets a
+# message naming the fix instead of a guess.
+_hyde_editor() {
+    local candidate
+    for candidate in "$EDITOR" "$VISUAL" nvim vim helix hx nano micro emacs; do
+        [[ -n "$candidate" ]] || continue
+        if command -v "$candidate" &>/dev/null; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 _fuzzy_change_directory() {
     local initial_query="$1"
     local selected_dir
@@ -34,11 +51,12 @@ _fuzzy_edit_search_file_content() {
     selected_file=$(grep -irl "${1:-}" ./ | fzf "${fzf_options[@]}")
 
     if [[ -n "$selected_file" ]]; then
-        if command -v "$EDITOR" &>/dev/null; then
-            "$EDITOR" "$selected_file"
+        local editor
+        if editor=$(_hyde_editor); then
+            "$editor" "$selected_file"
         else
-            echo "EDITOR is not specified. using vim.  (you can export EDITOR in ~/.zshrc)"
-            vim "$selected_file"
+            echo "No editor found. Install one, or export EDITOR from \$ZDOTDIR/user.zsh."
+            return 1
         fi
 
     else
@@ -61,11 +79,12 @@ _fuzzy_edit_search_file() {
     selected_file=$(find . -maxdepth $max_depth -type f 2>/dev/null | fzf "${fzf_options[@]}")
 
     if [[ -n "$selected_file" && -f "$selected_file" ]]; then
-        if command -v "$EDITOR" &>/dev/null; then
-            "$EDITOR" "$selected_file"
+        local editor
+        if editor=$(_hyde_editor); then
+            "$editor" "$selected_file"
         else
-            echo "EDITOR is not specified. using vim.  (you can export EDITOR in ~/.zshrc)"
-            vim "$selected_file"
+            echo "No editor found. Install one, or export EDITOR from \$ZDOTDIR/user.zsh."
+            return 1
         fi
     else
         return 1

--- a/Scripts/dots/deps.toml
+++ b/Scripts/dots/deps.toml
@@ -63,7 +63,8 @@ pacman = [
   "firefox", # browser
   "ark", # kde file archiver
   "unzip", # extracting zip files
-  "vim", # terminal text editor
+  # No text editor: HyDE runs none of its own, and the one it configures
+  # (Scripts/dots/wallbash-vim.toml) brings its own vim when it is opted into.
   # * "code", # ide text editor
   "nwg-displays", # monitor management utility
   "fzf", # Command-line fuzzy finder


### PR DESCRIPTION
`vim` sat in the core pacman array, so a restore on a machine that already had an editor stopped to install it and asked for a root password. HyDE runs no editor of its own, so the package was installed and never used.

The three places that do open one were all wrong in the other direction:

| File | Before |
| --- | --- |
| `Configs/.config/zsh/functions/fzf.zsh` | fell back to `vim` when `EDITOR` was unset |
| `Configs/.config/fish/functions/fzf/ffe.fish` | called `nvim` outright |
| `Configs/.config/fish/functions/fzf/ffec.fish` | called `nvim` outright |

`nvim` is not installed by HyDE at any tier, so those two fish helpers have been shipping broken.

## What changed

The dependency entry is gone. The editor is discovered instead: `EDITOR`, then `VISUAL`, then the first of `nvim vim helix hx nano micro emacs` already on the machine, and a message naming the fix when there is none. `_hyde_editor` in `fzf.zsh` and its fish counterpart in `functions/_hyde_editor.fish` are the same list in the same order.

`Configs/.config/zsh/.zshrc:41` exported `EDITOR=code`, pointing at a package the same dependency list deliberately refuses to install (`# * "code"` on the next line) and overriding whatever the user had set in their own profile. It is now commented out, matching the `# export EDITOR=nvim` line above it. Same for `set EDITOR code` in `Configs/.config/fish/user.fish`.

Both of those are `preserve`, so only fresh installs are seeded with the corrected default; the discovery above is what reaches everyone else, since `fzf.zsh` is `sync`.

## What is deliberately left alone

`Scripts/dots/wallbash-vim.toml` keeps declaring `vim` for itself — that dot configures vim, so it genuinely needs it, and it sits in the optional tier where a user opts in. `Configs/.config/hyde/wallbash/always/vim.dcol` keeps working either way: it writes a colour file and needs no binary.

`firefox` is the same class of entry — HyDE launches no browser of its own — but it is a separate call and not what this report is about.

## Checked

- suite: 15 cases, 0 failed
- both shells parse: `bash -n` on the zsh file, `fish -n` on the three fish files
- on a machine with helix and no vim, `_hyde_editor` returns `helix`; before this change the same machine could not finish a restore

Closes #1925


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically selects the first available text editor from configured preferences and supported fallbacks.
  - File-editing commands now use the selected editor across Fish and Zsh environments.

- **Bug Fixes**
  - Displays clear setup guidance when no usable editor is available.
  - Prevents commands from silently defaulting to an unavailable editor.

- **Configuration**
  - Default editor assignments are no longer enforced by shell configuration.
  - The base installation no longer requires Vim as a core dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->