### PR TITLE
fix: make PATH append idempotent across hyprctl reload (#1521)

### DIFF
--- a/Configs/.local/share/hypr/lua/env.lua
+++ b/Configs/.local/share/hypr/lua/env.lua
@@ -13,7 +13,7 @@ for segment in (current_path .. ":"):gmatch("([^:]*):") do
 	end
 end
 if not already_on_path then
-	hl.env("PATH", current_path .. ":" .. hyde.path.lib)
+	hl.env("PATH", current_path == "" and hyde.path.lib or current_path .. ":" .. hyde.path.lib)
 end
 -- ? Isolate dconf (Prevents already-opened GTK apps (brave, nwg-displays, etc.) from updating their theme)
 -- hl.env("DCONF_PROFILE",  ((os.getenv("XDG_CONFIG_HOME") ~= "" and os.getenv("XDG_CONFIG_HOME")) or (os.getenv("HOME") or "" ) .. "/.config") .. "/dconf/profile/hyde_hyprland")

--- a/Configs/.local/share/hypr/lua/env.lua
+++ b/Configs/.local/share/hypr/lua/env.lua
@@ -1,6 +1,20 @@
 hyde = hyde or {}
 hyde.env.finalize()
-hl.env("PATH", (hyde.env("PATH") or "") .. ":" .. hyde.path.lib)
+
+-- hl.env sets PATH on the live compositor process, so it is still there for
+-- os.getenv on the next `hyprctl reload` -- appending unconditionally grows it
+-- by one more copy of hyde.path.lib every reload (#1521).
+local current_path = hyde.env("PATH") or ""
+local already_on_path = false
+for segment in (current_path .. ":"):gmatch("([^:]*):") do
+	if segment == hyde.path.lib then
+		already_on_path = true
+		break
+	end
+end
+if not already_on_path then
+	hl.env("PATH", current_path .. ":" .. hyde.path.lib)
+end
 -- ? Isolate dconf (Prevents already-opened GTK apps (brave, nwg-displays, etc.) from updating their theme)
 -- hl.env("DCONF_PROFILE",  ((os.getenv("XDG_CONFIG_HOME") ~= "" and os.getenv("XDG_CONFIG_HOME")) or (os.getenv("HOME") or "" ) .. "/.config") .. "/dconf/profile/hyde_hyprland")
 

--- a/tests/lua/env_harness.lua
+++ b/tests/lua/env_harness.lua
@@ -1,0 +1,59 @@
+-- Simulates two consecutive config loads sharing one process environment --
+-- what `hyprctl reload` actually does, since hl.env("PATH", ...) sets the
+-- live compositor's own env var, and the next reload's os.getenv("PATH") sees
+-- whatever the previous load left there.
+--
+-- #1521 reports PATH entries duplicated after a reload; env.lua used to
+-- append hyde.path.lib to PATH unconditionally on every load, growing it by
+-- one more copy each time.
+
+local repo_root = assert(os.getenv("REPO_ROOT"), "REPO_ROOT is not set")
+local hypr_lua = repo_root .. "/Configs/.local/share/hypr/lua"
+local lib = "/home/user/.local/lib"
+
+local real_path = "/usr/bin"
+local real_getenv = os.getenv
+os.getenv = function(name)
+    if name == "PATH" then
+        return real_path
+    end
+    return real_getenv(name)
+end
+
+_G.hl = {
+    env = function(name, value)
+        if name == "PATH" then
+            real_path = value
+        end
+    end
+}
+
+local function load_once()
+    -- A fresh hyde.env module state each time, like a fresh Lua VM per reload.
+    _G.hyde = {path = {lib = lib}}
+    dofile(hypr_lua .. "/hyde/env.lua")
+    dofile(hypr_lua .. "/env.lua")
+end
+
+load_once()
+load_once()
+
+local function count_segment(path, segment)
+    local count = 0
+    for part in (path .. ":"):gmatch("([^:]*):") do
+        if part == segment then
+            count = count + 1
+        end
+    end
+    return count
+end
+
+local failures = 0
+local count = count_segment(real_path, lib)
+if count ~= 1 then
+    failures = failures + 1
+    print(string.format("    fail: PATH contains %d copies of %s after two reloads, want 1 -- %s", count, lib, real_path))
+end
+
+print("    PATH after two reloads: " .. real_path)
+os.exit(failures == 0 and 0 or 1)

--- a/tests/lua/env_harness.lua
+++ b/tests/lua/env_harness.lua
@@ -1,6 +1,6 @@
--- Simulates two consecutive config loads sharing one process environment --
--- what `hyprctl reload` actually does, since hl.env("PATH", ...) sets the
--- live compositor's own env var, and the next reload's os.getenv("PATH") sees
+-- Simulates one or more config loads sharing one process environment -- what
+-- `hyprctl reload` actually does, since hl.env("PATH", ...) sets the live
+-- compositor's own env var, and the next reload's os.getenv("PATH") sees
 -- whatever the previous load left there.
 --
 -- #1521 reports PATH entries duplicated after a reload; env.lua used to
@@ -11,7 +11,7 @@ local repo_root = assert(os.getenv("REPO_ROOT"), "REPO_ROOT is not set")
 local hypr_lua = repo_root .. "/Configs/.local/share/hypr/lua"
 local lib = "/home/user/.local/lib"
 
-local real_path = "/usr/bin"
+local real_path
 local real_getenv = os.getenv
 os.getenv = function(name)
     if name == "PATH" then
@@ -35,9 +35,6 @@ local function load_once()
     dofile(hypr_lua .. "/env.lua")
 end
 
-load_once()
-load_once()
-
 local function count_segment(path, segment)
     local count = 0
     for part in (path .. ":"):gmatch("([^:]*):") do
@@ -49,11 +46,28 @@ local function count_segment(path, segment)
 end
 
 local failures = 0
-local count = count_segment(real_path, lib)
-if count ~= 1 then
-    failures = failures + 1
-    print(string.format("    fail: PATH contains %d copies of %s after two reloads, want 1 -- %s", count, lib, real_path))
+local function check(condition, message)
+    if not condition then
+        failures = failures + 1
+        print("    fail: " .. message)
+    end
 end
 
+-- Two reloads sharing one environment must not duplicate the lib entry.
+real_path = "/usr/bin"
+load_once()
+load_once()
+check(
+    count_segment(real_path, lib) == 1,
+    string.format("PATH contains %d copies of %s after two reloads, want 1 -- %s", count_segment(real_path, lib), lib, real_path)
+)
 print("    PATH after two reloads: " .. real_path)
+
+-- A completely empty inherited PATH must not gain a leading empty segment --
+-- that puts the current directory first in the search order (CWE-427).
+real_path = ""
+load_once()
+check(real_path:sub(1, 1) ~= ":", string.format("PATH starts with an empty segment on an empty inherited PATH -- %q", real_path))
+print("    PATH from an empty inherited PATH: " .. real_path)
+
 os.exit(failures == 0 and 0 or 1)

--- a/tests/lua/env_harness.lua
+++ b/tests/lua/env_harness.lua
@@ -68,6 +68,8 @@ print("    PATH after two reloads: " .. real_path)
 real_path = ""
 load_once()
 check(real_path:sub(1, 1) ~= ":", string.format("PATH starts with an empty segment on an empty inherited PATH -- %q", real_path))
+check(count_segment(real_path, lib) == 1,
+    string.format("PATH must contain exactly one copy of %s -- %q", lib, real_path))
 print("    PATH from an empty inherited PATH: " .. real_path)
 
 os.exit(failures == 0 and 0 or 1)

--- a/tests/test_env_path.sh
+++ b/tests/test_env_path.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# hl.env("PATH", ...) sets the live compositor's env var, which survives a
+# `hyprctl reload` -- appending hyde.path.lib to PATH unconditionally on every
+# load grows it by one more copy each time. This is what #1521 reports as
+# "duplicated addresses" in PATH after a reload.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v lua >/dev/null 2>&1; then
+    skip "lua is not installed"
+    finish
+fi
+
+lua "$TESTS_DIR/lua/env_harness.lua" || fail "env_harness reported defects"
+
+finish


### PR DESCRIPTION
## Summary

`hl.env("PATH", ...)` in `env.lua` sets an env var on the live compositor process, which survives a `hyprctl reload` -- so the unconditional append of `hyde.path.lib` to PATH grew it by one more copy on every reload instead of just once at startup. This is the root cause behind the "duplicated addresses" symptom reported in #1521, traced there (in the pre-Lua-migration config) to a similar double-sourcing of environment setup; the same defect class exists in the current Lua-based `env.lua`.

Fix: check whether `hyde.path.lib` is already present as a PATH segment before appending, making the operation idempotent across repeated reloads.

## Test plan

- [x] Added `tests/lua/env_harness.lua` + `tests/test_env_path.sh`, simulating two consecutive config loads sharing one process environment (as two `hyprctl reload` calls would)
- [x] Verified the new test fails against the pre-fix code (PATH grows to 2 copies of `hyde.path.lib`) and passes after the fix (stays at 1)
- [x] Full suite: `tests/run.sh` -- 32/32 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate library paths from accumulating in the `PATH` environment variable after compositor reloads.
  * Corrected PATH initialization when no inherited path exists, avoiding an empty leading segment that could cause the current directory to be searched first.
  * Ensured environment updates remain consistent across repeated configuration reloads.

* **Tests**
  * Added coverage for repeated reloads and empty PATH scenarios.
  * Added a test script that runs validation when Lua is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->