### PR TITLE
fix: quote/escape the remaining shell-out call sites from #1901

### DIFF
--- a/Configs/.local/lib/hyde/altab.lua
+++ b/Configs/.local/lib/hyde/altab.lua
@@ -132,8 +132,18 @@ local function file_exists(path)
     return false
 end
 
+-- Quoting alone isn't escaping: a cmd containing a single quote still closes
+-- this early and reaches the shell (#1901's path.lua had the same class of
+-- bug via HOME; only hardcoded callers exist here today, but the next one
+-- might not be).
+local function shell_quote(arg)
+    arg = tostring(arg)
+    arg = arg:gsub("'", "'\\''")
+    return "'" .. arg .. "'"
+end
+
 local function which(cmd)
-    local h = io.popen("command -v '" .. cmd .. "' 2>/dev/null")
+    local h = io.popen("command -v " .. shell_quote(cmd) .. " 2>/dev/null")
     local r = h:read("*a")
     h:close()
     return r and r:match("%S")

--- a/Configs/.local/lib/hyde/batterynotify.lua
+++ b/Configs/.local/lib/hyde/batterynotify.lua
@@ -58,8 +58,16 @@ local function getenv_int(name, default)
     local v = os.getenv(name); if not v then return default end; local n = tonumber(v); if not n then return default end; return
         n
 end
+-- Unused today, but a command name reaching the shell unescaped is the same
+-- class of bug reported in #1901 (path.lua's directory probe) -- fixed here
+-- too so it isn't a landmine for whatever calls this next.
+local function shell_quote(arg)
+    arg = tostring(arg)
+    arg = arg:gsub("'", "'\\''")
+    return "'" .. arg .. "'"
+end
 local function has_command(cmd)
-    local f = io.popen('command -v ' .. cmd .. ' 2>/dev/null')
+    local f = io.popen('command -v ' .. shell_quote(cmd) .. ' 2>/dev/null')
     if not f then return false end
     local out = f:read('*l'); f:close(); return out and out ~= ''
 end

--- a/Configs/.local/lib/hyde/color/dconf.lua
+++ b/Configs/.local/lib/hyde/color/dconf.lua
@@ -61,9 +61,17 @@ local wm = Gio.Settings.new("org.gnome.desktop.wm.preferences")
 if BUTTON_LAYOUT then wm:set_string("button-layout", BUTTON_LAYOUT) end
 Gio.Settings.sync()
 
