### PR TITLE
fix: recognize AMD k10temp/zenpower sensor labels in gpuinfo.sh (#1952)

### DIFF
--- a/Configs/.local/lib/hyde/gpuinfo.sh
+++ b/Configs/.local/lib/hyde/gpuinfo.sh
@@ -192,10 +192,9 @@ generate_json() {
 general_query() {
     filter=''
     sensors_data=$(sensors 2>/dev/null)
-    # "edge" is amdgpu's GPU temp, "Package id.*" is Intel CPU package temp --
-    # an AMD CPU (k10temp/zenpower, label Tctl or Tdie) matched neither and
-    # fell through empty, cascading into an invalid "percentage" and an error
-    # log every poll (#1952).
+    # "edge" is amdgpu's GPU temp, "Package id.*" is Intel CPU package temp.
+    # Some AMD CPUs expose temperature via k10temp/zenpower with labels "Tctl"/"Tdie";
+    # without matching those, `temperature` can be empty on such systems (#1952).
     temperature=$(echo "$sensors_data" | $filter grep -m 1 -E "(edge|Package id.*|Tctl|Tdie)" | awk -F ':' '{print int($2)}')
     fan_speed=$(echo "$sensors_data" | $filter grep -m 1 -E "fan[1-9]" | awk -F ':' '{print int($2)}')
     local power_supply_dir="${GPUINFO_POWER_SUPPLY_DIR:-/sys/class/power_supply}"

--- a/Configs/.local/lib/hyde/gpuinfo.sh
+++ b/Configs/.local/lib/hyde/gpuinfo.sh
@@ -192,7 +192,11 @@ generate_json() {
 general_query() {
     filter=''
     sensors_data=$(sensors 2>/dev/null)
-    temperature=$(echo "$sensors_data" | $filter grep -m 1 -E "(edge|Package id.*|another keyword)" | awk -F ':' '{print int($2)}')
+    # "edge" is amdgpu's GPU temp, "Package id.*" is Intel CPU package temp --
+    # an AMD CPU (k10temp/zenpower, label Tctl or Tdie) matched neither and
+    # fell through empty, cascading into an invalid "percentage" and an error
+    # log every poll (#1952).
+    temperature=$(echo "$sensors_data" | $filter grep -m 1 -E "(edge|Package id.*|Tctl|Tdie)" | awk -F ':' '{print int($2)}')
     fan_speed=$(echo "$sensors_data" | $filter grep -m 1 -E "fan[1-9]" | awk -F ':' '{print int($2)}')
     local power_supply_dir="${GPUINFO_POWER_SUPPLY_DIR:-/sys/class/power_supply}"
     local power_raw current_raw voltage_raw

--- a/tests/test_gpuinfo.sh
+++ b/tests/test_gpuinfo.sh
@@ -123,4 +123,34 @@ else
     fi
 fi
 
+# An AMD CPU's k10temp/zenpower sensor labels its reading "Tctl"/"Tdie", not
+# "edge" (amdgpu GPU) or "Package id" (Intel CPU) -- the only two the
+# temperature regex recognized, plus a literal unfinished "another keyword"
+# placeholder that never matched anything. A system with neither an amdgpu
+# GPU nor an Intel CPU (e.g. an AMD CPU with a non-amdgpu/non-detected GPU)
+# got an empty temperature on every poll (#1952).
+cat >"$fake_bin/sensors" <<'EOF'
+#!/bin/sh
+cat <<'SENSORS'
+k10temp-pci-00c3
+Adapter: PCI adapter
+Tctl:         +45.0°C
+Tdie:         +45.0°C
+
+SENSORS
+EOF
+chmod +x "$fake_bin/sensors"
+
+rm -f "$state_file"
+amd_stdout=$(PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
+amd_stderr=$(cat "$stderr_file")
+
+case $amd_stdout in
+*'45°C'*) ;;
+*) fail "an AMD k10temp Tctl reading of 45°C was not picked up as the temperature: $amd_stdout" ;;
+esac
+case $amd_stderr in
+*"division by zero"*) fail "an AMD k10temp reading crashed awk with a division-by-zero: $amd_stderr" ;;
+esac
+
 finish

--- a/tests/test_gpuinfo.sh
+++ b/tests/test_gpuinfo.sh
@@ -129,28 +129,121 @@ fi
 # placeholder that never matched anything. A system with neither an amdgpu
 # GPU nor an Intel CPU (e.g. an AMD CPU with a non-amdgpu/non-detected GPU)
 # got an empty temperature on every poll (#1952).
+#
+# "Tctl" and "Tdie" are separate alternatives in the regex -- a dump carrying
+# only one of them has to match on its own, not just the pair together, or a
+# driver/board that only ever exposes one of the two would still come back
+# empty despite the fix.
 cat >"$fake_bin/sensors" <<'EOF'
 #!/bin/sh
 cat <<'SENSORS'
 k10temp-pci-00c3
 Adapter: PCI adapter
 Tctl:         +45.0°C
-Tdie:         +45.0°C
 
 SENSORS
 EOF
 chmod +x "$fake_bin/sensors"
 
 rm -f "$state_file"
-amd_stdout=$(PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
-amd_stderr=$(cat "$stderr_file")
+tctl_stdout=$(PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
+tctl_stderr=$(cat "$stderr_file")
 
-case $amd_stdout in
+case $tctl_stdout in
 *'45°C'*) ;;
-*) fail "an AMD k10temp Tctl reading of 45°C was not picked up as the temperature: $amd_stdout" ;;
+*) fail "an AMD k10temp Tctl-only reading of 45°C was not picked up as the temperature: $tctl_stdout" ;;
 esac
-case $amd_stderr in
-*"division by zero"*) fail "an AMD k10temp reading crashed awk with a division-by-zero: $amd_stderr" ;;
+case $tctl_stderr in
+*"division by zero"*) fail "a Tctl-only reading crashed awk with a division-by-zero: $tctl_stderr" ;;
+esac
+
+cat >"$fake_bin/sensors" <<'EOF'
+#!/bin/sh
+cat <<'SENSORS'
+k10temp-pci-00c3
+Adapter: PCI adapter
+Tdie:         +52.0°C
+
+SENSORS
+EOF
+chmod +x "$fake_bin/sensors"
+
+rm -f "$state_file"
+tdie_stdout=$(PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
+tdie_stderr=$(cat "$stderr_file")
+
+case $tdie_stdout in
+*'52°C'*) ;;
+*) fail "an AMD k10temp Tdie-only reading of 52°C was not picked up as the temperature: $tdie_stdout" ;;
+esac
+case $tdie_stderr in
+*"division by zero"*) fail "a Tdie-only reading crashed awk with a division-by-zero: $tdie_stderr" ;;
+esac
+
+# Out-of-spec: the matched line's value is not a number at all (a driver
+# quirk, or a board that reports an unsupported/placeholder reading). awk's
+# int() coerces this to 0 instead of dying on it -- this only confirms that
+# still holds for the newly matched labels, not just the pre-existing ones.
+cat >"$fake_bin/sensors" <<'EOF'
+#!/bin/sh
+cat <<'SENSORS'
+k10temp-pci-00c3
+Adapter: PCI adapter
+Tctl:         N/A
+
+SENSORS
+EOF
+chmod +x "$fake_bin/sensors"
+
+rm -f "$state_file"
+garbage_stdout=$(PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
+garbage_stderr=$(cat "$stderr_file")
+
+case $garbage_stderr in
+*"division by zero"*) fail "a non-numeric Tctl reading crashed awk with a division-by-zero: $garbage_stderr" ;;
+esac
+if [ -z "$garbage_stdout" ] || ! printf '%s\n' "$garbage_stdout" | python3 -c '
+import json, sys
+lines = [line for line in sys.stdin.read().splitlines() if line.strip()]
+if not lines:
+    raise SystemExit(1)
+for line in lines:
+    if not isinstance(json.loads(line), dict):
+        raise SystemExit(1)
+' >/dev/null 2>&1; then
+    fail "a non-numeric Tctl reading produced a line on stdout that is not a JSON object: $garbage_stdout"
+fi
+
+# Ambiguous case the regex was already living with before this fix: a system
+# that (however unusually) exposes both an amdgpu "edge" reading and a CPU
+# "Tctl" reading. grep -m 1 takes whichever line comes first in the sensors
+# dump -- asserting that pins the actual, currently-observed precedence as a
+# known behavior instead of leaving it silently undefined.
+cat >"$fake_bin/sensors" <<'EOF'
+#!/bin/sh
+cat <<'SENSORS'
+k10temp-pci-00c3
+Adapter: PCI adapter
+Tctl:         +45.0°C
+
+amdgpu-pci-0100
+Adapter: PCI adapter
+edge:         +60.0°C
+
+SENSORS
+EOF
+chmod +x "$fake_bin/sensors"
+
+rm -f "$state_file"
+both_stdout=$(PATH="$fake_bin:$PATH" bash "$script" 2>"$stderr_file")
+both_stderr=$(cat "$stderr_file")
+
+case $both_stdout in
+*'45°C'*) ;;
+*) fail "with both a Tctl and an edge reading present, the first line (Tctl, 45°C) was not the one picked: $both_stdout" ;;
+esac
+case $both_stderr in
+*"division by zero"*) fail "a combined Tctl+edge reading crashed awk with a division-by-zero: $both_stderr" ;;
 esac
 
 finish


