### PR TITLE
fixup: `layer_rule.ignore_alpha` should be float

### DIFF
--- a/Configs/.local/share/hypr/lua/layer_rules.lua
+++ b/Configs/.local/share/hypr/lua/layer_rules.lua
@@ -44,7 +44,7 @@ hl.layer_rule(
   {
     name = "hyde_layer_ignore_alpha",
     match = {namespace = ignore_alpha_layers.namespace},
-    ignore_alpha = true
+    ignore_alpha = 0.0
   }
 )
 


### PR DESCRIPTION
# Pull Request

## Description

According [to the docs](https://wiki.hypr.land/Configuring/Basics/Window-Rules/#layer-rules) `layer_rule.ignore_alpha` should be float.

Looks like `layer_rule.blur` isn't blurring because of this.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated layer rendering behavior to correctly preserve alpha transparency for Hyde layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->