### PR TITLE
fix: swap swipe-gesture finger counts to 3=workspace, 4=focus

### DIFF
--- a/Configs/.local/share/hypr/lua/layouts/dwindle.lua
+++ b/Configs/.local/share/hypr/lua/layouts/dwindle.lua
@@ -29,9 +29,11 @@ hl.bind("ALT + U", hl.dsp.layout("movetoroot"), {description = "[Dwindle] move f
 hl.bind("ALT + Y", hl.dsp.layout("preselect l"), {description = "[Dwindle] preselect left/top split"})
 hl.bind("ALT + I", hl.dsp.layout("preselect r"), {description = "[Dwindle] preselect right/bottom split"})
 
+-- 3-finger swipes switch workspaces, matching the monocle layout and the
+-- near-universal desktop convention; 4-finger swipes move focus instead.
 hl.gesture(
     {
-        fingers = 4,
+        fingers = 3,
         direction = "horizontal",
         action = "workspace"
     }
@@ -39,7 +41,7 @@ hl.gesture(
 
 hl.gesture(
     {
-        fingers = 4,
+        fingers = 3,
         direction = "vertical",
         action = "workspace"
     }
@@ -48,7 +50,7 @@ hl.gesture(
 for _, dir in ipairs({"up", "down", "left", "right"}) do
     hl.gesture(
         {
-            fingers = 3,
+            fingers = 4,
             direction = dir,
             action = function()
                 hl.dispatch(hl.dsp.focus({direction = dir}))

--- a/Configs/.local/share/hypr/lua/layouts/master.lua
+++ b/Configs/.local/share/hypr/lua/layouts/master.lua
@@ -86,9 +86,11 @@ hl.bind("ALT + U", hl.dsp.layout("rollnext"), _F)
 _F = {description = "[Master] rotate previous stack window into master"}
 hl.bind("ALT + I", hl.dsp.layout("rollprev"), _F)
 
+-- 3-finger swipes switch workspaces, matching the monocle layout and the
+-- near-universal desktop convention; 4-finger swipes move focus instead.
 hl.gesture(
     {
-        fingers = 4,
+        fingers = 3,
         direction = "horizontal",
         action = "workspace"
     }
@@ -96,7 +98,7 @@ hl.gesture(
 
 hl.gesture(
     {
-        fingers = 4,
+        fingers = 3,
         direction = "vertical",
         action = "workspace"
     }
@@ -105,7 +107,7 @@ hl.gesture(
 for _, dir in ipairs({"up", "down", "left", "right"}) do
     hl.gesture(
         {
-            fingers = 3,
+            fingers = 4,
             direction = dir,
             action = function()
                 hl.dispatch(hl.dsp.focus({direction = dir}))

--- a/Configs/.local/share/hypr/lua/layouts/scrolling-down.lua
+++ b/Configs/.local/share/hypr/lua/layouts/scrolling-down.lua
@@ -78,9 +78,11 @@ hl.bind(MOD .. "+CTRL + mouse_up", hl.dsp.focus({direction = "left"}), _F)
 _F = {description = "[Scrolling] scroll focus right"}
 hl.bind(MOD .. "+CTRL + mouse_down", hl.dsp.focus({direction = "right"}), _F)
 
+-- 3-finger swipes switch workspaces, matching the monocle layout and the
+-- near-universal desktop convention; 4-finger swipes move focus instead.
 hl.gesture(
 	{
-		fingers = 4,
+		fingers = 3,
 		direction = "horizontal",
 		action = "workspace"
 	}
@@ -88,7 +90,7 @@ hl.gesture(
 
 hl.gesture(
 	{
-		fingers = 4,
+		fingers = 3,
 		direction = "vertical",
 		action = "workspace"
 	}
@@ -97,7 +99,7 @@ hl.gesture(
 for _, dir in ipairs({"up", "down", "left", "right"}) do
 	hl.gesture(
 		{
-			fingers = 3,
+			fingers = 4,
 			direction = dir,
 			action = function()
 				hl.dispatch(hl.dsp.focus({direction = dir}))

--- a/Configs/.local/share/hypr/lua/layouts/scrolling.lua
+++ b/Configs/.local/share/hypr/lua/layouts/scrolling.lua
@@ -76,9 +76,11 @@ hl.bind(MOD .. "+CTRL + mouse_up", hl.dsp.focus({direction = "up"}), _F)
 _F = {description = "[Scrolling] scroll focus down"}
 hl.bind(MOD .. "+CTRL + mouse_down", hl.dsp.focus({direction = "down"}), _F)
 
+-- 3-finger swipes switch workspaces, matching the monocle layout and the
+-- near-universal desktop convention; 4-finger swipes move focus instead.
 hl.gesture(
 	{
-		fingers = 4,
+		fingers = 3,
 		direction = "horizontal",
 		action = "workspace"
 	}
@@ -86,7 +88,7 @@ hl.gesture(
 
 hl.gesture(
 	{
-		fingers = 4,
+		fingers = 3,
 		direction = "vertical",
 		action = "workspace"
 	}
@@ -95,7 +97,7 @@ hl.gesture(
 for _, dir in ipairs({"up", "down", "left", "right"}) do
 	hl.gesture(
 		{
-			fingers = 3,
+			fingers = 4,
 			direction = dir,
 			action = function()
 				hl.dispatch(hl.dsp.focus({direction = dir}))

--- a/tests/lua/layout_gestures_harness.lua
+++ b/tests/lua/layout_gestures_harness.lua
@@ -1,0 +1,97 @@
+-- Loads every shipped layout against a stubbed Hyprland API and checks that
+-- workspace-switch and directional-focus gestures use a consistent finger
+-- count across layouts.
+--
+-- The near-universal desktop convention -- and the one layout that already
+-- documents its own intent ("Use 3-finger swipes to move between
+-- workspaces" in monocle.lua) -- is 3 fingers for workspace switching. A
+-- layout that binds "workspace" to a different finger count is a regression,
+-- not a variant.
+
+local repo_root = assert(os.getenv("REPO_ROOT"), "REPO_ROOT is not set")
+local layouts_dir = repo_root .. "/Configs/.local/share/hypr/lua/layouts"
+
+local function dsp_proxy(prefix)
+    return setmetatable(
+        {},
+        {
+            __index = function(_, key)
+                return dsp_proxy(prefix == "" and key or prefix .. "." .. key)
+            end,
+            __call = function(_, ...)
+                return {dispatcher = prefix, args = {...}}
+            end
+        }
+    )
+end
+
+local function list_layout_files()
+    local files = {}
+    local handle = io.popen("ls '" .. layouts_dir .. "'/*.lua 2>/dev/null")
+    if handle then
+        for line in handle:lines() do
+            files[#files + 1] = line
+        end
+        handle:close()
+    end
+    table.sort(files)
+    return files
+end
+
+local failures = 0
+local total_gestures = 0
+
+local function check(condition, message)
+    if not condition then
+        failures = failures + 1
+        print("    fail: " .. message)
+    end
+end
+
+for _, path in ipairs(list_layout_files()) do
+    local name = path:match("([^/]+)%.lua$")
+    local gestures = {}
+
+    _G.hl = {
+        dsp = dsp_proxy(""),
+        dispatch = function()
+        end,
+        config = function()
+        end,
+        bind = function()
+        end,
+        gesture = function(spec)
+            gestures[#gestures + 1] = spec
+        end
+    }
+    _G.hyde = {
+        config = {
+            modifiers = {main = "SUPER"}
+        }
+    }
+
+    local ok, err = pcall(dofile, path)
+    check(ok, string.format("%s failed to load: %s", name, tostring(err)))
+
+    local seen = {}
+    for _, gesture in ipairs(gestures) do
+        total_gestures = total_gestures + 1
+
+        if gesture.action == "workspace" then
+            check(
+                gesture.fingers == 3,
+                string.format(
+                    "%s binds workspace-switch (%s) to %s fingers, not 3 -- inconsistent with the rest",
+                    name, tostring(gesture.direction), tostring(gesture.fingers)
+                )
+            )
+        end
+
+        local id = tostring(gesture.fingers) .. "|" .. tostring(gesture.direction)
+        check(seen[id] == nil, string.format("%s declares %s twice", name, id))
+        seen[id] = true
+    end
+end
+
+print(string.format("    %d gesture(s) checked across %d layout(s)", total_gestures, #list_layout_files()))
+os.exit(failures == 0 and 0 or 1)

--- a/tests/test_layout_gestures.sh
+++ b/tests/test_layout_gestures.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Every layout's touchpad gestures must agree on which finger count switches
+# workspaces. dwindle/master/scrolling/scrolling-down bound it to 4 fingers
+# while monocle bound it to 3 (its own comment: "Use 3-finger swipes to move
+# between workspaces") -- all five came out of the same Lua migration commit,
+# so this was drift, not an intentional per-layout difference, and it is
+# exactly what #1941/#1945 report as "3-finger swipe broken, falls back to
+# 4-finger".
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v lua >/dev/null 2>&1; then
+    skip "lua is not installed"
+    finish
+fi
+
+lua "$TESTS_DIR/lua/layout_gestures_harness.lua" || fail "layout_gestures_harness reported defects"
+
+finish

--- a/tests/test_monitor_scale.sh
+++ b/tests/test_monitor_scale.sh
@@ -28,7 +28,23 @@ for pair in '1 100' '1.0 100' '1.00 100' '1.000000 100' '1.25 125' '1.5 150' '2 
         fail "a scale of $raw reads as $got, not $want"
 done
 
-got=$(probe "")
+# An empty argument makes get_monitor_scale fall back to querying the live
+# compositor via hyprctl, so "unreadable" has to be forced by making that
+# query fail -- otherwise this case silently tests the real session's scale
+# instead of the fallback path, and passes or fails depending on whether the
+# machine running the suite has a Hyprland session open.
+unreadable_bin_dir="$work_dir/bin_unreadable"
+mkdir -p "$unreadable_bin_dir"
+cat > "$unreadable_bin_dir/hyprctl" << 'STUB'
+#!/usr/bin/env sh
+exit 1
+STUB
+chmod +x "$unreadable_bin_dir/hyprctl"
+
+got=$(HOME="$work_dir/home" \
+    XDG_CONFIG_HOME="$work_dir/home/.config" \
+    PATH="$unreadable_bin_dir:$PATH" \
+    bash -c ". '$lib_dir/globalcontrol.sh' >/dev/null 2>&1; get_monitor_scale ''" 2>/dev/null)
 [ "$got" = "100" ] ||
     fail "an unreadable scale reads as $got, not 100"
 


### PR DESCRIPTION
## What

`dwindle`, `master`, `scrolling` and `scrolling-down` bound workspace-switch swipes to **4 fingers** and directional focus-switch to 3, while `monocle` used **3 fingers** for workspace-switch (with its own comment stating that intent: "Use 3-finger swipes to move between workspaces"). All five layouts came from the same Lua migration commit, so this was drift between copy-pasted files, not a deliberate per-layout difference.

This matches the near-universal desktop convention (GNOME/KDE etc. all use 3-finger swipe for workspace switching) and is exactly what's reported as broken in #1941 and one of the symptoms listed in #1945 ("Gestures are broken (e.g., 3-finger swipe not working, fallback to 4-finger or no response)").

**Note on scope:** this addresses only the gesture symptom from #1941/#1945 — both are multi-symptom reports and the rest of their listed issues are untouched by this PR.

## Fix

Swapped the finger counts in the four inconsistent layouts (workspace-switch → 3 fingers, directional focus → 4 fingers), matching `monocle.lua`.

## Test

Added `tests/test_layout_gestures.sh` (+ `tests/lua/layout_gestures_harness.lua`), which loads every shipped layout file against a stubbed Hyprland API and asserts every `action == "workspace"` gesture uses 3 fingers — so this can't silently drift apart again.

Also includes an unrelated small fix found while investigating: `tests/test_monitor_scale.sh`'s "unreadable scale" case wasn't hermetic — it queried the real running compositor when no explicit scale was given, so it passed or failed depending on whether the machine running the suite had a live Hyprland session (it failed here, since this machine's real scale is 1.5). The production fallback logic in `get_monitor_scale` was already correct; only the test needed a stubbed `hyprctl` to force the fallback path deterministically.

Verified live: deployed to a running HyDE session (Hyprland 0.56.2) and confirmed via `hyprctl reload` with no config errors. Full test suite passes (31/31).

Related: #1941, #1945 (partial)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reassigned touchpad gestures across layouts so three-finger swipes switch workspaces, while four-finger swipes move focus.
  * Standardized horizontal and vertical gesture behavior across supported layouts.

* **Tests**
  * Added automated checks to detect incorrect or duplicate gesture bindings.
  * Improved monitor-scale testing by validating fallback behavior without requiring an active Hyprland session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->