### PR TITLE
fix: keep pyprland's no_anim rule for scratchpads across config reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Waybar: add VSCodium and Chromium icon rules to window module
 
 ### Fixed
+- Hyprland: the dropdown terminal (`SUPER + ALT + T`) no longer reappears and fades out after sliding off-screen when an animation preset is active; pyprland's `no_anim` rule for the `pypr_noanim` tag is registered at runtime and was lost on every config reload, so it is now declared in `window_rules.lua`
 - Waybar, wlogout: fix logout button behavior
 - Waybar: resolve visual collision between privacy and tray modules by adding margins
 - Docs: fix broken HyDE wiki links across the main and translated `README` files

--- a/Configs/.local/share/hypr/lua/window_rules.lua
+++ b/Configs/.local/share/hypr/lua/window_rules.lua
@@ -165,6 +165,19 @@ hl.window_rule(
   }
 )
 
+-- Pyprland tags scratchpad windows `pypr_noanim` while teleporting them off-screen on hide.
+-- It registers this no_anim rule itself via `hyprctl eval`, but rules added at runtime do
+-- not survive `hyprctl reload`, so declare it here. See hyprland-community/pyprland#221.
+hl.window_rule(
+  {
+    name = "pypr_noanim",
+    match = {
+      tag = "pypr_noanim"
+    },
+    no_anim = true
+  }
+)
+
 -- filemanagers
 hl.window_rule({
 	name = "filemanagers-fullscreen",


### PR DESCRIPTION
## Description

Hiding the dropdown terminal (`SUPER + ALT + T`) with any animation preset active makes the window slide off-screen, then reappear at its on-screen position and fade out ("ghost"). Only the *Disabled (No Animations)* preset hides the problem, because it disables every animation.

**Cause.** Pyprland tags the scratchpad window with `pypr_noanim` while it teleports the window off-screen and onto its special workspace, and relies on a `no_anim` windowrule for that tag so the teleport and the workspace move are instant. Under the Lua config it registers that rule at startup through `hyprctl eval` (`hl.window_rule({no_anim=true, match={tag="pypr_noanim"}})`). Rules added at runtime are discarded by every `hyprctl reload`, and HyDE reloads on each theme or animation switch. From then on the teleport and the workspace move are animated, which is the ghost. Verified on Hyprland 0.56.2 with pyprland 3.4.3: an `eval`-registered rule stops matching right after `hyprctl reload`, while the same rule declared in `window_rules.lua` keeps matching.

**Fix.** Declare the rule in `window_rules.lua`, so it is part of the config and survives reloads. It only affects windows carrying the `pypr_noanim` tag, which pyprland adds for a single frame during hide, so the slide animation itself is unchanged.

**Verification.** Sampled a strip of the screen with `grim` every ~60 ms while hiding the terminal with the *Classic* preset (mean pixel difference to the hidden desktop). Without the rule the difference drops as the terminal slides out and then rises again (1.8 → 5.1 → 7.0) before fading: the ghost. With the rule it drops and stays down (2.3 → 0.7 → 0.9 → 0.8). A class-wide `no_anim` also removes the ghost but kills the slide, so the tag-scoped rule is the right one.

Ref: hyprland-community/pyprland#221 (same symptom; pyprland's own fix is the runtime-registered rule that this PR makes reload-proof under the Lua config).

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have tested my code locally and it works as expected.

## Additional context

Tested on Arch Linux, Hyprland 0.56.2, pyprland 3.4.3 (HyDE-pinned), 1920x1080 @ scale 1, NVIDIA + AMD iGPU.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Hyprland dropdown terminal could reappear and fade out after being hidden when animations were enabled.
  * The terminal now consistently moves off-screen instantly, including after Hyprland configuration reloads.
  * Dropdown terminal behavior remains consistent when using animation presets and reloading the Hyprland configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
