### PR TITLE
#1897 fix: resolve the shipped modules from the entry point's own path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Hyprland: a session started without `HYPRLAND_CONFIG`, such as one launched from a TTY or a display manager, no longer trips emergency mode with `module 'lua.hyde.path' not found`; Hyprland resolves `require` against the directory of the config it picked, so the entry point now finds the modules shipped beside it from its own path instead of from a search path only one of the two entry points provides
 - Weather Applet: Avoid crashes from unknown weather codes or unavailable wttr.in responses.
 - Core: an install no longer ends at the Lua step on a machine that cannot build `lgi`; the introspection headers it compiles against are declared as a dependency, and an optional rock that still fails is reported and skipped instead of taking the run down before any dotfile is deployed
 - Hyprland: a session on a machine with a discrete NVIDIA GPU no longer comes up with a timed-out configuration; driver detection reads `/proc` and `/sys`, and the library directories are found by opening the candidate paths, so the budget Hyprland allows the whole configuration is no longer spent waiting on a subprocess

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
-- Hyprland: a session started without `HYPRLAND_CONFIG`, such as one launched from a TTY or a display manager, no longer trips emergency mode with `module 'lua.hyde.path' not found`; Hyprland resolves `require` against the directory of the config it picked, so the entry point now finds the modules shipped beside it from its own path instead of from a search path only one of the two entry points provides
+- Hyprland: a session started without `HYPRLAND_CONFIG`, from a TTY or a display manager, no longer trips emergency mode with `module 'lua.hyde.path' not found`; the entry point resolves the modules shipped beside it from its own path
 - Fish: `~/.local/bin` reaches `PATH` again, so `hyde-shell` and everything the keybinds call resolve in a fish session; the directory was handed to `fish_add_path` joined to the rest of `PATH` by colons, which is one path that exists nowhere and is dropped without a word
 - Weather Applet: Avoid crashes from unknown weather codes or unavailable wttr.in responses.
 - Core: an install no longer ends at the Lua step on a machine that cannot build `lgi`; the introspection headers it compiles against are declared as a dependency, and an optional rock that still fails is reported and skipped instead of taking the run down before any dotfile is deployed

--- a/Configs/.local/share/hypr/hyde.lua
+++ b/Configs/.local/share/hypr/hyde.lua
@@ -13,28 +13,11 @@
 -- // ██████╔╝╚█████╔╝  ██║░╚███║╚█████╔╝░░░██║░░░  ███████╗██████╔╝██║░░░██║░░░
 -- // ╚═════╝░░╚════╝░  ╚═╝░░╚══╝░╚════╝░░░░╚═╝░░░  ╚══════╝╚═════╝░╚═╝░░░╚═╝░░░
 
--- Hyprland builds the Lua search path from the directory of the config it was
--- started with and prepends nothing else, so a module shipped beside this file
--- is reachable by name only while this file is that config. Since v26.8.1 the
--- entry point is the user's hyprland.lua, which anchors the search path at
--- ~/.config/hypr and leaves nothing here within reach.
---
--- The resolver is therefore loaded by path, and with dofile rather than
--- require. Hyprland wraps require: a module that fails for any reason other
--- than "not found" is logged and answered with an empty table, which would
--- reach the session as an unresolved path several modules later instead of as
--- an error on the line that caused it. The config directory is prepended to
--- the search path as well, so a file the user happens to keep at
--- hypr/hyde/path.lua would answer to the name first. Neither can happen to a
--- dofile of a path this file resolved itself, and registering the result under
--- the name the rest of the tree uses keeps a later require on the same table.
---
--- Everything below loads by name, from the search path this block sets.
-local root =
-	assert(
-		debug.getinfo(1, "S").source:match("^@(.*)/"),
-		"HyDE's entry point was not loaded from a file, so it cannot reach the modules shipped beside it"
-	)
+-- require() resolves against the directory of the config Hyprland was started
+-- with, which since v26.8.1 is the user's hyprland.lua, not this file. The
+-- resolver is therefore loaded by its own path; everything below loads by name
+-- from the search path it sets.
+local root = assert(debug.getinfo(1, "S").source:match("^@(.*)/"), "not loaded from a file")
 
 hyde = hyde or {}
 hyde.path = dofile(root .. "/lua/hyde/path.lua")
