### PR TITLE
docs: link lua migration guide and fix broken wiki link

### DIFF
--- a/MIGRATION-LUA.md
+++ b/MIGRATION-LUA.md
@@ -4,6 +4,9 @@ Hyprland 0.56 warns against the old `hyprlang` config format, so HyDE moved its
 entire Hyprland configuration to Lua. If you installed HyDE before that release,
 this page covers what changed, what breaks, and what to do about it.
 
+> [!NOTE]
+> For the most comprehensive guide on migration, it is highly recommended to check the HyDE wiki first: [Lua for the User & Migration](https://hydeproject.pages.dev/en/help/lua/)
+
 ## What changed
 
 | Before | Now |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ View installation instructions for HyDE in [Hyde-cli - Usage](https://github.com
 -->
 
 Please reboot after the install script completes and takes you to the SDDM login screen (or black screen) for the first time.
-For more details, please refer to the [installation wiki](https://github.com/HyDE-Project/HyDE/wiki/installation).
+For more details, please refer to the [installation wiki](https://hydeproject.pages.dev/en/getting-started/installation).
 
 Quick checklist for Arch-based distros such as BigLinux / Manjaro:
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ Whether you're helping with code, testing, or documentation, we appreciate your 
 
 ---
 
+> [!NOTE]
+> If you are upgrading from an older version to the new Lua configuration, please follow the [Lua Migration Guide](https://hydeproject.pages.dev/en/help/lua/) in the HyDE wiki.
+
 To update HyDE, you will need to pull the latest changes from GitHub and restore the configs by running the following commands:
 
 > [!WARNING]

--- a/Source/docs/README.ar.md
+++ b/Source/docs/README.ar.md
@@ -93,7 +93,7 @@ cd ~/HyDE/Scripts
 -->
 
 قم بإعادة تشغيل الجهاز بعد اكتمال البرنامج النصي للتثبيت وستظهر لك شاشة تسجيل الدخول SDDM (أو شاشة سوداء) لأول مرة.
-لمزيد من التفاصيل، راجع [دليل التثبيت](https://github.com/HyDE-Project/HyDE/wiki/installation).
+لمزيد من التفاصيل، راجع [دليل التثبيت](https://hydeproject.pages.dev/en/getting-started/installation).
 
 <div align="right">
   <br>

--- a/Source/docs/README.de.md
+++ b/Source/docs/README.de.md
@@ -99,7 +99,7 @@ Sehen Sie sich die Installationsanweisungen für HyDE in [Hyde-cli - Usage](http
 -->
 
 Bitte starten Sie neu, nachdem das Installationsskript abgeschlossen ist und Sie zum ersten Mal den SDDM-Anmeldebildschirm (oder einen schwarzen Bildschirm) sehen.
-Weitere Einzelheiten entnehmen Sie bitte dem [Installations-Wiki](https://github.com/HyDE-Project/HyDE/wiki/installation).
+Weitere Einzelheiten entnehmen Sie bitte dem [Installations-Wiki](https://hydeproject.pages.dev/de/getting-started/installation).
 
 <div align="right">
   <br>

--- a/Source/docs/README.es.md
+++ b/Source/docs/README.es.md
@@ -108,7 +108,7 @@ Consulte las instrucciones de instalación de HyDE en [Hyde-cli - Usage](https:/
 -->
 
 Por favor, reinicie el sistema una vez que el script de instalación haya finalizado y lo lleve por primera vez a la pantalla de inicio de sesión de SDDM (o a una pantalla negra).
-Para más detalles, consulte la [wiki de instalación](https://github.com/HyDE-Project/HyDE/wiki/installation).
+Para más detalles, consulte la [wiki de instalación](https://hydeproject.pages.dev/es/getting-started/installation).
 
 <div align="right">
   <br>

--- a/Source/docs/README.fr.md
+++ b/Source/docs/README.fr.md
@@ -101,7 +101,7 @@ Voir les instructions d'installation pour HyDE dans [Hyde-cli - Usage](https://g
 -->
 
 Veuillez redémarrer après que le script d'installation se termine et vous amène à l'écran de connexion SDDM (ou écran noir) pour la première fois.
-Pour plus de détails, veuillez consulter le [wiki d'installation](https://github.com/HyDE-Project/HyDE/wiki/installation).
+Pour plus de détails, veuillez consulter le [wiki d'installation](https://hydeproject.pages.dev/fr/getting-started/installation).
 
 <div align="right">
   <br>

--- a/Source/docs/README.nl.md
+++ b/Source/docs/README.nl.md
@@ -86,7 +86,7 @@ cd ~/HyDE/Scripts
 > Baseer je lijst op basis van `Scripts/pkg_extra.lst`
 > of je kunt `cp  Scripts/pkg_extra.lst Scripts/pkg_user.lst` Als je alle extra pakketten wilt installeren.
 
-Start je systeem opnieuw op na het installatiescript klaar is en je voor de eerste keer naar het SDDM inlogscherm (of zwart scherm) brengt. Voor meer details, raadpleeg de [installatie wiki](https://github.com/HyDE-Project/HyDE/wiki/installation).
+Start je systeem opnieuw op na het installatiescript klaar is en je voor de eerste keer naar het SDDM inlogscherm (of zwart scherm) brengt. Voor meer details, raadpleeg de [installatie wiki](https://hydeproject.pages.dev/en/getting-started/installation).
 
 <div align="right">
   <br>

--- a/Source/docs/README.pt-br.md
+++ b/Source/docs/README.pt-br.md
@@ -107,7 +107,7 @@ As a second install option, you can also use `Hyde-install`, which might be easi
 View installation instructions for HyDE in [Hyde-cli - Usage](https://github.com/kRHYME7/Hyde-cli?tab=readme-ov-file#usage).
 -->
 Por favor, reinicie o sistema após o script concluir a instalação e levá-lo à tela de login do SDDM (ou a uma tela preta) pela primeira vez.
-Para mais detalhes, por favor consulte a [wiki de instalação](https://github.com/HyDE-Project/HyDE/wiki/installation).
+Para mais detalhes, por favor consulte a [wiki de instalação](https://hydeproject.pages.dev/en/getting-started/installation).
 
 Checklist rápido para distros derivadas do Arch, como BigLinux / Manjaro:
 

--- a/Source/docs/README.tr.md
+++ b/Source/docs/README.tr.md
@@ -102,7 +102,7 @@ View installation instructions for HyDE in [Hyde-cli - Usage](https://github.com
 -->
 
 Kurulum betiği (script) tamamlandıktan ve sizi ilk kez SDDM oturum açma ekranına (veya siyah ekrana) yönlendirdikten sonra lütfen yeniden başlatın.
-Daha fazla ayrıntı için lütfen [kurulum wiki](https://github.com/HyDE-Project/HyDE/wiki/installation) sayfasına bakın.
+Daha fazla ayrıntı için lütfen [kurulum wiki](https://hydeproject.pages.dev/en/getting-started/installation) sayfasına bakın.
 
 <div align="right">
   <br>

--- a/Source/docs/README.zh.md
+++ b/Source/docs/README.zh.md
@@ -107,7 +107,7 @@ View installation instructions for HyDE in [Hyde-cli - Usage](https://github.com
 -->
 
 
-在安装脚本运行完成后请重启，首次启动时您将看到 SDDM 登录界面（或者黑屏）。更多细节请看[安装 wiki](https://github.com/HyDE-Project/HyDE/wiki/installation)
+在安装脚本运行完成后请重启，首次启动时您将看到 SDDM 登录界面（或者黑屏）。更多细节请看[安装 wiki](https://hydeproject.pages.dev/zh/getting-started/installation)
 
 <div align="right">
   <br>


### PR DESCRIPTION
## Description
Adds notes to check the wiki before migrating to Lua and fixes the old installation wiki link.

Closes #2015

## Type of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation links across all supported language guides to point to the new documentation site.
  * Added upgrade guidance directing users to the Lua migration guide.
  * Added a note recommending the HyDE wiki’s Lua migration guide before reviewing configuration migration details.
  * Clarified the transition from `.conf` files to Lua configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->