### PR TITLE
fix: source globalcontrol.sh in hyde-shell's app dispatch (#1951)

### DIFF
--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -516,6 +516,16 @@ export BIN_DIR LIB_DIR SHARE_DIR PATH HYDE_SCRIPTS_PATH
 
 case "$1" in
 app)
+    # app launches a service/scope that outlives this shell via exec, so
+    # anything it needs from HyDE's generated config (e.g. config.toml ->
+    # env vars like BATTERY_NOTIFY_DOCK) has to be sourced and exported
+    # before the exec below -- this path used to skip globalcontrol.sh
+    # entirely and reach it only on the fallback branch further down,
+    # silently launching every app-managed service without it (#1951).
+    if ! source "${LIB_DIR}/hyde/globalcontrol.sh"; then
+        echo "Error: Could not load HyDE, broken installation?"
+        exit 1
+    fi
     export PATH="${HYDE_SCRIPTS_PATH}:${PATH}"
     [[ "${HYDEPY}" -eq 1 ]] && python_activate
     shift

--- a/tests/test_hyde_shell_app_env.sh
+++ b/tests/test_hyde_shell_app_env.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# `hyde-shell app` launches a service/scope via `exec`, so a process started
+# through it (every hc.start.* entry in variables.lua uses this path) has to
+# inherit whatever HyDE's generated config exports. This case used to skip
+# globalcontrol.sh entirely -- and with it export_hyde_config(), which
+# sources ~/.local/state/hyde/config (config.toml's generated env vars, e.g.
+# BATTERY_NOTIFY_DOCK) -- and only reached it on hyde-shell's other,
+# non-"app" code path (#1951).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+hyde_shell="$REPO_ROOT/Configs/.local/bin/hyde-shell"
+[ -f "$hyde_shell" ] || {
+    fail "hyde-shell not found at $hyde_shell"
+    finish
+}
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+home_dir="$work_dir/home"
+mkdir -p "$home_dir/.local/state/hyde" "$home_dir/.config"
+printf 'export BATTERY_NOTIFY_DOCK=true\n' >"$home_dir/.local/state/hyde/config"
+
+# app.sh hands off to app2unit when a systemd user session exists, or to a
+# plain `exec` of the trailing command otherwise -- this fake stands in for
+# both identically, so the test doesn't depend on whether this machine
+# happens to have one running.
+fake_bin="$work_dir/fake_bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/app2unit" <<'EOF'
+#!/bin/sh
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+[ "$#" -gt 0 ] && shift
+exec "$@"
+EOF
+chmod +x "$fake_bin/app2unit"
+
+bin_dir=$(dirname "$hyde_shell")
+
+##
+# Runs `hyde-shell app -- "$@"` against the sandboxed HOME, with the fake
+# app2unit and the real hyde-shell/its sibling scripts on PATH.
+##
+run_app() {
+    env -i \
+        HOME="$home_dir" \
+        XDG_CONFIG_HOME="$home_dir/.config" \
+        XDG_DATA_HOME="$home_dir/.local/share" \
+        XDG_CACHE_HOME="$home_dir/.cache" \
+        XDG_STATE_HOME="$home_dir/.local/state" \
+        XDG_RUNTIME_DIR="$home_dir/run" \
+        PATH="$fake_bin:$bin_dir:/usr/bin:/bin" \
+        bash "$hyde_shell" app -- "$@"
+}
+
+output=$(run_app sh -c 'echo "BATTERY_NOTIFY_DOCK=$BATTERY_NOTIFY_DOCK"' 2>"$work_dir/stderr")
+
+case $output in
+*'BATTERY_NOTIFY_DOCK=true'*) ;;
+*)
+    fail "hyde-shell app did not forward BATTERY_NOTIFY_DOCK from ~/.local/state/hyde/config to the launched process: got '$output' (stderr: $(cat "$work_dir/stderr"))"
+    ;;
+esac
+
+# Out-of-spec: no generated config file at all (a fresh install, or a user
+# who never set anything in config.toml) must not turn into a hard failure --
+# export_hyde_config() is documented to treat an absent file as success, and
+# that has to keep holding on this newly-added call site too.
+rm -f "$home_dir/.local/state/hyde/config"
+missing_output=$(run_app sh -c 'echo "status=ok BATTERY_NOTIFY_DOCK=$BATTERY_NOTIFY_DOCK"' 2>"$work_dir/stderr")
+case $missing_output in
+*'status=ok'*) ;;
+*)
+    fail "hyde-shell app failed outright with no generated config file present: got '$missing_output' (stderr: $(cat "$work_dir/stderr"))"
+    ;;
+esac
+case $missing_output in
+*'BATTERY_NOTIFY_DOCK=true'*)
+    fail "a variable from a nonexistent config file was still set: $missing_output"
+    ;;
+esac
+
+finish


### PR DESCRIPTION
Fixes #1951.

## What was wrong

Every `hc.start.*` entry in `variables.lua` launches its service through `hyde-shell app -u ... -t service|scope -- <cmd>`. That subcommand is handled by its own early `case "$1" in app) ... exec app.sh "$@" ;; ... esac` branch, which `exec`s straight into `app.sh` (and from there into `app2unit`, or a plain `exec` when there's no systemd user session) -- it never reaches `source "${LIB_DIR}/hyde/globalcontrol.sh"` further down the script, which every *other* hyde-shell subcommand goes through.

`globalcontrol.sh` calls `export_hyde_config()`, which sources `~/.local/state/hyde/config` -- the env vars HyDE generates from `~/.config/hyde/config.toml` (`BATTERY_NOTIFY_DOCK`, in the report). So a service launched via `app` never saw those variables: the generated file had the right value, but the running process's environment didn't, and it silently fell back to its own default.

This affects any `hc.start.*` service, not just `batterynotify.lua` -- `dunst`, the applets, `hyprsunset`, etc. all launch through the same `app` path.

## Fix

Source `globalcontrol.sh` inside the `app)` case too, before the `exec`, matching the error handling already used on the other path. `export`ed variables set before an `exec` are inherited by the process that replaces the shell, so this reaches the actual launched service.

## Tests

New `tests/test_hyde_shell_app_env.sh`:
- a sandboxed `HOME` with a generated `~/.local/state/hyde/config` setting `BATTERY_NOTIFY_DOCK=true` -- confirms `hyde-shell app -- <cmd>` now forwards it to the launched process (fails against the pre-fix script, verified locally).
- no generated config file at all (a fresh install) -- confirms this doesn't turn into a hard failure, since `export_hyde_config()` already treats a missing file as success and that has to keep holding on this newly added call site too.

Both a real systemd user session and its absence hit the same code path in this test (a stubbed `app2unit` stands in for either), so it's not dependent on the runner's systemd state.

All existing test cases still pass (33/33).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `hyde-shell app` so generated configuration environment variables are available to app-managed services.
  - Added clear error handling when configuration loading fails.
  - Commands continue to work when no generated configuration file is present.

- **Tests**
  - Added coverage verifying environment variable forwarding and behavior with missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->