+-- TERMINAL comes from the user's own config (hyde.config.ui.terminal), so a
+-- quote in it must not break the probe or reach the shell unescaped (#1901).
+local function shell_quote(arg)
+    arg = tostring(arg)
+    arg = arg:gsub("'", "'\\''")
+    return "'" .. arg .. "'"
+end
+
 local ok_term, term = pcall(Gio.Settings.new, "org.gnome.desktop.default-applications.terminal")
 if ok_term and term then
-    local handle = io.popen("command -v " .. TERMINAL .. " 2>/dev/null")
+    local handle = io.popen("command -v " .. shell_quote(TERMINAL) .. " 2>/dev/null")
     local bin = handle and handle:read("*l") or TERMINAL
     if handle then handle:close() end
     if bin and bin ~= "" then

--- a/tests/lua/shell_quote_harness.lua
+++ b/tests/lua/shell_quote_harness.lua
@@ -1,0 +1,91 @@
+-- Every fix for #1901's remaining call sites (dconf.lua, batterynotify.lua,
+-- altab.lua) uses this exact single-quote-escaping idiom, already
+-- established elsewhere in the codebase (hyde/dispatcher.lua, among
+-- others). Rather than loading each of those three files -- which pull in
+-- lgi/Gio/DBus -- this proves the shared escaping logic itself is actually
+-- injection-proof against both vulnerable shapes those files had, and still
+-- resolves a real command name correctly.
+--
+-- The three sites had two distinct unsafe shapes, and a payload crafted for
+-- one does not exploit the other -- both are exercised explicitly:
+--   1. No shell quoting at all (dconf.lua, batterynotify.lua before the fix):
+--      "command -v " .. value .. " ...". Any value containing a shell
+--      metacharacter runs as a separate command outright.
+--   2. Quoted but not escaped (altab.lua before the fix):
+--      "command -v '" .. value .. "' ...". A value containing a single quote
+--      closes that quote early, so its remainder runs unquoted.
+
+local function shell_quote(arg)
+    arg = tostring(arg)
+    arg = arg:gsub("'", "'\\''")
+    return "'" .. arg .. "'"
+end
+
+local failures = 0
+local function check(condition, message)
+    if not condition then
+        failures = failures + 1
+        print("    fail: " .. message)
+    end
+end
+
+local function marker_was_created(cmd)
+    local marker = os.tmpname()
+    os.remove(marker)
+    -- Grouped so the redirect swallows every command in a ";"-separated
+    -- payload, not just the last one -- an unredirected earlier command
+    -- (e.g. the sanity checks' own "command -v sh") would otherwise leak
+    -- its output to this test's stdout.
+    os.execute("{ " .. cmd:gsub("MARKER", marker) .. "; } >/dev/null 2>&1")
+    local f = io.open(marker, "r")
+    local created = f ~= nil
+    if f then
+        f:close()
+        os.remove(marker)
+    end
+    return created
+end
+
+-- Shape 1, unfixed: no shell quoting at all -- confirms the payload below is
+-- a real exploit against that shape before checking the fix neutralizes it.
+check(
+    marker_was_created('command -v sh; touch MARKER; echo x'),
+    "sanity check failed: the unquoted-shape payload did not execute against the actually-unquoted template -- the test payload itself is wrong"
+)
+
+-- Shape 1, fixed: same payload, now through shell_quote.
+check(
+    not marker_was_created("command -v " .. shell_quote("sh; touch MARKER; echo x")),
+    "a value with no framing quotes still executed an injected command once passed through shell_quote"
+)
+
+-- Shape 2, unfixed: quoted but not escaped (altab.lua/path.lua's original
+-- bug) -- confirms this payload is a real exploit against that shape too.
+check(
+    marker_was_created("command -v 'x'; touch MARKER; echo '' 2>/dev/null"),
+    "sanity check failed: the quote-closing payload did not execute against the actually-quoted-not-escaped template -- the test payload itself is wrong"
+)
+
+-- Shape 2, fixed: same style of payload, now through shell_quote.
+check(
+    not marker_was_created("command -v " .. shell_quote("x'; touch MARKER; echo '") .. " 2>/dev/null"),
+    "a quote-closing payload still executed an injected command once passed through shell_quote"
+)
+
+-- A value that is merely quoted, not escaped, breaks the same way on a bare
+-- single quote with no command at all -- the plain "lost functionality" half
+-- of #1901 (a HOME/username with an apostrophe), not just code execution.
+local quote_only_payload = "o'brien"
+local handle = io.popen("echo " .. shell_quote(quote_only_payload))
+local echoed = handle:read("*l")
+handle:close()
+check(echoed == quote_only_payload, "a value containing a single quote did not round-trip through shell_quote: got " .. tostring(echoed))
+
+-- A real command name must still resolve correctly once quoted -- the fix
+-- must not make command lookup fail for the common, unremarkable case.
+local sh_handle = io.popen("command -v " .. shell_quote("sh") .. " 2>/dev/null")
+local sh_path = sh_handle:read("*l")
+sh_handle:close()
+check(sh_path ~= nil and sh_path ~= "", "a plain command name ('sh') no longer resolves once quoted")
+
+os.exit(failures == 0 and 0 or 1)

--- a/tests/test_shell_quote_injection.sh
+++ b/tests/test_shell_quote_injection.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+# #1901's path.lua fix (PR #1902) left three other call sites with the same
+# class of bug, flagged in the issue's own "Additional Information" but not
+# fixed there: dconf.lua and batterynotify.lua interpolated a value into a
+# shell command with no quoting at all, and altab.lua quoted but did not
+# escape, so a value containing a single quote still closes the quote early.
+# In all three cases the value traces back to something the local user
+# controls (a config.toml setting, or a command name), the same trust
+# boundary #1901 was about.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v lua >/dev/null 2>&1; then
+    skip "lua is not installed"
+    finish
+fi
+
+lua "$TESTS_DIR/lua/shell_quote_harness.lua" || fail "shell_quote_harness reported defects"
+
+dconf_lua="$REPO_ROOT/Configs/.local/lib/hyde/color/dconf.lua"
+batterynotify_lua="$REPO_ROOT/Configs/.local/lib/hyde/batterynotify.lua"
+altab_lua="$REPO_ROOT/Configs/.local/lib/hyde/altab.lua"
+
+for f in "$dconf_lua" "$batterynotify_lua" "$altab_lua"; do
+    [ -f "$f" ] || fail "expected file missing: ${f#"$REPO_ROOT"/}"
+done
+
+grep -q 'io\.popen("command -v " \.\. shell_quote(TERMINAL)' "$dconf_lua" ||
+    fail "dconf.lua's terminal probe no longer quotes TERMINAL before it reaches the shell"
+
+grep -q "io\.popen('command -v ' \.\. shell_quote(cmd)" "$batterynotify_lua" ||
+    fail "batterynotify.lua's has_command no longer quotes cmd before it reaches the shell"
+
+grep -q 'io\.popen("command -v " \.\. shell_quote(cmd) \.\. " 2>/dev/null")' "$altab_lua" ||
+    fail "altab.lua's which no longer quotes cmd before it reaches the shell"
+
+finish


### PR DESCRIPTION
Follow-up to #1901 (already partly fixed in PR #1902 for path.lua's directory probe).

## What was wrong

#1901's own "Additional Information" flagged three more call sites with the same class of bug -- a value interpolated into a shell command without proper quoting/escaping -- that weren't fixed by #1902:

- `Configs/.local/lib/hyde/color/dconf.lua`'s terminal probe: `io.popen("command -v " .. TERMINAL .. " 2>/dev/null")` -- no shell quoting at all. `TERMINAL` comes from the user's own config (`hyde.config.ui.terminal`), so a value containing a shell metacharacter runs as a separate command, the same trust boundary as #1901's `HOME`.
- `Configs/.local/lib/hyde/batterynotify.lua`'s `has_command`: same shape around `cmd`. Currently unused anywhere in the file, but left unfixed it's a landmine for whatever calls it next.
- `Configs/.local/lib/hyde/altab.lua`'s `which`: quotes `cmd` in single quotes but never escapes an embedded one, so it closes the quote early the same way `path.lua`'s original bug did. Only called with a hardcoded `"notify-send"` today, so not currently reachable with untrusted input, but the same reasoning applies.

## Fix

All three now use the single-quote-escaping helper already established elsewhere in this codebase (`hyde/dispatcher.lua`, `luautils/selector/rofi.lua`, `luautils/theme/parser.lua`): `'` -> `'\''`, wrapped in single quotes.

## Tests

- `tests/lua/shell_quote_harness.lua`: proves the escaping logic itself is injection-proof against both vulnerable shapes these files had (no quoting at all, and quoted-but-not-escaped), using the exact exploit shape from #1901 (a value that closes a quote and runs an injected command) for each -- including a sanity check that the *unfixed* shape of each payload actually would have executed, so the exploit shapes themselves are verified real. Also confirms a value with an embedded quote round-trips correctly and a plain command name still resolves.
- `tests/test_shell_quote_injection.sh`: runs the harness, plus a static check per file that the fixed call site actually appears (guards against a future edit dropping the quoting).

All existing test cases still pass (33/33).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of command and terminal values containing special characters.
  * Prevented specially crafted values from being interpreted as additional shell commands during command detection.

* **Tests**
  * Added coverage for shell-quoting behavior, including embedded quotes, command resolution, and injection attempts.
  * Added validation for the affected command and terminal checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->