### PR TITLE
fix: read monitor scale as a number, not by stripping the dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Theme, wallpaper and rofi selectors show a usable grid again on Hyprland 0.56.2, which reports a whole-number monitor scale; the pickers were reading that as a hundredth of its value and laying out hundreds of columns
 - Hyprland: a session started without `HYPRLAND_CONFIG`, from a TTY or a display manager, no longer trips emergency mode with `module 'lua.hyde.path' not found`; the entry point resolves the modules shipped beside it from its own path
 - Fish: `~/.local/bin` reaches `PATH` again, so `hyde-shell` and everything the keybinds call resolve in a fish session; the directory was handed to `fish_add_path` joined to the rest of `PATH` by colons, which is one path that exists nowhere and is dropped without a word
 - Weather Applet: Avoid crashes from unknown weather codes or unavailable wttr.in responses.

--- a/Configs/.local/lib/hyde/rofiselect.sh
+++ b/Configs/.local/lib/hyde/rofiselect.sh
@@ -13,6 +13,8 @@ icon_border=$((elem_border - 5))
 mon_data=$(hyprctl -j monitors)
 mon_x_res=$(jq '.[] | select(.focused==true) | if (.transform % 2 == 0) then .width else .height end' <<< "$mon_data")
 mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data" | awk '{printf "%d", ($1>0 ? $1*100 : 100)}')
+mon_x_res=${mon_x_res:-1920}
+mon_scale=${mon_scale:-100}
 mon_x_res=$((mon_x_res * 100 / mon_scale))
 elm_width=$(((20 + 12 + 16) * font_scale))
 max_avail=$((mon_x_res - (4 * font_scale)))

--- a/Configs/.local/lib/hyde/rofiselect.sh
+++ b/Configs/.local/lib/hyde/rofiselect.sh
@@ -12,16 +12,16 @@ elem_border=$((hypr_border * 5))
 icon_border=$((elem_border - 5))
 mon_data=$(hyprctl -j monitors)
 mon_x_res=$(jq '.[] | select(.focused==true) | if (.transform % 2 == 0) then .width else .height end' <<< "$mon_data")
-mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data" | sed "s/\.//")
+mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data" | awk '{printf "%d", ($1>0 ? $1*100 : 100)}')
 mon_x_res=$((mon_x_res * 100 / mon_scale))
 elm_width=$(((20 + 12 + 16) * font_scale))
 max_avail=$((mon_x_res - (4 * font_scale)))
 col_count=$((max_avail / elm_width))
 [[ $col_count -gt 5 ]] && col_count=5
-r_override="window{width:100%;} 
+r_override="window{width:100%;}
     listview{columns:$col_count;}
     element{orientation:vertical;border-radius:${elem_border}px;}
-    element-icon{border-radius:${icon_border}px;size:20em;} 
+    element-icon{border-radius:${icon_border}px;size:20em;}
     element-text{enabled:false;}"
 RofiSel=$(find -L "$rofiStyleDir" -type f -exec grep -l "Attr.*launcher.*" {} \; | while
     read -r file

--- a/Configs/.local/lib/hyde/theme.select.sh
+++ b/Configs/.local/lib/hyde/theme.select.sh
@@ -7,11 +7,11 @@ hypr_border=${hypr_border:-2}
 if [[ -n $HYPRLAND_INSTANCE_SIGNATURE ]]; then
     mon_data=$(hyprctl -j monitors)
     mon_x_res=$(jq '.[] | select(.focused==true) | if (.transform % 2 == 0) then .width else .height end' <<< "$mon_data")
-    mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data" | sed "s/\.//")
+    mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data" | awk '{printf "%d", ($1>0 ? $1*100 : 100)}')
 fi
 
 mon_x_res=${mon_x_res:-1920}
-mon_scale=${mon_scale:-1}
+mon_scale=${mon_scale:-100}
 mon_x_res=$((mon_x_res * 100 / mon_scale))
 
 selector_menu() {

--- a/Configs/.local/lib/hyde/wallpaper/select.sh
+++ b/Configs/.local/lib/hyde/wallpaper/select.sh
@@ -12,10 +12,10 @@ Wall_Select() {
     if [ -n "$HYPRLAND_INSTANCE_SIGNATURE" ]; then
         mon_data=$(hyprctl -j monitors)
         mon_x_res=$(jq '.[] | select(.focused==true) | if (.transform % 2 == 0) then .width else .height end' <<<"$mon_data")
-        mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<<"$mon_data" | sed "s/\.//")
+        mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<<"$mon_data" | awk '{printf "%d", ($1>0 ? $1*100 : 100)}')
     fi
     mon_x_res=${mon_x_res:-1920}
-    mon_scale=${mon_scale:-1}
+    mon_scale=${mon_scale:-100}
     mon_x_res=$((mon_x_res * 100 / mon_scale))
     elm_width=$(((28 + 8 + 5) * font_scale))
     max_avail=$((mon_x_res - (4 * font_scale)))


### PR DESCRIPTION
## Description

Fixes #1946.

The theme, wallpaper and rofi selectors derive their rofi column count from the focused monitor's scale, converting it to a percentage by deleting the decimal point:

```bash
mon_scale=$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data" | sed "s/\.//")
mon_x_res=$((mon_x_res * 100 / mon_scale))
```

That relies on `hyprctl -j monitors` printing `1.00`. **Hyprland 0.56.2 prints `1`** — an integer, no decimal point:

```console
$ hyprctl monitors -j | jq '.[] | select(.focused==true) | .scale'
1
```

`sed` finds no dot, `mon_scale` stays `1`, and the width is inflated a hundredfold: `1920 * 100 / 1 = 192000`. With `elm_width = (23+12+1) * 10 * 2 = 720` that asks rofi for `(192000 - 40) / 720 = 266` columns instead of 2, and the pickers render as a few oversized thumbnails that cannot be navigated.

This replaces the string surgery with a numeric conversion, so any serialisation works:

| reported scale | before | after |
|---|---|---|
| `1` | 1 ❌ | 100 ✅ |
| `1.00` | 100 ✅ | 100 ✅ |
| `1.5` | 15 ❌ | 150 ✅ |
| `2` | 2 ❌ | 200 ✅ |

Note `1.5` was already wrong before 0.56.2 — stripping the dot from `1.5` gives `15`, i.e. a scale of 0.15.

The `${mon_scale:-1}` fallback had the same bug (it means scale 0.01, not 1.0) and becomes `100`.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Testing

Arch, Hyprland 0.56.2, single 1920x1080 at scale 1.

Before — `pgrep -a rofi` while the picker is open:

```
rofi -dmenu ... -theme-str listview{columns:266;} ... element-icon{size:23em;}
```

After:

```
theme.select      -> columns:2
wallpaper --select -> columns:4
```

Conversion checked against every serialisation in the table above, and `bash -n` passes on all three scripts.

## Notes for reviewers

- The commit also removes trailing whitespace on two lines of `rofiselect.sh`. That was `pre-commit run --all-files` acting on a file the fix already touches, not a deliberate change. Running it across the repo modifies ~200 unrelated files; those were all reverted so this PR stays focused.
- `luacheck` is not installed in my environment, so that hook was skipped. The change is shell-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored correct selector grid layouts on Hyprland 0.56.2.
  * Improved handling of whole-number monitor scaling.
  * Fixed display scaling and resolution normalization in selector and wallpaper views.
  * Added safe defaults when monitor scale information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->