### PR TITLE
feat: auto-load monitors.lua for nwg-displays and monique support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## Unreleased
 
 ### Added
+- Hyprland: automatically load `monitors.lua`. `nwg-displays` now works without requiring manual imports, while still allowing users to override them in `hyprland.lua`.
 - Docs: `MIGRATION-LUA.md`, a transition guide for upgrading from the hyprlang configuration — what moved where, the silent failures and their causes, and the files the upgrade leaves behind
 
 ### Removed

--- a/Configs/.local/share/hypr/hyde.lua
+++ b/Configs/.local/share/hypr/hyde.lua
@@ -63,6 +63,8 @@ require("key_binds")
 require("events")
 --* HyDE's startup overridable too!
 require("start_up")
+-- * Automatically load generated monitor configs (e.g., from nwg-displays)
+check_require("monitors")
 -- --* user now can have this file
 check_require("hyprland")
 -- --* workflows configuration overrides everything


### PR DESCRIPTION
## Description

Fixes #1977
Partially addresses #1983

Automatically loads `monitors.lua` via `check_require("monitors")` so that GUI display managers like `nwg-displays` and `monique` work out of the box without requiring manual `require()` imports from the user.

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

(if appropriate)

## Additional context

Add any other context about the problem here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically loads optional monitor configurations after startup, enabling generated setups from nwg-displays.
  * Users can still override monitor settings in their Hyprland configuration.

* **Documentation**
  * Updated the unreleased changelog to document automatic monitor configuration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->