### PR TITLE
#1931 fix: put the user's bin directory on PATH in fish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install test dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends lua5.4 shellcheck
+          sudo apt-get install -y --no-install-recommends lua5.4 shellcheck fish
           sudo ln -sf /usr/bin/lua5.4 /usr/local/bin/lua
           sudo ln -sf /usr/bin/luac5.4 /usr/local/bin/luac
 
@@ -32,6 +32,7 @@ jobs:
         run: |
           lua -v
           shellcheck --version
+          fish --version
           python3 --version
 
       - name: Run the test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Fish: `~/.local/bin` reaches `PATH` again, so `hyde-shell` and everything the keybinds call resolve in a fish session; the directory was handed to `fish_add_path` joined to the rest of `PATH` by colons, which is one path that exists nowhere and is dropped without a word
 - Weather Applet: Avoid crashes from unknown weather codes or unavailable wttr.in responses.
 - Core: an install no longer ends at the Lua step on a machine that cannot build `lgi`; the introspection headers it compiles against are declared as a dependency, and an optional rock that still fails is reported and skipped instead of taking the run down before any dotfile is deployed
 - Hyprland: a session on a machine with a discrete NVIDIA GPU no longer comes up with a timed-out configuration; driver detection reads `/proc` and `/sys`, and the library directories are found by opening the candidate paths, so the budget Hyprland allows the whole configuration is no longer spent waiting on a subprocess

--- a/Configs/.config/fish/conf.d/hyde.fish
+++ b/Configs/.config/fish/conf.d/hyde.fish
@@ -82,7 +82,10 @@ end
 end
 end
 
-fish_add_path $HOME/.local/bin:$PATH
+# One directory per argument: fish_add_path does not split on ":", so a
+# colon-joined string is a single path that exists nowhere, and a path that
+# does not exist is dropped without a word.
+fish_add_path $HOME/.local/bin
 
 
 if type -q starship

--- a/tests/test_fish_env.sh
+++ b/tests/test_fish_env.sh
@@ -16,7 +16,10 @@ drop_in="$REPO_ROOT/Configs/.config/fish/conf.d/hyde.fish"
     finish
 }
 
-if ! command -v fish >/dev/null 2>&1; then
+# Resolved here rather than called by name below: the run is started with a
+# PATH of its own, and a fish installed anywhere but there would not be found.
+fish_bin=$(command -v fish 2>/dev/null)
+if [ -z "$fish_bin" ]; then
     skip "fish is not installed"
     finish
 fi
@@ -37,16 +40,19 @@ path_entries=$(
         XDG_CONFIG_HOME="$work_dir/config" \
         PATH=/usr/bin:/bin \
         TERM=dumb \
-        fish -c "source '$drop_in' 2>/dev/null; for entry in \$PATH; echo \$entry; end" 2>/dev/null
+        "$fish_bin" -c "source '$drop_in' 2>/dev/null; for entry in \$PATH; echo \$entry; end" 2>/dev/null
 )
 
 printf '%s\n' "$path_entries" | grep -qxF "$home/.local/bin" ||
     fail "the drop-in did not put ~/.local/bin on PATH, so no HyDE command resolves in fish"
 
 # The failure this case exists for leaves a single entry holding the whole
-# joined string, which is a path in name only.
-printf '%s\n' "$path_entries" | grep -q ':' &&
-    fail "PATH holds a colon-joined entry, which is one path that exists nowhere"
+# joined string, which is a path in name only. Only the entries this drop-in
+# contributes are judged; what the machine's own fish configuration puts on
+# PATH is not this file's business.
+stray=$(printf '%s\n' "$path_entries" | grep "^$home" | grep ':')
+[ -n "$stray" ] &&
+    fail "PATH holds a colon-joined entry, which is one path that exists nowhere: $stray"
 
 printf '    %d PATH entry(ies) checked\n' "$(printf '%s\n' "$path_entries" | grep -c .)"
 

--- a/tests/test_fish_env.sh
+++ b/tests/test_fish_env.sh
@@ -31,9 +31,10 @@ home="$work_dir/home"
 mkdir -p "$home/.local/bin" "$work_dir/data" "$work_dir/config"
 
 # An isolated home keeps the universal variables fish_add_path writes out of