@@ -48,7 +31,7 @@ local pkg_paths = {
 	hyde.path.state .. "/hyde/lua_env/share/lua/5.5/?.lua", -- virtual env for lua
 	hyde.path.state .. "/hyde/lua_env/share/lua/5.5/?/init.lua", -- virtual env for lua
 	hyde.path.config .. "/hypr/?.lua", -- expose main users config
-	root .. "/lua/?.lua" -- the tree shipped beside this file, whichever prefix it was installed under
+	root .. "/lua/?.lua" -- this file's own tree, whatever prefix it sits under
 }
 
 package.path = package.path .. ";" .. table.concat(pkg_paths, ";") .. ";"

--- a/Configs/.local/share/hypr/hyde.lua
+++ b/Configs/.local/share/hypr/hyde.lua
@@ -13,8 +13,22 @@
 -- // ██████╔╝╚█████╔╝  ██║░╚███║╚█████╔╝░░░██║░░░  ███████╗██████╔╝██║░░░██║░░░
 -- // ╚═════╝░░╚════╝░  ╚═╝░░╚══╝░╚════╝░░░░╚═╝░░░  ╚══════╝╚═════╝░╚═╝░░░╚═╝░░░
 
+-- Hyprland anchors require() at the directory of the config it was started
+-- with, and nowhere else, so a module shipped beside this file is reachable by
+-- name only while this file is that config. Since v26.8.1 the entry point is
+-- the user's hyprland.lua, which anchors the search path at ~/.config/hypr and
+-- puts nothing here within reach. The bootstrap therefore comes off this
+-- file's own path; everything after it loads by name from the search path this
+-- block sets, so this is the only place that may not rely on one.
+local root =
+	assert(
+		debug.getinfo(1, "S").source:match("^@(.*)/"),
+		"HyDE's entry point was not loaded from a file, so it cannot reach the modules shipped beside it"
+	)
+
 hyde = hyde or {}
