### PR TITLE
fix: update hyprctl exit dispatcher syntax

### DIFF
--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -278,7 +278,7 @@ hyde-logout() {
         if command -v hyprshutdown >/dev/null 2>&1; then
             hyprshutdown --top-label "Stay HyDErated!🫧"
         else
-            hyprctl dispatch exit 0
+            hyprctl dispatch 'hl.dsp.exit()'
         fi
     fi
 }

--- a/Configs/.local/share/waybar/modules/custom-power.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-power.jsonc
@@ -9,7 +9,7 @@
         "menu-file": "${HYDE_WAYBAR_MENU_DIR:-$XDG_DATA_HOME/waybar/menus}/power.xml",
         "menu-actions": {
             "lock": "hyde-shell lockscreen.sh",
-            "logout": "hyprctl dispatch exit 0",
+            "logout": "hyprctl dispatch 'hl.dsp.exit()'",
             "shutdown-now": "shutdown now",
             "shutdown-wait": "systemctl poweroff",
             "reboot-now": "systemctl reboot",

--- a/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
+++ b/Configs/.local/share/waybar/modules/custom-powermenu.jsonc
@@ -6,7 +6,7 @@
         "menu-file": "${HYDE_WAYBAR_MENU_DIR:-$XDG_DATA_HOME/waybar/menus}/power.xml",
         "menu-actions": {
             "lock": "hyde-shell lockscreen.sh",
-            "logout": "hyprctl dispatch exit 0",
+            "logout": "hyprctl dispatch 'hl.dsp.exit()'",
             "shutdown-now": "shutdown now",
             "shutdown-wait": "systemctl poweroff",
             "reboot-now": "systemctl reboot",


### PR DESCRIPTION
## Description
Updates `hyprctl` dispatch syntax to use lua formatting in `hyde-logout` function
Fixes #2033

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout behavior when the standard shutdown command is unavailable.
  * Sessions now terminate through the compositor’s supported exit mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->