### PR TITLE
ci: measure shell coverage and report it with a patch threshold

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,48 @@ jobs:
 
       - name: Run the test suite
         run: sh tests/run.sh
+
+  coverage:
+    name: Shell coverage
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      KCOV_VERSION: v43
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install test and coverage dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            lua5.4 shellcheck fish \
+            binutils-dev build-essential cmake ninja-build libssl-dev \
+            libcurl4-openssl-dev libelf-dev zlib1g-dev libdw-dev libiberty-dev
+          sudo ln -sf /usr/bin/lua5.4 /usr/local/bin/lua
+          sudo ln -sf /usr/bin/luac5.4 /usr/local/bin/luac
+
+      - name: Build the coverage tool
+        run: |
+          git clone --depth 1 --branch "$KCOV_VERSION" https://github.com/SimonKagstrom/kcov.git "$RUNNER_TEMP/kcov"
+          cmake -S "$RUNNER_TEMP/kcov" -B "$RUNNER_TEMP/kcov/build" -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake --build "$RUNNER_TEMP/kcov/build"
+          sudo install -m 0755 "$RUNNER_TEMP/kcov/build/src/kcov" /usr/local/bin/kcov
+
+      - name: Measure the suite
+        run: |
+          mkdir -p coverage
+          kcov \
+            --include-path=Scripts,Configs/.local/bin,Configs/.local/lib/hyde \
+            --exclude-pattern=/tests/ \
+            coverage sh tests/run.sh
+
+      - name: Upload the report
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: coverage
+          flags: shell
+          name: shell
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,49 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 1
+  round: down
+  range: "40...80"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        informational: true
+
+flags:
+  shell:
+    paths:
+      - Scripts/
+      - Configs/.local/bin/
+      - Configs/.local/lib/hyde/
+    carryforward: true
+
+comment:
+  layout: "condensed_header, diff, flags, components, files"
+  behavior: default
+  require_changes: true
+  hide_project_coverage: false
+
+ignore:
+  - "tests/**"
+  - "docs/**"
+  - "**/*.dcol"
+  - "**/*.Xcol"
+  - "**/*.t2"
+  - "**/*.theme"
+  - "**/*.conf"
+  - "**/*.jsonc"
+  - "**/*.toml"
+  - "Configs/.config/**"
+  - "Configs/.local/share/hyde/**"
+  - "Configs/.local/share/wallbash/**"
+  - "Configs/.local/share/waybar/**"
+  - "Scripts/nvidia-db/**"
+  - "Source/**"


### PR DESCRIPTION
The test workflow proves the suite passes but says nothing about how much of the shipped shell it actually executes, so a change can land fully untested and still show a green run.

This adds a coverage job that runs after the existing suite. It builds kcov from its release tag, measures `tests/run.sh` over `Scripts`, `Configs/.local/bin` and `Configs/.local/lib/hyde`, and uploads the report. The service configuration keeps both the project and the patch status informational, so nothing blocks a merge while the baseline settles, and it ignores the asset trees that carry no executable shell.

The job is additive: the existing test job is untouched and stays the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated code coverage measurement to the CI workflow.
  * Coverage reports are now uploaded and validated against configured thresholds.
* **Chores**
  * Added coverage reporting configuration, including ignored files and directories.
  * Enabled shell coverage tracking and persistent reporting across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->