-hyde.path = require("lua.hyde.path")
+hyde.path = dofile(root .. "/lua/hyde/path.lua")
+package.loaded["hyde.path"] = hyde.path
 
 local pkg_paths = {
 	hyde.path.state .. "/hyde/?.lua", -- Lua state
@@ -23,7 +37,8 @@ local pkg_paths = {
 	hyde.path.share .. "/hypr/lua/?.lua",
 	hyde.path.state .. "/hyde/lua_env/share/lua/5.5/?.lua", -- virtual env for lua
 	hyde.path.state .. "/hyde/lua_env/share/lua/5.5/?/init.lua", -- virtual env for lua
-	hyde.path.config .. "/hypr/?.lua" -- expose main users config
+	hyde.path.config .. "/hypr/?.lua", -- expose main users config
+	root .. "/lua/?.lua" -- the tree shipped beside this file, whichever prefix it was installed under
 }
 
 package.path = package.path .. ";" .. table.concat(pkg_paths, ";") .. ";"

--- a/Configs/.local/share/hypr/hyde.lua
+++ b/Configs/.local/share/hypr/hyde.lua
@@ -13,13 +13,23 @@
 -- // ██████╔╝╚█████╔╝  ██║░╚███║╚█████╔╝░░░██║░░░  ███████╗██████╔╝██║░░░██║░░░
 -- // ╚═════╝░░╚════╝░  ╚═╝░░╚══╝░╚════╝░░░░╚═╝░░░  ╚══════╝╚═════╝░╚═╝░░░╚═╝░░░
 
--- Hyprland anchors require() at the directory of the config it was started
--- with, and nowhere else, so a module shipped beside this file is reachable by
--- name only while this file is that config. Since v26.8.1 the entry point is
--- the user's hyprland.lua, which anchors the search path at ~/.config/hypr and
--- puts nothing here within reach. The bootstrap therefore comes off this
--- file's own path; everything after it loads by name from the search path this
--- block sets, so this is the only place that may not rely on one.
+-- Hyprland builds the Lua search path from the directory of the config it was
+-- started with and prepends nothing else, so a module shipped beside this file
+-- is reachable by name only while this file is that config. Since v26.8.1 the
+-- entry point is the user's hyprland.lua, which anchors the search path at
+-- ~/.config/hypr and leaves nothing here within reach.
+--
+-- The resolver is therefore loaded by path, and with dofile rather than
+-- require. Hyprland wraps require: a module that fails for any reason other
+-- than "not found" is logged and answered with an empty table, which would
+-- reach the session as an unresolved path several modules later instead of as
+-- an error on the line that caused it. The config directory is prepended to
+-- the search path as well, so a file the user happens to keep at
+-- hypr/hyde/path.lua would answer to the name first. Neither can happen to a
+-- dofile of a path this file resolved itself, and registering the result under
+-- the name the rest of the tree uses keeps a later require on the same table.
+--
+-- Everything below loads by name, from the search path this block sets.
 local root =
 	assert(
 		debug.getinfo(1, "S").source:match("^@(.*)/"),

--- a/tests/lua/config_entry_harness.lua
+++ b/tests/lua/config_entry_harness.lua
@@ -1,0 +1,94 @@
+-- Loads the shipped Hyprland entry point the way Hyprland loads it, and checks
+-- that it can still reach the modules shipped beside it.
+--
+-- Hyprland builds package.path from the directory of the config it was started
+-- with and prepends nothing else, so which files a bare require() can see
+-- depends entirely on which file the session was pointed at. HyDE is reachable
+-- through two of them: hyde.lua directly, which is what HYPRLAND_CONFIG names,
+-- and the user's hyprland.lua, which is what Hyprland picks on its own. Only
+-- the first puts the shipped tree on the search path, so the bootstrap has to
+-- resolve it without one.
+--
+-- Usage:
+--   lua config_entry_harness.lua <entry> <anchor> <root>
+--
+--   entry   config file to load, as Hyprland would
+--   anchor  directory Hyprland would anchor the search path at
+--   root    directory the shipped Lua tree has to be reachable under
+
+local entry = assert(arg[1], "entry point is not set")
+local anchor = assert(arg[2], "anchor directory is not set")
+local root = assert(arg[3], "shipped root is not set")
+
+package.path = anchor .. "/?.lua;" .. anchor .. "/?/init.lua;" .. package.path
+
+-- Only the bootstrap is under test. Everything the entry point pulls in after
+-- it wants a live compositor, so the first require issued once the search path
+-- is in place ends the load and records where it got to. A run that never
+-- reaches one is a run that stopped earlier, which is the defect this case
+-- exists for.
+--
+-- Extending the search path is what separates the two: anything required
+-- before that is the bootstrap resolving itself, and has to succeed on its own
+-- terms rather than be answered by this harness.
+local STOP = "stopped-at:"
+local bootstrap_path = package.path
+local real_require = require
+local stopped_at
+
+_G.require = function(name)
+    if package.path == bootstrap_path then
+        return real_require(name)
+    end
+
+    stopped_at = name
+    error(STOP .. name, 0)
+end
+
+local failures = 0
+
+local function check(condition, message)
+    if not condition then
+        failures = failures + 1
+        print("    fail: " .. message)
+    end
+end
+
+local ok, err = pcall(dofile, entry)
+
+check(not ok, "the entry point loaded past its first require without a compositor")
+check(
+    stopped_at ~= nil,
+    string.format("%s stopped before the first require: %s", entry, tostring(err))
+)
+check(
+    stopped_at == "hyde.utils",
+    string.format(
+        "the bootstrap did not complete: the load stopped at %q instead of the first module after it",
+        tostring(stopped_at)
+    )
+)
+
+-- The resolver is what every later path is built from, so an entry point that
+-- reaches it but leaves it half filled is no better than one that never did.
+check(type(hyde) == "table" and type(hyde.path) == "table", "hyde.path was not populated")
+
+if type(hyde) == "table" and type(hyde.path) == "table" then
+    for _, field in ipairs({"config", "state", "data", "share", "lib"}) do
+        check(type(hyde.path[field]) == "string", string.format("hyde.path.%s was not resolved", field))
+    end
+
+    check(
+        package.loaded["hyde.path"] == hyde.path,
+        "the resolver was not registered as a module, so requiring it by name loads a second copy"
+    )
+end
+
+check(
+    package.path:find(root .. "/lua/?.lua", 1, true) ~= nil,
+    string.format("%s/lua is not on the search path, the modules below the entry point cannot load", root)
+)
+
+if failures > 0 then
+    os.exit(1)
+end

--- a/tests/lua/config_entry_harness.lua
+++ b/tests/lua/config_entry_harness.lua
@@ -1,12 +1,6 @@
--- Loads the shipped Hyprland entry point the way Hyprland loads it, and checks
--- that it can still reach the modules shipped beside it.
---
--- Hyprland builds package.path from the directory of the config it was started
--- with and prepends nothing else, so which files a bare require() can see
--- depends entirely on which file the session was pointed at. HyDE is reachable
--- through two of them: hyde.lua directly, which is what HYPRLAND_CONFIG names,
--- and the user's hyprland.lua, which is what Hyprland picks on its own. Only
--- the first puts the shipped tree on the search path, so the bootstrap has to
+-- Loads the shipped entry point with the search path Hyprland would give it,
+-- and checks it can still reach the modules beside it. Only one of the two
+-- entry points puts that tree on the search path, so the bootstrap has to
 -- resolve it without one.
 --
 -- Usage:
@@ -22,15 +16,9 @@ local root = assert(arg[3], "shipped root is not set")
 
 package.path = anchor .. "/?.lua;" .. anchor .. "/?/init.lua;" .. package.path
 
--- Only the bootstrap is under test. Everything the entry point pulls in after
--- it wants a live compositor, so the first require issued once the search path
--- is in place ends the load and records where it got to. A run that never
--- reaches one is a run that stopped earlier, which is the defect this case
--- exists for.
---
--- Extending the search path is what separates the two: anything required
--- before that is the bootstrap resolving itself, and has to succeed on its own
--- terms rather than be answered by this harness.
+-- Only the bootstrap is under test: the rest wants a live compositor. A
+-- require issued once the search path is in place ends the load; one issued
+-- before that is the bootstrap resolving itself and has to succeed on its own.
 local STOP = "stopped-at:"
 local bootstrap_path = package.path
 local real_require = require
@@ -69,8 +57,8 @@ check(
     )
 )
 
--- The resolver is what every later path is built from, so an entry point that
--- reaches it but leaves it half filled is no better than one that never did.
+-- Every later path is built from the resolver, so reaching it half filled is
+-- no better than never reaching it.
 check(type(hyde) == "table" and type(hyde.path) == "table", "hyde.path was not populated")
 
 if type(hyde) == "table" and type(hyde.path) == "table" then

--- a/tests/test_lua_entry_point.sh
+++ b/tests/test_lua_entry_point.sh
@@ -125,4 +125,43 @@ layer_runs=$(XDG_DATA_HOME="$work_dir/data" lua -e "
 " 2>/dev/null | tail -n 1)
 [ "$layer_runs" = "0" ] || fail "the loader ran again while HyDE was loading this file, got '$layer_runs'"
 
+# Reaching HyDE is half of it. Hyprland builds the Lua search path from the
+# directory of the config it was started with and prepends nothing else, so an
+# entry point that resolves the modules shipped beside it by name works from
+# one of the two files and takes the session down from the other — with no
+# window on screen to report it from. Both are loaded here the way Hyprland
+# loads them, against the real tree rather than the stub above.
+harness="$TESTS_DIR/lua/config_entry_harness.lua"
+shipped="$REPO_ROOT/Configs/.local/share/hypr"
+
+[ -f "$harness" ] || {
+    fail "the entry point harness is missing"
+    finish
+}
+
+deployed="$work_dir/deployed"
+mkdir -p "$deployed/.config/hypr" "$deployed/.local/share"
+cp -R "$shipped" "$deployed/.local/share/hypr"
+cp "$template" "$deployed/.config/hypr/hyprland.lua"
+
+# The cases below would pass for the wrong reason if the config directory
+# carried a copy of the shipped tree: the anchored search path would find it.
+[ -e "$deployed/.config/hypr/lua" ] &&
+    fail "the config directory ships a Lua tree, the two entry points cannot be told apart"
+
+load_entry() {
+    env -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME HOME="$deployed" \
+        lua "$harness" "$1" "$2" "$deployed/.local/share/hypr"
+}
+
+# Started with no HYPRLAND_CONFIG: Hyprland picks the user's config and anchors
+# the search path there, where nothing HyDE ships can be reached by name.
+load_entry "$deployed/.config/hypr/hyprland.lua" "$deployed/.config/hypr" ||
+    fail "the entry point does not hold when Hyprland picks the user config"
+
+# Started through HYPRLAND_CONFIG, which names the entry point directly. This
+# is the path the shell drop-ins and the uwsm environment take.
+load_entry "$deployed/.local/share/hypr/hyde.lua" "$deployed/.local/share/hypr" ||
+    fail "the entry point does not hold when HYPRLAND_CONFIG names it"
+
 finish

--- a/tests/test_lua_entry_point.sh
+++ b/tests/test_lua_entry_point.sh
@@ -125,12 +125,10 @@ layer_runs=$(XDG_DATA_HOME="$work_dir/data" lua -e "
 " 2>/dev/null | tail -n 1)
 [ "$layer_runs" = "0" ] || fail "the loader ran again while HyDE was loading this file, got '$layer_runs'"
 
-# Reaching HyDE is half of it. Hyprland builds the Lua search path from the
-# directory of the config it was started with and prepends nothing else, so an
-# entry point that resolves the modules shipped beside it by name works from
-# one of the two files and takes the session down from the other — with no
-# window on screen to report it from. Both are loaded here the way Hyprland
-# loads them, against the real tree rather than the stub above.
+# Reaching HyDE is half of it. The search path comes from the directory of the
+# config Hyprland was started with, so an entry point that resolves its modules
+# by name works from one of the two files and takes the session down from the
+# other. Both are loaded here against the real tree, not the stub above.
 harness="$TESTS_DIR/lua/config_entry_harness.lua"
 shipped="$REPO_ROOT/Configs/.local/share/hypr"
 
@@ -154,13 +152,11 @@ load_entry() {
         lua "$harness" "$1" "$2" "$deployed/.local/share/hypr"
 }
 
-# Started with no HYPRLAND_CONFIG: Hyprland picks the user's config and anchors
-# the search path there, where nothing HyDE ships can be reached by name.
+# No HYPRLAND_CONFIG: Hyprland picks the user's config.
 load_entry "$deployed/.config/hypr/hyprland.lua" "$deployed/.config/hypr" ||
     fail "the entry point does not hold when Hyprland picks the user config"
 
-# Started through HYPRLAND_CONFIG, which names the entry point directly. This
-# is the path the shell drop-ins and the uwsm environment take.
+# HYPRLAND_CONFIG names the entry point, as the shell drop-ins and uwsm do.
 load_entry "$deployed/.local/share/hypr/hyde.lua" "$deployed/.local/share/hypr" ||
     fail "the entry point does not hold when HYPRLAND_CONFIG names it"
 


### PR DESCRIPTION
Closes the remaining half of #1897.

Hyprland builds the Lua search path from the directory of the config it was started with and prepends nothing else — [`Lua::CConfigManager`](https://github.com/hyprwm/Hyprland/blob/main/src/config/lua/ConfigManager.cpp) does `configDir = path(m_mainConfigPath).parent_path()` and puts `configDir/?.lua;configDir/?/init.lua` in front of `package.path`. Which files a bare `require()` can see therefore depends entirely on which file the session was pointed at.

HyDE is reachable through two of them, and since #1922 both are live:

| Entry point | Search path anchored at | `require("lua.hyde.path")` |
| --- | --- | --- |
| `~/.local/share/hypr/hyde.lua`, named by `HYPRLAND_CONFIG` | `~/.local/share/hypr` | resolves |
| `~/.config/hypr/hyprland.lua`, what Hyprland picks on its own | `~/.config/hypr` | not found |

The second one is what a session started from a TTY or a display manager gets, and it ends the way it was reported in #1897:

```
Emergency mode tripped: A lua config error resulted in no binds being registered.
/home/timeslayer/.local/share/hypr/hyde.lua:17: module 'lua.hyde.path' not found:
no file '/home/timeslayer/.config/hypr/lua/hyde/path.lua'
```

The resolver is what every later path is built from, so it is the one module that may not be reached through a search path it has not set up yet. It now comes off the entry point's own location, which `debug.getinfo` reports for both entry points because Hyprland loads the config with `luaL_loadfile`. The module is registered under the name the rest of the tree uses, so requiring `hyde.path` later returns the same table rather than a second copy. That location also joins `pkg_paths` as the last entry, which makes a system-wide install find its own tree when `XDG_DATA_HOME` exists but holds no HyDE.

Nothing about the modules loaded after it changes: they still load by name, from the search path this block sets.

## Tests

`tests/test_lua_entry_point.sh` already covered the loader and its migration against a stub. It now also loads the real tree the way Hyprland loads it, from both entry points, and checks that the bootstrap completes, that every `hyde.path` field is resolved, that the resolver is registered once, and that the shipped tree is on the search path.

Against this branch:

```
test_lua_entry_point
  ok
```

Against `dev`, the first entry point reproduces the report verbatim:

```
fail: /tmp/.../.config/hypr/hyprland.lua stopped before the first require:
      module 'lua.hyde.path' not found: no file '/tmp/.../.config/hypr/lua/hyde/path.lua'
fail: hyde.path was not populated
fail: .../hypr/lua is not on the search path, the modules below the entry point cannot load
```

Full suite: 18 cases, 1 failed — `test_git` reports `Configs/.config/zsh/ohmyzsh is a gitlink but the tree has no .gitmodules`. That arrived with 8fcdb37d on `dev` and is untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Hyprland sessions without `HYPRLAND_CONFIG` failing to start in emergency mode.
  * HyDE now correctly locates Lua modules relative to the selected configuration file, including alternate entry points.
  * Improved reliability when loading `hyde.path` and other bundled HyDE modules.
  * Prevented configuration setups from requiring a duplicated Lua module tree.
  * Improved startup consistency across deployed and direct configuration locations.
  * Added coverage to verify module loading across supported configuration entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->