### PR TITLE
test: sharpen #2051's gesture and monitor-scale tests

### DIFF
--- a/tests/lua/layout_gestures_harness.lua
+++ b/tests/lua/layout_gestures_harness.lua
@@ -85,6 +85,14 @@ for _, path in ipairs(list_layout_files()) do
                     name, tostring(gesture.direction), tostring(gesture.fingers)
                 )
             )
+        elseif type(gesture.action) == "function" then
+            check(
+                gesture.fingers == 4,
+                string.format(
+                    "%s binds directional focus (%s) to %s fingers, not 4 -- inconsistent with the rest",
+                    name, tostring(gesture.direction), tostring(gesture.fingers)
+                )
+            )
         end
 
         local id = tostring(gesture.fingers) .. "|" .. tostring(gesture.direction)

--- a/tests/lua/layout_gestures_harness.lua
+++ b/tests/lua/layout_gestures_harness.lua
@@ -77,25 +77,27 @@ for _, path in ipairs(list_layout_files()) do
     for _, gesture in ipairs(gestures) do
         total_gestures = total_gestures + 1
 
+        local fingers = tonumber(gesture.fingers)
+
         if gesture.action == "workspace" then
             check(
-                gesture.fingers == 3,
+                fingers == 3,
                 string.format(
                     "%s binds workspace-switch (%s) to %s fingers, not 3 -- inconsistent with the rest",
-                    name, tostring(gesture.direction), tostring(gesture.fingers)
+                    name, tostring(gesture.direction), tostring(fingers)
                 )
             )
         elseif type(gesture.action) == "function" then
             check(
-                gesture.fingers == 4,
+                fingers == 4,
                 string.format(
                     "%s binds directional focus (%s) to %s fingers, not 4 -- inconsistent with the rest",
-                    name, tostring(gesture.direction), tostring(gesture.fingers)
+                    name, tostring(gesture.direction), tostring(fingers)
                 )
             )
         end
 
-        local id = tostring(gesture.fingers) .. "|" .. tostring(gesture.direction)
+        local id = tostring(fingers) .. "|" .. tostring(gesture.direction)
         check(seen[id] == nil, string.format("%s declares %s twice", name, id))
         seen[id] = true
     end

--- a/tests/test_monitor_scale.sh
+++ b/tests/test_monitor_scale.sh
@@ -13,7 +13,7 @@ lib_dir="$REPO_ROOT/Configs/.local/lib/hyde"
 probe() {
     HOME="$work_dir/home" \
         XDG_CONFIG_HOME="$work_dir/home/.config" \
-        bash -c ". '$lib_dir/globalcontrol.sh' >/dev/null 2>&1; get_monitor_scale '$1'" 2>/dev/null
+        bash -c '. "$1/globalcontrol.sh" >/dev/null 2>&1; get_monitor_scale "$2"' _ "$lib_dir" "$1" 2>/dev/null
 }
 
 work_dir=$(mktemp -d) || exit 1
@@ -44,7 +44,7 @@ chmod +x "$unreadable_bin_dir/hyprctl"
 got=$(HOME="$work_dir/home" \
     XDG_CONFIG_HOME="$work_dir/home/.config" \
     PATH="$unreadable_bin_dir:$PATH" \
-    bash -c ". '$lib_dir/globalcontrol.sh' >/dev/null 2>&1; get_monitor_scale ''" 2>/dev/null)
+    bash -c '. "$1/globalcontrol.sh" >/dev/null 2>&1; get_monitor_scale ""' _ "$lib_dir" 2>/dev/null)
 [ "$got" = "100" ] ||
     fail "an unreadable scale reads as $got, not 100"
 
@@ -60,7 +60,7 @@ grep -q 'export -f .*get_monitor_scale' "$lib_dir/globalcontrol.sh" ||
     fail "the helper is not exported, so a function that calls it breaks in a child shell"
 
 exported=$(HOME="$work_dir/home" XDG_CONFIG_HOME="$work_dir/home/.config" \
-    bash -c ". '$lib_dir/globalcontrol.sh' >/dev/null 2>&1; bash -c 'get_monitor_scale 1.5'" 2>/dev/null)
+    bash -c '. "$1/globalcontrol.sh" >/dev/null 2>&1; bash -c "get_monitor_scale 1.5"' _ "$lib_dir" 2>/dev/null)
 [ "$exported" = "150" ] ||
     fail "a child shell reads the scale as '$exported', not 150"
 


### PR DESCRIPTION
Two follow-ups CodeRabbit flagged on #2051, addressed now per "I don't review tests so please deal with it if anything borkes":

1. **`layout_gestures_harness.lua` coverage gap**: it only asserted the finger count on workspace-switch gestures, so a regression in the paired directional-focus gestures (e.g. an accidental `fingers = 2`) wouldn't have been caught. Added the matching assertion for focus-direction gestures (`fingers == 4`). Verified by deliberately breaking one layout's focus gestures locally and confirming the harness fails on it (then reverted).

2. **`test_monitor_scale.sh` quoting bug**: three `bash -c` invocations built the command by interpolating `$lib_dir` inside single quotes. A checkout path containing an apostrophe truncates that quoting and breaks every case in the file. Verified directly: running the pre-fix version of this test from a checkout at a path containing an apostrophe produces 10 failures; switched to passing `$lib_dir` as a positional parameter instead of interpolating it, which passes cleanly from the same path.

Full suite still green (31/31).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved gesture validation by consistently handling finger counts for workspace switching, directional focus, failure reporting, and duplicate detection.
  * Improved monitor-scale test execution by passing shell values safely as positional parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->