### PR TITLE
fix: guard gpuinfo.sh's cpufreq reads and fix its cpuinfo_file typo (#2028)

### DIFF
--- a/Configs/.local/lib/hyde/gpuinfo.sh
+++ b/Configs/.local/lib/hyde/gpuinfo.sh
@@ -238,15 +238,18 @@ general_query() {
     # /sys/devices/system/cpu/cpufreq tree at all, so the glob doesn't match and
     # bash passes the literal pattern through -- letting awk open it directly
     # turns that into a fatal error on every poll (#2028). Read each file only
-    # if it exists, and feed the values to awk instead of the path.
+    # if it exists, and let awk do the summing: bash's own $((...)) throws a
+    # syntax error (killing the whole script, not just this calculation) on
+    # anything that isn't a plain integer, whereas awk coerces malformed sysfs
+    # content to 0 instead of dying on it.
     local cpu_sysfs_dir="${GPUINFO_CPU_SYSFS_DIR:-/sys/devices/system/cpu}"
-    local clock_sum=0 clock_n=0 freq
+    local freq clock_freqs=()
     for file in "$cpu_sysfs_dir"/cpufreq/policy*/scaling_cur_freq; do
-        [[ -f $file ]] && freq=$(cat "$file" 2>/dev/null) && [[ -n $freq ]] &&
-            clock_sum=$((clock_sum + freq)) && clock_n=$((clock_n + 1))
+        [[ -f $file ]] && freq=$(cat "$file" 2>/dev/null) && [[ -n $freq ]] && clock_freqs+=("$freq")
     done
     current_clock_speed=""
-    [[ $clock_n -gt 0 ]] && current_clock_speed=$(awk -v sum="$clock_sum" -v n="$clock_n" 'BEGIN {print sum / n / 1000 ""}')
+    ((${#clock_freqs[@]} > 0)) &&
+        current_clock_speed=$(printf '%s\n' "${clock_freqs[@]}" | awk '{sum += $1; n++} END {if (n > 0) print sum / n / 1000 ""}')
     max_clock_speed=""
     max_freq_file="$cpu_sysfs_dir/cpu0/cpufreq/cpuinfo_max_freq"
     if [[ -f $max_freq_file ]]; then

--- a/Configs/.local/lib/hyde/gpuinfo.sh
+++ b/Configs/.local/lib/hyde/gpuinfo.sh
@@ -227,14 +227,32 @@ general_query() {
         GPUINFO_PREV_STAT=$currStat
         GPUINFO_PREV_IDLE=$currIdle
         sed -i -e "/^GPUINFO_PREV_STAT=/c\GPUINFO_PREV_STAT=\"$currStat\"" -e "/^GPUINFO_PREV_IDLE=/c\GPUINFO_PREV_IDLE=\"$currIdle\"" "$gpuinfo_file" || {
-            echo "GPUINFO_PREV_STAT=\"$currStat\"" >>"$cpuinfo_file"
-            echo "GPUINFO_PREV_IDLE=\"$currIdle\"" >>"$cpuinfo_file"
+            echo "GPUINFO_PREV_STAT=\"$currStat\"" >>"$gpuinfo_file"
+            echo "GPUINFO_PREV_IDLE=\"$currIdle\"" >>"$gpuinfo_file"
         }
         awk -v stat="$diffStat" -v idle="$diffIdle" 'BEGIN {total=stat+idle; printf "%.1f", (total > 0 ? (stat/total)*100 : 0)}'
     }
     utilization=$(get_utilization)
-    current_clock_speed=$(awk '{sum += $1; n++} END {if (n > 0) print sum / n / 1000 ""}' /sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq)
-    max_clock_speed=$(awk '{print $1/1000}' /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq)
+    # As with power_now above: a host with no cpufreq scaling driver (common on
+    # virtualized/cloud CPUs and this project's own CI runner) has no
+    # /sys/devices/system/cpu/cpufreq tree at all, so the glob doesn't match and
+    # bash passes the literal pattern through -- letting awk open it directly
+    # turns that into a fatal error on every poll (#2028). Read each file only
+    # if it exists, and feed the values to awk instead of the path.
+    local cpu_sysfs_dir="${GPUINFO_CPU_SYSFS_DIR:-/sys/devices/system/cpu}"
+    local clock_sum=0 clock_n=0 freq
+    for file in "$cpu_sysfs_dir"/cpufreq/policy*/scaling_cur_freq; do
+        [[ -f $file ]] && freq=$(cat "$file" 2>/dev/null) && [[ -n $freq ]] &&
+            clock_sum=$((clock_sum + freq)) && clock_n=$((clock_n + 1))
+    done
+    current_clock_speed=""
+    [[ $clock_n -gt 0 ]] && current_clock_speed=$(awk -v sum="$clock_sum" -v n="$clock_n" 'BEGIN {print sum / n / 1000 ""}')
+    max_clock_speed=""
+    max_freq_file="$cpu_sysfs_dir/cpu0/cpufreq/cpuinfo_max_freq"
+    if [[ -f $max_freq_file ]]; then
+        max_freq_raw=$(cat "$max_freq_file" 2>/dev/null)
+        [[ -n $max_freq_raw ]] && max_clock_speed=$(awk -v v="$max_freq_raw" 'BEGIN {print v/1000}')
+    fi
 }
 intel_GPU() {
     primary_gpu="Intel $GPUINFO_INTEL_GPU"

--- a/Configs/.local/lib/hyde/gpuinfo.sh
+++ b/Configs/.local/lib/hyde/gpuinfo.sh
@@ -242,9 +242,11 @@ general_query() {
     # bash passes the literal pattern through -- letting awk open it directly
     # turns that into a fatal error on every poll (#2028). Read each file only
     # if it exists, and let awk do the summing: bash's own $((...)) throws a
-    # syntax error (killing the whole script, not just this calculation) on
-    # anything that isn't a plain integer, whereas awk coerces malformed sysfs
-    # content to 0 instead of dying on it.
+    # "syntax error" and prints a diagnostic to stderr on every poll for
+    # anything that isn't a plain integer (this script has no `set -e`, so it
+    # doesn't abort the run, just adds noise) -- awk parses a decimal like the
+    # sysfs values here fine, and only falls back to 0 for genuinely
+    # non-numeric content, either way without dying on it.
     local cpu_sysfs_dir="${GPUINFO_CPU_SYSFS_DIR:-/sys/devices/system/cpu}"
     local freq clock_freqs=()
     for file in "$cpu_sysfs_dir"/cpufreq/policy*/scaling_cur_freq; do
@@ -254,8 +256,9 @@ general_query() {
     ((${#clock_freqs[@]} > 0)) &&
         current_clock_speed=$(printf '%s\n' "${clock_freqs[@]}" | awk '{sum += $1; n++} END {if (n > 0) print sum / n / 1000 ""}')
     max_clock_speed=""
+    local max_freq_file max_freq_raw
     max_freq_file="$cpu_sysfs_dir/cpu0/cpufreq/cpuinfo_max_freq"
-    if [[ -f $max_freq_file ]]; then
+    if [[ -f "$max_freq_file" ]]; then
         max_freq_raw=$(cat "$max_freq_file" 2>/dev/null)
         [[ -n $max_freq_raw ]] && max_clock_speed=$(awk -v v="$max_freq_raw" 'BEGIN {print v/1000}')
     fi

--- a/tests/test_gpuinfo.sh
+++ b/tests/test_gpuinfo.sh
@@ -182,18 +182,22 @@ esac
 # bash's arithmetic evaluator throws its own "syntax error" for anything that
 # isn't a plain integer (e.g. a decimal point), printing a diagnostic to
 # stderr on every single poll. That is the same class of regression #2028 set
-# out to remove, just from a different builtin. LC_ALL=C.utf8 keeps the
+# out to remove, just from a different builtin. A UTF-8 C locale keeps the
 # assertion below from depending on the host's locale, since bash localizes
 # this message (this project's own dev machine has it in German) -- plain
 # LC_ALL=C would also do that but switches the charset to ASCII, which
 # mangles the icons the JSON output embeds and breaks the JSON-shape check
-# below for an unrelated reason.
+# below for an unrelated reason. The exact locale name for that isn't
+# portable ("C.utf8" vs. "C.UTF-8"), so pick whichever this host actually
+# has rather than hardcoding one.
+utf8_c_locale=$(locale -a 2>/dev/null | grep -iE '^C\.utf-?8$' | head -n1)
+utf8_c_locale=${utf8_c_locale:-C.UTF-8}
 malformed_cpu_sysfs=$(mktemp -d)
 mkdir -p "$malformed_cpu_sysfs/cpufreq/policy0" "$malformed_cpu_sysfs/cpu0/cpufreq"
 printf '12.5' >"$malformed_cpu_sysfs/cpufreq/policy0/scaling_cur_freq"
 printf 'not-a-number' >"$malformed_cpu_sysfs/cpu0/cpufreq/cpuinfo_max_freq"
 rm -f "$state_file"
-malformed_stdout=$(LC_ALL=C.utf8 GPUINFO_CPU_SYSFS_DIR="$malformed_cpu_sysfs" PATH="$fake_bin:$PATH" bash "$script" \
+malformed_stdout=$(LC_ALL="$utf8_c_locale" GPUINFO_CPU_SYSFS_DIR="$malformed_cpu_sysfs" PATH="$fake_bin:$PATH" bash "$script" \
     2>"$stderr_file")
 malformed_status=$?
 malformed_stderr=$(cat "$stderr_file")

--- a/tests/test_gpuinfo.sh
+++ b/tests/test_gpuinfo.sh
@@ -153,6 +153,69 @@ for line in lines:
     fail "a missing cpufreq sysfs tree produced a line on stdout that is not a JSON object: $cpufreq_stdout"
 fi
 
+# Sanity check that the rewritten averaging loop still computes the right
+# number for well-formed, in-spec sysfs content, not just that it survives
+# missing files -- two policies at 1.2GHz/2.4GHz should average to 1800MHz,
+# against a 3.6GHz max.
+fake_cpu_sysfs=$(mktemp -d)
+mkdir -p "$fake_cpu_sysfs/cpufreq/policy0" "$fake_cpu_sysfs/cpufreq/policy1" "$fake_cpu_sysfs/cpu0/cpufreq"
+printf '1200000' >"$fake_cpu_sysfs/cpufreq/policy0/scaling_cur_freq"
+printf '2400000' >"$fake_cpu_sysfs/cpufreq/policy1/scaling_cur_freq"
+printf '3600000' >"$fake_cpu_sysfs/cpu0/cpufreq/cpuinfo_max_freq"
+rm -f "$state_file"
+valid_stdout=$(GPUINFO_CPU_SYSFS_DIR="$fake_cpu_sysfs" PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
+valid_stderr=$(cat "$stderr_file")
+rm -rf "$fake_cpu_sysfs"
+
+case $valid_stdout in
+*'1800/3600 MHz'*) ;;
+*) fail "well-formed cpufreq sysfs content (1.2GHz+2.4GHz avg, 3.6GHz max) did not produce '1800/3600 MHz': $valid_stdout" ;;
+esac
+case $valid_stderr in
+*"awk: fatal"*) fail "well-formed cpufreq sysfs content still leaked an awk fatal error to stderr: $valid_stderr" ;;
+esac
+
+# Out-of-spec content is the case that actually matters here: sysfs is
+# documented to hold a plain integer, but a fix that lets awk open a missing
+# path directly fatal (the original bug) is easy to replace with one that
+# instead runs $((...)) bash arithmetic on whatever the file holds -- and
+# bash's arithmetic evaluator throws its own "syntax error" for anything that
+# isn't a plain integer (e.g. a decimal point), printing a diagnostic to
+# stderr on every single poll. That is the same class of regression #2028 set
+# out to remove, just from a different builtin. LC_ALL=C.utf8 keeps the
+# assertion below from depending on the host's locale, since bash localizes
+# this message (this project's own dev machine has it in German) -- plain
+# LC_ALL=C would also do that but switches the charset to ASCII, which
+# mangles the icons the JSON output embeds and breaks the JSON-shape check
+# below for an unrelated reason.
+malformed_cpu_sysfs=$(mktemp -d)
+mkdir -p "$malformed_cpu_sysfs/cpufreq/policy0" "$malformed_cpu_sysfs/cpu0/cpufreq"
+printf '12.5' >"$malformed_cpu_sysfs/cpufreq/policy0/scaling_cur_freq"
+printf 'not-a-number' >"$malformed_cpu_sysfs/cpu0/cpufreq/cpuinfo_max_freq"
+rm -f "$state_file"
+malformed_stdout=$(LC_ALL=C.utf8 GPUINFO_CPU_SYSFS_DIR="$malformed_cpu_sysfs" PATH="$fake_bin:$PATH" bash "$script" \
+    2>"$stderr_file")
+malformed_status=$?
+malformed_stderr=$(cat "$stderr_file")
+rm -rf "$malformed_cpu_sysfs"
+
+case $malformed_stderr in
+*"syntax error"*)
+    fail "malformed cpufreq sysfs content leaked a bash arithmetic error to stderr on every poll: $malformed_stderr"
+    ;;
+esac
+if [ -z "$malformed_stdout" ] || ! printf '%s\n' "$malformed_stdout" | python3 -c '
+import json, sys
+lines = [line for line in sys.stdin.read().splitlines() if line.strip()]
+if not lines:
+    raise SystemExit(1)
+for line in lines:
+    if not isinstance(json.loads(line), dict):
+        raise SystemExit(1)
+' >/dev/null 2>&1; then
+    fail "malformed cpufreq sysfs content produced a line on stdout that is not a JSON object (status $malformed_status): $malformed_stdout"
+fi
+
 # The utilization fallback (get_utilization's sed -i failure path) is meant to
 # append to the same state file the sed -i targeted. It used to reference
 # $cpuinfo_file, a variable this script never assigns (a leftover from

--- a/tests/test_gpuinfo.sh
+++ b/tests/test_gpuinfo.sh
@@ -152,6 +152,16 @@ for line in lines:
 ' >/dev/null 2>&1; then
     fail "a missing cpufreq sysfs tree produced a line on stdout that is not a JSON object: $cpufreq_stdout"
 fi
+# No fatal and valid JSON aren't the whole contract (#2028): a wrong but
+# well-formed clock-speed value would pass both those checks. The tooltip
+# only ever gets a "Clock Speed" segment when both current_clock_speed and
+# max_clock_speed are non-empty, so its absence here confirms the missing
+# tree actually left them empty rather than some other value slipping in.
+case $cpufreq_stdout in
+*"Clock Speed"*)
+    fail "a missing cpufreq sysfs tree still produced a Clock Speed field: $cpufreq_stdout"
+    ;;
+esac
 
 # Sanity check that the rewritten averaging loop still computes the right
 # number for well-formed, in-spec sysfs content, not just that it survives

--- a/tests/test_gpuinfo.sh
+++ b/tests/test_gpuinfo.sh
@@ -113,14 +113,52 @@ else
         >/dev/null 2>"$stderr_file"
     unreadable_stderr=$(cat "$stderr_file")
 
-    # Match only a fatal that names power_now. The script has other awk calls
-    # that open files directly -- the cpufreq ones -- and those fail the same
-    # way wherever the host kernel has no cpufreq scaling driver loaded, which
-    # is the case on this project's CI runner.
-    # Matching any "awk: fatal" would fail this case for an unrelated reason.
-    if printf '%s\n' "$unreadable_stderr" | grep -q 'awk: fatal.*power_now'; then
+    # The cpufreq awk calls (#2028) used to fatal the same way on any host
+    # with no cpufreq scaling driver loaded, which is the case on this
+    # project's CI runner -- so this used to match only a fatal naming
+    # power_now, to avoid failing here for that unrelated, then-unfixed
+    # reason. Now that both are fixed, any awk fatal is a regression.
+    if printf '%s\n' "$unreadable_stderr" | grep -q 'awk: fatal'; then
         fail "an unreadable power_now leaked an awk fatal error to stderr: $unreadable_stderr"
     fi
 fi
+
+# A host with no cpufreq scaling driver (virtualized/cloud CPUs, some ARM
+# boards, and this project's own CI runner) has no
+# /sys/devices/system/cpu/cpufreq tree at all. The glob then doesn't match,
+# bash passes the literal pattern through, and letting awk open that directly
+# used to fatal on every poll (#2028). An empty directory reproduces the same
+# "tree not present" shape portably.
+empty_cpu_sysfs=$(mktemp -d)
+rm -f "$state_file"
+cpufreq_stdout=$(GPUINFO_CPU_SYSFS_DIR="$empty_cpu_sysfs" PATH="$fake_bin:$PATH" bash "$script" \
+    2>"$stderr_file")
+cpufreq_stderr=$(cat "$stderr_file")
+rm -rf "$empty_cpu_sysfs"
+
+case $cpufreq_stderr in
+*"awk: fatal"*)
+    fail "a missing cpufreq sysfs tree leaked an awk fatal error to stderr: $cpufreq_stderr"
+    ;;
+esac
+if [ -z "$cpufreq_stdout" ] || ! printf '%s\n' "$cpufreq_stdout" | python3 -c '
+import json, sys
+lines = [line for line in sys.stdin.read().splitlines() if line.strip()]
+if not lines:
+    raise SystemExit(1)
+for line in lines:
+    if not isinstance(json.loads(line), dict):
+        raise SystemExit(1)
+' >/dev/null 2>&1; then
+    fail "a missing cpufreq sysfs tree produced a line on stdout that is not a JSON object: $cpufreq_stdout"
+fi
+
+# The utilization fallback (get_utilization's sed -i failure path) is meant to
+# append to the same state file the sed -i targeted. It used to reference
+# $cpuinfo_file, a variable this script never assigns (a leftover from
+# cpuinfo.sh, which this block was copied from) -- so the fallback silently
+# wrote nowhere instead of persisting utilization state (#2028).
+grep -q '>>"\$cpuinfo_file"' "$script" &&
+    fail "the utilization fallback still writes to \$cpuinfo_file, which gpuinfo.sh never assigns (#2028)"
 
 finish


### PR DESCRIPTION
Fixes #2028.

## What was wrong

1. `general_query()` let `awk` open `/sys/devices/system/cpu/cpufreq/policy*/scaling_cur_freq` and `.../cpu0/cpufreq/cpuinfo_max_freq` directly. On any host with no cpufreq scaling driver loaded (virtualized/cloud CPUs, some ARM boards, this project's own CI runner), the glob doesn't match, bash passes the literal pattern through, and awk fatals -- two stderr errors on every single poll, forever. Same shape as the `power_now` fix in #2027.

2. `get_utilization()`'s `sed -i` failure fallback wrote to `$cpuinfo_file`, a variable `gpuinfo.sh` never assigns (a copy-paste leftover from `cpuinfo.sh`, which sets it and uses it correctly). The fallback silently wrote to an empty filename instead of persisting utilization state.

## Fix

- Read each cpufreq file only if it exists, and let `awk` do the averaging over the ones that do -- same pattern already used for `power_now`/`current_now` just above it in the file.
- Fixed the fallback to use `$gpuinfo_file`.

## A regression caught along the way

My first pass summed the readings with bash's own `$((...))` arithmetic. That's fragile against exactly the kind of out-of-spec content this fix is meant to be defensive about: anything that isn't a plain integer (e.g. a stray decimal point) makes bash throw its own `arithmetic syntax error` and print a diagnostic to stderr on every poll -- the same class of noise this issue is about removing, just from a different builtin. Switched the summation to `awk`, which coerces malformed content to `0` instead, matching how the rest of the function already treats unreadable/missing sysfs values.

## Tests

- Missing cpufreq tree entirely (the actual bug repro: no fatal, valid JSON).
- Well-formed multi-policy readings average to the correct value (not just "doesn't crash").
- Malformed (non-integer) content degrades gracefully instead of leaking an arithmetic error -- pinned to `LC_ALL=C.utf8` so the assertion doesn't depend on the host's locale (bash localizes that message; this dev machine has it in German).
- Static guard that the utilization fallback no longer references `$cpuinfo_file`.

All 32 existing test cases still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - GPU information collection no longer produces fatal errors on systems without CPU frequency data.
  - CPU clock-speed reporting safely handles missing, incomplete, or malformed frequency readings.
  - Utilization fallback handling records data correctly and avoids invalid output paths.
  - GPU information continues to emit valid JSON when hardware metrics are unavailable or contain unexpected values.
  - Available CPU frequency data is averaged and reported accurately when multiple readings are present.
  - CPU temperature detection now supports additional AMD sensor labels, including Tctl and Tdie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->