### PR DESCRIPTION
Fixes #1952.

## What was wrong

`general_query()`'s temperature regex only recognized `edge` (amdgpu GPU temp) and `Package id.*` (Intel CPU package temp), plus a literal, unfinished `another keyword` placeholder that never matched anything. A system with an AMD CPU and no amdgpu GPU (e.g. paired with an Intel/unrecognized dGPU, as in the report) matched neither branch, so `temperature` came back empty every poll.

The JSON-validity/division-by-zero fallout from an empty temperature is already handled by #2022 (merged) -- this fix is just the regex itself, so real hardware actually gets a number instead of falling through to the already-safe empty case.

## Fix

Replaced the placeholder with `Tctl|Tdie`, the labels AMD's `k10temp`/`zenpower` sensor drivers use for CPU temperature (already known to this codebase -- `cpuinfo.sh` matches against `k10temp-pci-00c3`/`zenpower-pci-00c3` chip names for the same reason).

## Tests

Extended `tests/test_gpuinfo.sh` with cases for:
- `Tctl` alone and `Tdie` alone (they're separate regex alternatives; a combined dump wouldn't have exercised both branches)
- a non-numeric matched value (confirms the existing `awk int()` coercion still degrades gracefully instead of crashing for the newly matched labels)
- an amdgpu `edge` reading and a `Tctl` reading both present, pinning the actual observed `grep -m 1` precedence as known behavior

All existing test cases still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature monitoring for AMD systems using Tctl or Tdie sensor labels.
  * Prevented missing temperature readings from causing invalid percentages and recurring error messages.
  * Handled unavailable temperature values without crashing.

* **Tests**
  * Added coverage for AMD sensor formats, unavailable readings, and systems reporting multiple temperature sensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->