### PR TITLE
test(theme-state): align test_theme_state.sh with the lua-only refactor

### DIFF
--- a/tests/test_theme_state.sh
+++ b/tests/test_theme_state.sh
@@ -88,43 +88,10 @@ for created in ".local/state/hyde/lua_state" ".cache/hyde/wallbash" "run/hyde" "
         fail "loading the shared helpers left $created uncreated, so its template is skipped as a missing dependency"
 done
 
-expect "lua" "$(probe "$home_dirs" "/somewhere/hyde.lua" 'hyde_config_flavour' 2>/dev/null)" \
-    "a session on a Lua configuration"
-expect "hyprlang" "$(probe "$home_dirs" "/somewhere/hyprland.conf" 'hyde_config_flavour' 2>/dev/null)" \
-    "a session on a hyprlang configuration"
-
 home_entry="$work_dir/entry"
 mkdir -p "$home_entry/.local/share/hypr"
 probe "$home_entry" "" 'true' 2>/dev/null
 : >"$home_entry/.local/share/hypr/hyde.lua"
-expect "lua" "$(probe "$home_entry" "" 'hyde_config_flavour' 2>/dev/null)" \
-    "a deployed Lua entry point outside a session"
-
-home_config="$work_dir/config"
-mkdir -p "$home_config/.config/hypr"
-probe "$home_config" "" 'true' 2>/dev/null
-: >"$home_config/.config/hypr/hyprland.lua"
-expect "lua" "$(probe "$home_config" "" 'hyde_config_flavour' 2>/dev/null)" \
-    "a deployed Lua configuration outside a session"
-
-home_legacy="$work_dir/legacy"
-mkdir -p "$home_legacy"
-probe "$home_legacy" "" 'true' 2>/dev/null
-expect "hyprlang" "$(probe "$home_legacy" "" 'hyde_config_flavour' 2>/dev/null)" \
-    "an installation carrying no Lua entry point"
-
-for shared in local system; do
-    home_shared="$work_dir/shared-$shared"
-    case "$shared" in
-    local) shared_root="$home_shared/usr-local-share" ;;
-    system) shared_root="$home_shared/usr-share" ;;
-    esac
-    mkdir -p "$shared_root/hypr"
-    probe "$home_shared" "" 'true' 2>/dev/null
-    : >"$shared_root/hypr/hyde.lua"
-    expect "lua" "$(PROBE_DATA_DIRS="$shared_root" probe "$home_shared" "" 'hyde_config_flavour' 2>/dev/null)" \
-        "a Lua entry point deployed system-wide under the $shared data directory"
-done
 
 state_dir="$home_entry/.local/state/hyde/lua_state"
 report='wallbash_state_is_complete && echo complete || echo incomplete'
@@ -156,8 +123,8 @@ expect "incomplete" "$(probe "$home_hyprlang" "/somewhere/hyprland.conf" "$repor
     "a hyprlang installation with no colour include"
 
 printf '$color = rgb(000000)\n' >"$home_hyprlang/.config/hypr/themes/colors.conf"
-expect "complete" "$(probe "$home_hyprlang" "/somewhere/hyprland.conf" "$report" 2>/dev/null)" \
-    "a hyprlang installation carrying its colour include"
+expect "incomplete" "$(probe "$home_hyprlang" "/somewhere/hyprland.conf" "$report" 2>/dev/null)" \
+    "a hyprlang-style installation carrying its colour include but no Lua state"
 
 home_directory="$work_dir/directory"
 mkdir -p "$home_directory/.config/hypr/themes/colors.conf"
@@ -166,10 +133,8 @@ probe "$home_directory" "" 'true' 2>/dev/null
 expect "incomplete" "$(probe "$home_directory" "/somewhere/hyprland.conf" "$report" 2>/dev/null)" \
     "a colour include that is a directory rather than a generated file"
 
-for helper in hyde_config_flavour wallbash_state_is_complete; do
-    expect "function" "$(probe "$home_dirs" "" "bash -c 'type -t $helper'" 2>/dev/null)" \
-        "$helper reaching a child process"
-done
+expect "function" "$(probe "$home_dirs" "" "bash -c 'type -t wallbash_state_is_complete'" 2>/dev/null)" \
+    "wallbash_state_is_complete reaching a child process"
 
 core_flat=$(tr '\n' ' ' <"$core_sh")
 
@@ -269,8 +234,6 @@ case "$color_flat" in
 *) fail "the colour pass exits zero although templates failed" ;;
 esac
 
-grep -q 'hyde_config_flavour' "$color_hypr" ||
-    fail "the colour writer branches on the session environment instead of the deployed configuration"
 grep -qE '\$\{HYPRLAND_CONFIG##\*\.\}. == .lua' "$color_hypr" &&
     fail "the colour writer still reads the raw session variable"
 


### PR DESCRIPTION
## Summary

`dev` has had a failing \"Tests\" workflow since f143242e (#1972, \"refactor: generate the theme state for lua only\"); `test_theme_state.sh` fails 10 assertions there and on every commit since. Noticed this on an unrelated PR (#1974) targeting `dev`.

## Root cause

#1971 (\"test: cover the theme colour state and the colour pass\") and #1972 were merged minutes apart the same day. #1972 intentionally removed `hyde_config_flavour` and every hyprlang branch it fed (`globalcontrol.sh`, `color/hypr.sh`, `theme.switch.sh`, `color.set.sh`) as part of dropping hyprlang support in favour of Lua-only config, but `test_theme_state.sh`, merged just before, still calls the now-deleted `hyde_config_flavour` directly and still expects `wallbash_state_is_complete` to treat a hyprlang colour include on its own as sufficient. Both assumptions predate the lua-only model #1972 establishes.

## Fix

- Drop every `hyde_config_flavour` probe: the function is gone by design, and the lua/hyprlang distinction it tested no longer exists.
- A hyprlang-style install with only the legacy colour include is now `incomplete` rather than `complete`, matching `wallbash_state_is_complete`'s unconditional requirement of the Lua state files (`lua_state/colors.lua`, `lua_state/ui.lua`) post-refactor.
- Drop the `color/hypr.sh` assertion requiring a `hyde_config_flavour` call: the file no longer branches on flavour at all (that's the point of the refactor); `test_hyprlang_leftovers.sh`, added in the same commit, already guards against hyprlang-only code reappearing.

## Test plan

- [x] `bash tests/test_theme_state.sh`: 0 failures (was 10) on `dev` @ f143242e
- [x] `sh tests/run.sh`: only remaining failure is `test_monitor_scale` (\"an unreadable scale reads as 150, not 100\"), reproduces identically on unmodified `dev` when run as root (root can read a file made unreadable via chmod), unrelated to this change

## Disclosure

Investigated and written with Claude Code (bisected the failure to f143242e by diffing it against its parent, traced the assertions back to the removed `hyde_config_flavour`), reviewed and the test run verified by me before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation to focus on deployed Lua entry-point setup.
  * Confirmed that colour-only Hyprlang installations remain incomplete.
  * Verified that `wallbash_state_is_complete` is propagated to child processes.
  * Removed obsolete configuration-flavour checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
