### PR TITLE
Fix: Remove zsh word skipping file

### DIFF
--- a/Configs/.config/zsh/conf.d/binds.zsh
+++ b/Configs/.config/zsh/conf.d/binds.zsh
@@ -1,7 +1,0 @@
-bindkey "^[[1;5C" forward-word
-bindkey "^[[1;5D" backward-word
-bindkey "^[[5C" forward-word
-bindkey "^[[5D" backward-word
-bindkey "^[OC" forward-word
-bindkey "^[OD" backward-word
-bindkey "^[[3~" delete-char

--- a/Scripts/dots/zsh.toml
+++ b/Scripts/dots/zsh.toml
@@ -43,7 +43,6 @@
         "prompt.zsh",
         "plugin.zsh",
         ".zshrc",
-        "conf.d/binds.zsh",
     ]
     source_root = "Configs/.config/zsh"
     target_root = "${XDG_CONFIG_HOME}/zsh"


### PR DESCRIPTION
# Pull Request

## Description

- Remove file dropped in [Previous PR](https://github.com/HyDE-Project/HyDE/pull/2036)

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [ ] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Additional context

- This time I have tested the change by running a full install of both before and after using hydevm
- While the previous change did produce a small warning in the install, I'm not sure I would've caught it like this, am I missing something about the testing process? I have read the file and followed it to my best knowledge, even fixing hydevm to run against my actual repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Removed custom Zsh key bindings for word navigation and character deletion.
  - The deleted key-binding configuration is no longer preserved by the Zsh setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->