### PR TITLE
`wallpaper.waydeeper.sh` backend updated to support latest version of waydeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - OCR: the language list in the result notification is no longer split across arguments
 - Wallpaper: the duplicate check in the kon backend compares against the whole hash list again
 - Repo: dropped two stray gitlinks that made `git submodule` fail on a fresh clone
+- Waydeeper: drop unsupported `--inpaint` option and inpaint model, use `--3d` instead
 
 ## v26.7.4 | 4th Week of July 2026 Release
 

--- a/Configs/.local/lib/hyde/wallpaper.waydeeper.sh
+++ b/Configs/.local/lib/hyde/wallpaper.waydeeper.sh
@@ -42,18 +42,8 @@ if ! command -v waydeeper &>/dev/null; then
     exit 1
 fi
 
-# Ensure the inpaint model is downloaded
-if [ ! -d "$XDG_DATA_HOME/waydeeper/models/inpaint" ] && [ ! -d "$HOME/.local/share/waydeeper/models/inpaint" ]; then
-    print_log -sec "wallpaper" -stat "downloading inpaint model"
-    if ! waydeeper download-model inpaint; then
-        print_log -err "failed to download waydeeper inpaint model"
-        notify-send -a "HyDE Alert" "ERROR: failed to download waydeeper inpaint model"
-        exit 1
-    fi
-fi
-
-# Build waydeeper command with --inpaint always enabled
-waydeeper_args=(waydeeper set "$selected_wall" --inpaint)
+# Build waydeeper command with --3d always enabled
+waydeeper_args=(waydeeper set "$selected_wall" --3d)
 
 # Add depth model if configured
 if [ -n "$WALLPAPER_WAYDEEPER_MODEL" ]; then


### PR DESCRIPTION
# Pull Request

## Description

Small PR allowing to use latest waydeeper cli options available

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Waydeeper wallpaper generation to use the supported `--3d` option instead of the unsupported inpainting mode.
  * Removed unnecessary inpainting model checks and downloads.
* **Documentation**
  * Added a changelog entry describing the updated Waydeeper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->