### PR TITLE
fix: use Lua DPMS dispatchers in hypridle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Waybar, wlogout: fix logout button behavior
 - Waybar: resolve visual collision between privacy and tray modules by adding margins
 - Docs: fix broken HyDE wiki links across the main and translated `README` files
-- Waybar: correct spacing and missing icons in window module 
+- Waybar: correct spacing and missing icons in window module
 - Waybar: choosing a theme, or just a wallpaper within the current theme, from the HyDE menu, the theme module, the wallpaper widget or the macOS layout's menu no longer silently leaves the wallpaper and colour state unapplied; both paths write into `hypr/themes/colors.conf`, which triggers a Hyprland autoreload, whose reload hook sends `SIGUSR2` to the whole `hyde-Hyprland-bar.service` cgroup — killing the in-flight `theme.select.sh`/`theme.switch.sh`/`wallpaper.sh` process tree along with it. These menu actions now launch them via `hyde-shell app -t scope` so they run in their own cgroup instead of waybar's.
 - Waybar: `gpuinfo` no longer floods stderr with an `awk` fatal error on every poll when a battery exposes a `power_now` attribute the firmware cannot actually read; the value is now read before it is used instead of being handed straight to `awk`
 - Installer: a fresh install no longer aborts on a missing AUR helper before having the chance to install it
 - Wallbash: resolve `integer expected` syntax error in `color.set.sh` when evaluating template failure state
 - Waybar: `gpuinfo` no longer crashes with a division-by-zero error, leaks a plain-text banner into its JSON output on the first poll after a reboot or a `--reset`, or emits an invalid `"percentage":` with no value when no temperature sensor is available; all three used to break the module's parsing
 - Python environment: `uv sync` now targets the HyDE-managed venv at `~/.local/state/hyde/python_env` instead of creating a project-local `.venv`; also forces `--link-mode copy` to avoid silent reflink failures on ext4 that left packages uninstalled
+- Hypridle: use Lua DPMS dispatchers so idle screen-off and resume work with the Hyprland Lua config parser
 
 ## v26.08.21
 

--- a/Configs/.config/hypr/hypridle.conf
+++ b/Configs/.config/hypr/hypridle.conf
@@ -1,11 +1,11 @@
 # Configuring hypridle
 # See: https://wiki.hypr.land/Hypr-Ecosystem/hypridle/
-# 
+#
 # hypridle.conf - Hypridle configuration for HyDE
 # Handles idle actions: dim, lock, DPMS, suspend, and custom listeners
-# 
+#
 # Listeners: Each listener block defines an idle timeout and actions to run
-# 
+#
 # For more info, see: https://wiki.hypr.land/Hypr-Ecosystem/hypridle/
 
 #!      ░▒▒▒░░░▓▓           ___________
@@ -46,8 +46,8 @@ listener {
 # Turns off display (but not if media is playing)
 listener {
     timeout = 300
-    on-timeout = hyprctl dispatch dpms off # Turn off display
-    on-resume = hyprctl dispatch dpms on   # Turn display back on
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })' # Turn off display
+    on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'   # Turn display back on
 }
 
 # // --- Listener: Suspend after 500s idle ---


### PR DESCRIPTION
## Description

Fix the default hypridle DPMS listener for Hyprland's Lua config parser.

The existing commands:

`hyprctl dispatch dpms off`
`hyprctl dispatch dpms on`

are interpreted by the Lua config manager as invalid Lua expressions and fail with:

`[string "return hl.dispatch(dpms off)"]:1: ')' expected near 'off'`

This changes them to the Lua dispatcher API:

`hl.dsp.dpms({ action = "disable" })`
`hl.dsp.dpms({ action = "enable" })`

No new dependencies are introduced.

## Type of change

- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Documentation update**
- [ ] **Technical debt**
- [ ] **Other**

## Checklist

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the commit guidelines.
- [ ] My change requires a change to the documentation.
- [x] I have added a changelog entry.
- [x] I have tested my code locally and it works as expected.

## Testing

Reproduced on HyDE using Hyprland's Lua configuration.

Before the change, the DPMS timeout fails with a Lua parse error.

After the change:
- the idle timeout disables DPMS successfully;
- activity/resume enables DPMS successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed spacing and icon rendering in the Waybar window module.
  - Updated Hypridle DPMS handling to reliably disable and re-enable display power management during idle and resume events.
  - Preserved existing documented fixes while improving the formatting of unreleased changelog entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->