-# the one running the suite. The drop-in reaches for functions that live
-# elsewhere in the shipped config, past the line under test, so its diagnostics
-# are dropped rather than the whole file being pulled in.
+# the one running the suite. Past the line under test the drop-in calls a
+# function defined elsewhere in the shipped config, which is not sourced here;
+# fish reports that on stderr and carries on, so stderr is discarded rather
+# than the rest of the configuration being pulled in to silence it.
 path_entries=$(
     env -i HOME="$home" \
         XDG_DATA_HOME="$work_dir/data" \

--- a/tests/test_fish_env.sh
+++ b/tests/test_fish_env.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+# Everything HyDE installs for the user lives in ~/.local/bin, so the fish
+# drop-in has to put that directory on PATH. It is easy to get wrong in a way
+# nothing reports: fish_add_path takes one directory per argument, does not
+# split on ":", and drops a path that does not exist without a word. A
+# colon-joined string therefore adds nothing at all and the shell comes up
+# looking healthy with no hyde-shell in it.
+
+# shellcheck source=tests/lib/common.sh
+. "$(dirname -- "$0")/lib/common.sh"
+
+drop_in="$REPO_ROOT/Configs/.config/fish/conf.d/hyde.fish"
+
+[ -f "$drop_in" ] || {
+    fail "the fish drop-in is missing"
+    finish
+}
+
+if ! command -v fish >/dev/null 2>&1; then
+    skip "fish is not installed"
+    finish
+fi
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+home="$work_dir/home"
+mkdir -p "$home/.local/bin" "$work_dir/data" "$work_dir/config"
+
+# An isolated home keeps the universal variables fish_add_path writes out of
+# the one running the suite. The drop-in reaches for functions that live
+# elsewhere in the shipped config, past the line under test, so its diagnostics
+# are dropped rather than the whole file being pulled in.
+path_entries=$(
+    env -i HOME="$home" \
+        XDG_DATA_HOME="$work_dir/data" \
+        XDG_CONFIG_HOME="$work_dir/config" \
+        PATH=/usr/bin:/bin \
+        TERM=dumb \
+        fish -c "source '$drop_in' 2>/dev/null; for entry in \$PATH; echo \$entry; end" 2>/dev/null
+)
+
+printf '%s\n' "$path_entries" | grep -qxF "$home/.local/bin" ||
+    fail "the drop-in did not put ~/.local/bin on PATH, so no HyDE command resolves in fish"
+
+# The failure this case exists for leaves a single entry holding the whole
+# joined string, which is a path in name only.
+printf '%s\n' "$path_entries" | grep -q ':' &&
+    fail "PATH holds a colon-joined entry, which is one path that exists nowhere"
+
+printf '    %d PATH entry(ies) checked\n' "$(printf '%s\n' "$path_entries" | grep -c .)"
+
+finish


### PR DESCRIPTION
Closes #1931.

On fish no HyDE command resolves, which is what was reported from a live session in #1897:

```
$ hyde-shell version
fish: Unknown command: hyde-shell
```

`Configs/.config/fish/conf.d/hyde.fish:85` read

```fish
fish_add_path $HOME/.local/bin:$PATH
```

`fish_add_path` takes one directory per argument and does not split on `:`. The whole joined string is therefore a single path named `/home/you/.local/bin:/usr/bin:/bin:…`, which exists nowhere, and a path that does not exist is dropped without a word. `~/.local/bin` never reaches `PATH`, so `hyde-shell`, `hydectl` and every wrapper the keybinds call are reachable only from a session that already had the directory there for some other reason. The zsh drop-in gets this right in `conf.d/hyde/env.zsh`.

Checked against fish 4.8.1:

| Call | PATH afterwards |
| --- | --- |
| `fish_add_path $HOME/.local/bin:$PATH` | unchanged |
| `fish_add_path $HOME/.local/bin` | the directory, first |

## Tests

`tests/test_fish_env.sh` is new. It sources the shipped drop-in in an isolated home — so the universal variables `fish_add_path` writes stay out of the one running the suite — and checks that `~/.local/bin` is on `PATH` and that no entry holds a colon-joined string, which is the shape of this defect. It skips where fish is not installed.

Against this branch:

```
test_fish_env
    4 PATH entry(ies) checked
  ok
```

Against `dev`:

```
test_fish_env
    fail: the drop-in did not put ~/.local/bin on PATH, so no HyDE command resolves in fish
```

The suite here reports 19 cases with one failure, `test_git`, which is the checkout breakage #1930 covers and is untouched by this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored `~/.local/bin` to the Fish shell `PATH`, allowing `hyde-shell` and keybind commands to resolve correctly.
  - Ensured PATH entries are handled separately for more reliable Fish sessions.

- **Tests**
  - Added coverage to verify Fish PATH configuration and prevent incorrectly joined entries.

- **Documentation**
  - Documented Fish PATH handling behavior in the configuration changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->