### PR TITLE
fix: prevent multiple screenshot annotation processes

### DIFF
--- a/Configs/.local/lib/hyde/screenshot.sh
+++ b/Configs/.local/lib/hyde/screenshot.sh
@@ -5,6 +5,14 @@ else
     export_hyde_config
 fi
 
+# Prevent multiple screenshot annotation windows from running at once.
+screenshot_lock="${XDG_RUNTIME_DIR:-/tmp}/hyde-screenshot.lock"
+exec {screenshot_lock_fd}>"$screenshot_lock"
+
+if ! flock -n "$screenshot_lock_fd"; then
+    exit 0
+fi
+
 # shellcheck disable=SC1091
 [[ -f "${LIB_DIR}/hyde/shutils/l10n.sh" ]] && source "${LIB_DIR}/hyde/shutils/l10n.sh"
 


### PR DESCRIPTION
# Pull Request

## Description

Prevent multiple screenshot annotation processes from running at the same time.
When the screenshot shortcut was triggered repeatedly, HyDE started multiple Satty or Swappy processes. These processes could each consume approximately 100% CPU and cause high system load.
This change adds a non-blocking flock lock to screenshot.sh. If another screenshot annotation process is already running, additional requests exit safely.

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Dependencies
No new dependencies are required. The change uses the existing `flock` utility.

## Testing
`bash  -n Configs/.local/lib/hyde/screenshot.sh`

`pre-commit run --files Configs/.local/lib/hyde/screenshot.sh`
 
The focused checks passed. The full repository pre-commit check reports unrelated existing issues in a broken symlink and Lua files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple screenshot annotation windows from opening at the same time.
  * Additional screenshot requests now exit immediately when another annotation is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->