### PR TITLE
fix: default the display width in rofiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Hyprland: dropped the legacy hyprlang dot, the files it deployed no longer exist
 
 ### Fixed
+- Rofi selector: the launcher grid is sized from the display again when the focused-monitor query comes back empty, instead of collapsing to a single column; the width had no fallback while the other two selectors both default to 1920
 - Hyprlock: the lock screen comes up with its layout again instead of a black screen; the directory holding the shipped layouts was left behind by the move to the dot metafiles, so the selector listed nothing, `$LAYOUT_PATH` pointed at a file that was never deployed, and wallbash skipped the template rather than create the directory
 - Hyprland: the shader selector offers the shipped shaders again, and the colors wallbash writes for the lock screen have somewhere to land; both directories stopped being deployed when the installer moved off the restore list
 - Waybar: the stylesheet's own `user-style.css` import resolves again; the file it names was never deployed

--- a/Configs/.local/lib/hyde/rofiselect.sh
+++ b/Configs/.local/lib/hyde/rofiselect.sh
@@ -13,16 +13,17 @@ icon_border=$((elem_border - 5))
 mon_data=$(hyprctl -j monitors)
 mon_x_res=$(jq '.[] | select(.focused==true) | if (.transform % 2 == 0) then .width else .height end' <<< "$mon_data")
 mon_scale=$(get_monitor_scale "$(jq '.[] | select(.focused==true) | .scale' <<< "$mon_data")")
+mon_x_res=${mon_x_res:-1920}
 mon_scale=${mon_scale:-100}
 mon_x_res=$((mon_x_res * 100 / mon_scale))
 elm_width=$(((20 + 12 + 16) * font_scale))
 max_avail=$((mon_x_res - (4 * font_scale)))
 col_count=$((max_avail / elm_width))
 [[ $col_count -gt 5 ]] && col_count=5
-r_override="window{width:100%;} 
+r_override="window{width:100%;}
     listview{columns:$col_count;}
     element{orientation:vertical;border-radius:${elem_border}px;}
-    element-icon{border-radius:${icon_border}px;size:20em;} 
+    element-icon{border-radius:${icon_border}px;size:20em;}
     element-text{enabled:false;}"
 RofiSel=$(find -L "$rofiStyleDir" -type f -exec grep -l "Attr.*launcher.*" {} \; | while
     read -r file


### PR DESCRIPTION
## Description

Follow-up to #1948, which is now closed — the scale parsing it fixed was solved upstream in d3d30c03 by `get_monitor_scale()`, and better. This is the one piece that fix did not cover.

`theme.select.sh` and `wallpaper/select.sh` both default the width when the focused-monitor query returns nothing:

```bash
mon_x_res=${mon_x_res:-1920}
mon_scale=${mon_scale:-100}
```

`rofiselect.sh` has only the second line.

Now that `get_monitor_scale()` guarantees a non-zero divisor, the empty case no longer aborts with a division-by-zero — so this is no longer a crash. But an empty `mon_x_res` still evaluates to `0` in the arithmetic, so:

```bash
mon_x_res=$((0 * 100 / 100))      # 0
max_avail=$((0 - (4 * font_scale)))   # negative
col_count=$((max_avail / elm_width))  # <= 0
```

The launcher grid collapses instead of falling back to a usable width.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Testing

```console
$ mon_x_res=""; mon_scale=100
$ echo $((mon_x_res * 100 / mon_scale))          # before: 0
$ mon_x_res=${mon_x_res:-1920}
$ echo $((mon_x_res * 100 / mon_scale))          # after: 1920
```

`bash -n` clean. One line changed, matching the two selectors that already have it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Rofi launcher grid collapsing to a single column when focused-monitor resolution detection returns no value.
  * Added a fallback display width so the launcher layout remains properly sized across monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->