### PR TITLE
Fix already opened gtk themes not updating

### DIFF
--- a/Configs/.local/share/hypr/lua/env.lua
+++ b/Configs/.local/share/hypr/lua/env.lua
@@ -1,8 +1,8 @@
 hyde = hyde or {}
 hyde.env.finalize()
 hl.env("PATH", (hyde.env("PATH") or "") .. ":" .. hyde.path.lib)
--- ? Isolate dconf
-hl.env("DCONF_PROFILE",  ((os.getenv("XDG_CONFIG_HOME") ~= "" and os.getenv("XDG_CONFIG_HOME")) or (os.getenv("HOME") or "" ) .. "/.config") .. "/dconf/profile/hyde_hyprland")
+-- ? Isolate dconf (Prevents already-opened GTK apps (brave, nwg-displays, etc.) from updating their theme)
+-- hl.env("DCONF_PROFILE",  ((os.getenv("XDG_CONFIG_HOME") ~= "" and os.getenv("XDG_CONFIG_HOME")) or (os.getenv("HOME") or "" ) .. "/.config") .. "/dconf/profile/hyde_hyprland")
 
 -- NVIDIA hook
 -- https://wiki.hypr.land/Nvidia/


### PR DESCRIPTION
# Pull Request

## Description
Switching theme from keybind(MOD + SHIFT + T) does not update already opened gtk apps such as brave but running `hyde-shell theme.select` from terminal does.

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ ] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop theme consistency by preventing GTK applications from unexpectedly updating their theme.
  * Removed the Hyprland-specific desktop settings override so standard desktop configuration behavior is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->