### PR TITLE
fix: remove word-skipping zsh bindings

### DIFF
--- a/Configs/.config/zsh/conf.d/binds.zsh
+++ b/Configs/.config/zsh/conf.d/binds.zsh
@@ -1,7 +1,0 @@
-bindkey "^[[1;5C" forward-word
-bindkey "^[[1;5D" backward-word
-bindkey "^[[5C" forward-word
-bindkey "^[[5D" backward-word
-bindkey "^[OC" forward-word
-bindkey "^[OD" backward-word
-bindkey "^[[3~" delete-char


### PR DESCRIPTION
# Pull Request

## Description

- Removes zsh keybindings that make cursor skip entire words
- I think it's a really bad default that most people won't like

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removals**
  * Removed custom Zsh key bindings for word navigation and character deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->