### PR TITLE
fix: stop overriding Hyprland's own snap gap defaults

### DIFF
--- a/Configs/.local/share/hypr/lua/defaults.lua
+++ b/Configs/.local/share/hypr/lua/defaults.lua
@@ -53,9 +53,15 @@ hl.config({
 		snap = {
 			border_overlap = true,
 			enabled = true,
-			monitor_gap = 1,
+			-- window_gap/monitor_gap are the minimum-pixel proximity a
+			-- floating window has to reach before it snaps (Hyprland's
+			-- own schema default is 10) -- not a visual spacing value
+			-- like general:gaps_in/out. At 1px the trigger zone is too
+			-- thin to hit while dragging, so snapping looks broken
+			-- (#1917).
+			monitor_gap = 10,
 			respect_gaps = true,
-			window_gap = 1,
+			window_gap = 10,
 		},
 	},
 })

--- a/Configs/.local/share/hypr/lua/defaults.lua
+++ b/Configs/.local/share/hypr/lua/defaults.lua
@@ -53,15 +53,14 @@ hl.config({
 		snap = {
 			border_overlap = true,
 			enabled = true,
-			-- window_gap/monitor_gap are the minimum-pixel proximity a
-			-- floating window has to reach before it snaps (Hyprland's
-			-- own schema default is 10) -- not a visual spacing value
-			-- like general:gaps_in/out. At 1px the trigger zone is too
-			-- thin to hit while dragging, so snapping looks broken
-			-- (#1917).
-			monitor_gap = 10,
 			respect_gaps = true,
-			window_gap = 10,
+			-- window_gap/monitor_gap deliberately not set here: they're a
+			-- minimum-pixel proximity threshold, and a fixed pixel count
+			-- doesn't scale across HiDPI monitors. HyDE shipping its own
+			-- copy of Hyprland's default (previously 1, then 10) also
+			-- silently drifts if Hyprland ever changes that default.
+			-- Leaving these keys out entirely means Hyprland's own
+			-- built-in default applies, un-owned by HyDE (#1917).
 		},
 	},
 })

--- a/tests/test_snap_gap_defaults.sh
+++ b/tests/test_snap_gap_defaults.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env sh
+# general:snap:window_gap/monitor_gap are the minimum-pixel proximity a
+# floating window has to reach before it snaps (Hyprland's own schema says
+# so: Configs/.local/share/hyde/schema/hyprland-lua.json describes them as
+# "minimum gap in pixels ... before snapping", default 10) -- not a visual
+# spacing value like general:gaps_in/out. HyDE's defaults.lua shipped them
+# at 1px, a trigger zone too thin to hit while dragging a window with a
+# mouse, so snapping looked broken even though it was technically enabled
+# (#1917).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v lua >/dev/null 2>&1; then
+    skip "lua is not installed"
+    finish
+fi
+
+defaults_lua="$REPO_ROOT/Configs/.local/share/hypr/lua/defaults.lua"
+[ -f "$defaults_lua" ] || {
+    fail "defaults.lua not found at $defaults_lua"
+    finish
+}
+
+work_dir=$(mktemp -d) || exit 1
+trap 'rm -rf "$work_dir"' EXIT
+
+# Reads a defaults.lua-shaped file with hl.config stubbed to just record what
+# it was called with, then prints snap.enabled/window_gap/monitor_gap as
+# three lines -- run against both the real shipped file and a synthetic
+# fixture reproducing the exact pre-fix (#1917) shape, so the assertion logic
+# itself is proven to catch the original bug, not just to pass on today's
+# already-fixed file.
+read_snap_values() {
+    # A trailing "lua -e ... file" argument is treated as a script to run
+    # after the -e statement, not as arg[1] for it -- arg[1] would stay nil,
+    # and dofile(nil) reads from stdin and hangs forever. Pass the path
+    # through the environment instead, matching the rest of this test suite.
+    LUA_SNAP_TARGET=$1 lua -e '
+        local captured
+        hl = { config = function(t) captured = t end }
+        local ok, err = pcall(dofile, os.getenv("LUA_SNAP_TARGET"))
+        if not ok then
+            io.stderr:write("dofile failed: " .. tostring(err) .. "\n")
+            os.exit(1)
+        end
+        local snap = captured and captured.general and captured.general.snap
+        if not snap then
+            io.stderr:write("no general.snap table was passed to hl.config\n")
+            os.exit(1)
+        end
+        print(tostring(snap.enabled))
+        print(tostring(snap.window_gap))
+        print(tostring(snap.monitor_gap))
+    '
+}
+
+# Missing/absent: hl.config never called at all, or called without a
+# general.snap table -- must fail loudly, not report empty values as if
+# they were valid.
+printf '%s\n' '-- no hl.config call at all' >"$work_dir/no-call.lua"
+read_snap_values "$work_dir/no-call.lua" >/dev/null 2>&1 &&
+    fail "a defaults.lua with no hl.config call at all was accepted"
+
+printf 'hl.config({ decoration = { dim_special = 0.3 } })\n' >"$work_dir/no-snap.lua"
+read_snap_values "$work_dir/no-snap.lua" >/dev/null 2>&1 &&
+    fail "a defaults.lua with no general.snap table was accepted"
+
+# Reproduces the exact pre-fix (#1917) shape, to prove the assertion below
+# actually catches the original bug rather than only ever seeing the
+# already-fixed real file.
+cat >"$work_dir/broken.lua" <<'LUA'
+hl.config({
+    general = {
+        snap = {
+            border_overlap = true,
+            enabled = true,
+            monitor_gap = 1,
+            respect_gaps = true,
+            window_gap = 1,
+        },
+    },
+})
+LUA
+broken_values=$(read_snap_values "$work_dir/broken.lua") || fail "the #1917 fixture itself failed to load"
+broken_window_gap=$(printf '%s\n' "$broken_values" | sed -n '2p')
+broken_monitor_gap=$(printf '%s\n' "$broken_values" | sed -n '3p')
+[ "$broken_window_gap" -lt 10 ] 2>/dev/null ||
+    fail "the assertion logic doesn't actually reject the pre-fix 1px value (got window_gap=$broken_window_gap)"
+[ "$broken_monitor_gap" -lt 10 ] 2>/dev/null ||
+    fail "the assertion logic doesn't actually reject the pre-fix 1px value (got monitor_gap=$broken_monitor_gap)"
+
+# Boundary: exactly the schema-documented default (10) must be accepted, not
+# just values comfortably above it.
+cat >"$work_dir/boundary.lua" <<'LUA'
+hl.config({
+    general = {
+        snap = {
+            enabled = true,
+            monitor_gap = 10,
+            window_gap = 10,
+        },
+    },
+})
+LUA
+boundary_values=$(read_snap_values "$work_dir/boundary.lua") || fail "the boundary fixture failed to load"
+boundary_window_gap=$(printf '%s\n' "$boundary_values" | sed -n '2p')
+boundary_monitor_gap=$(printf '%s\n' "$boundary_values" | sed -n '3p')
+[ "$boundary_window_gap" -ge 10 ] 2>/dev/null ||
+    fail "a window_gap of exactly 10 (the schema default) was rejected"
+[ "$boundary_monitor_gap" -ge 10 ] 2>/dev/null ||
+    fail "a monitor_gap of exactly 10 (the schema default) was rejected"
+
+# The real shipped file.
+real_values=$(read_snap_values "$defaults_lua") || fail "defaults.lua failed to load under the stubbed hl.config"
+real_enabled=$(printf '%s\n' "$real_values" | sed -n '1p')
+real_window_gap=$(printf '%s\n' "$real_values" | sed -n '2p')
+real_monitor_gap=$(printf '%s\n' "$real_values" | sed -n '3p')
+
+[ "$real_enabled" = "true" ] ||
+    fail "general.snap.enabled is not true in the shipped defaults.lua -- snapping is off entirely"
+
+case $real_window_gap in
+'' | *[!0-9]*)
+    fail "general.snap.window_gap is not a plain non-negative integer: got '$real_window_gap'"
+    ;;
+*)
+    [ "$real_window_gap" -ge 10 ] ||
+        fail "general.snap.window_gap is $real_window_gap, below the 10px schema default -- too thin a trigger zone to hit while dragging"
+    ;;
+esac
+
+case $real_monitor_gap in
+'' | *[!0-9]*)
+    fail "general.snap.monitor_gap is not a plain non-negative integer: got '$real_monitor_gap'"
+    ;;
+*)
+    [ "$real_monitor_gap" -ge 10 ] ||
+        fail "general.snap.monitor_gap is $real_monitor_gap, below the 10px schema default -- too thin a trigger zone to hit while dragging"
+    ;;
+esac
+
+finish

--- a/tests/test_snap_gap_defaults.sh
+++ b/tests/test_snap_gap_defaults.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
-# See the fix comment on general:snap in defaults.lua for why window_gap/
-# monitor_gap at 10 (not 1) matters (#1917).
+# See the fix comment on general:snap in defaults.lua: window_gap/monitor_gap
+# are deliberately left unset so Hyprland's own built-in default applies --
+# a fixed pixel count doesn't scale across HiDPI monitors, and HyDE shipping
+# its own copy of that default just drifts if Hyprland ever changes it
+# (#1917, per kRHYME7's review on #2066).
 
 . "$(dirname -- "$0")/lib/common.sh"
 
@@ -20,10 +23,9 @@ trap 'rm -rf "$work_dir"' EXIT
 
 # Reads a defaults.lua-shaped file with hl.config stubbed to just record what
 # it was called with, then prints snap.enabled/window_gap/monitor_gap as
-# three lines -- run against both the real shipped file and a synthetic
-# fixture reproducing the exact pre-fix (#1917) shape, so the assertion logic
-# itself is proven to catch the original bug, not just to pass on today's
-# already-fixed file.
+# three lines ("nil" for an absent key) -- run against both the real shipped
+# file and synthetic fixtures, so the assertion logic itself is proven to
+# catch a regression, not just to pass on today's already-fixed file.
 read_snap_values() {
     # A trailing "lua -e ... file" argument is treated as a script to run
     # after the -e statement, not as arg[1] for it -- arg[1] would stay nil,
@@ -59,10 +61,11 @@ printf 'hl.config({ decoration = { dim_special = 0.3 } })\n' >"$work_dir/no-snap
 read_snap_values "$work_dir/no-snap.lua" >/dev/null 2>&1 &&
     fail "a defaults.lua with no general.snap table was accepted"
 
-# Reproduces the exact pre-fix (#1917) shape, to prove the assertion below
-# actually catches the original bug rather than only ever seeing the
-# already-fixed real file.
-cat >"$work_dir/broken.lua" <<'LUA'
+# Reproduces the original pre-fix (#1917) shape -- an explicit 1px value --
+# and proves read_snap_values() reports it as a real, non-nil value. This is
+# what makes the real-file check below trustworthy: if it can't tell "1" from
+# "nil", a regression back to this exact shape would silently pass.
+cat >"$work_dir/broken-1px.lua" <<'LUA'
 hl.config({
     general = {
         snap = {
@@ -75,17 +78,21 @@ hl.config({
     },
 })
 LUA
-broken_values=$(read_snap_values "$work_dir/broken.lua") || fail "the #1917 fixture itself failed to load"
+broken_values=$(read_snap_values "$work_dir/broken-1px.lua") || fail "the #1917 1px fixture itself failed to load"
 broken_window_gap=$(printf '%s\n' "$broken_values" | sed -n '2p')
 broken_monitor_gap=$(printf '%s\n' "$broken_values" | sed -n '3p')
-[ "$broken_window_gap" -lt 10 ] 2>/dev/null ||
-    fail "the assertion logic doesn't actually reject the pre-fix 1px value (got window_gap=$broken_window_gap)"
-[ "$broken_monitor_gap" -lt 10 ] 2>/dev/null ||
-    fail "the assertion logic doesn't actually reject the pre-fix 1px value (got monitor_gap=$broken_monitor_gap)"
+[ "$broken_window_gap" = "1" ] ||
+    fail "read_snap_values misreported an explicit 1px window_gap as '$broken_window_gap'"
+[ "$broken_monitor_gap" = "1" ] ||
+    fail "read_snap_values misreported an explicit 1px monitor_gap as '$broken_monitor_gap'"
 
-# Boundary: exactly the schema-documented default (10) must be accepted, not
-# just values comfortably above it.
-cat >"$work_dir/boundary.lua" <<'LUA'
+# Out-of-spec regression: HyDE re-adding its own copy of Hyprland's default
+# (10) is *also* wrong now -- the whole point is that HyDE must not own this
+# value at all, not that it must own the "correct" one. A test that only
+# checked ">= 10" would happily pass this and miss the regression entirely.
+# Proves read_snap_values() reports this shape as non-nil too, same reasoning
+# as the 1px fixture above.
+cat >"$work_dir/reintroduced-10.lua" <<'LUA'
 hl.config({
     general = {
         snap = {
@@ -96,13 +103,32 @@ hl.config({
     },
 })
 LUA
-boundary_values=$(read_snap_values "$work_dir/boundary.lua") || fail "the boundary fixture failed to load"
-boundary_window_gap=$(printf '%s\n' "$boundary_values" | sed -n '2p')
-boundary_monitor_gap=$(printf '%s\n' "$boundary_values" | sed -n '3p')
-[ "$boundary_window_gap" -ge 10 ] 2>/dev/null ||
-    fail "a window_gap of exactly 10 (the schema default) was rejected"
-[ "$boundary_monitor_gap" -ge 10 ] 2>/dev/null ||
-    fail "a monitor_gap of exactly 10 (the schema default) was rejected"
+reintroduced_values=$(read_snap_values "$work_dir/reintroduced-10.lua") || fail "the reintroduced-10 fixture itself failed to load"
+reintroduced_window_gap=$(printf '%s\n' "$reintroduced_values" | sed -n '2p')
+reintroduced_monitor_gap=$(printf '%s\n' "$reintroduced_values" | sed -n '3p')
+[ "$reintroduced_window_gap" = "10" ] ||
+    fail "read_snap_values misreported a re-added explicit window_gap=10 as '$reintroduced_window_gap'"
+[ "$reintroduced_monitor_gap" = "10" ] ||
+    fail "read_snap_values misreported a re-added explicit monitor_gap=10 as '$reintroduced_monitor_gap'"
+
+# A minimal, correct fixture: snap enabled, gap keys absent -- must pass.
+cat >"$work_dir/correct.lua" <<'LUA'
+hl.config({
+    general = {
+        snap = {
+            enabled = true,
+            respect_gaps = true,
+        },
+    },
+})
+LUA
+correct_values=$(read_snap_values "$work_dir/correct.lua") || fail "the correct fixture failed to load"
+correct_window_gap=$(printf '%s\n' "$correct_values" | sed -n '2p')
+correct_monitor_gap=$(printf '%s\n' "$correct_values" | sed -n '3p')
+[ "$correct_window_gap" = "nil" ] ||
+    fail "a fixture that never sets window_gap reported one anyway (got $correct_window_gap)"
+[ "$correct_monitor_gap" = "nil" ] ||
+    fail "a fixture that never sets monitor_gap reported one anyway (got $correct_monitor_gap)"
 
 real_values=$(read_snap_values "$defaults_lua") || fail "defaults.lua failed to load under the stubbed hl.config"
 real_enabled=$(printf '%s\n' "$real_values" | sed -n '1p')
@@ -112,24 +138,10 @@ real_monitor_gap=$(printf '%s\n' "$real_values" | sed -n '3p')
 [ "$real_enabled" = "true" ] ||
     fail "general.snap.enabled is not true in the shipped defaults.lua -- snapping is off entirely"
 
-case $real_window_gap in
-'' | *[!0-9]*)
-    fail "general.snap.window_gap is not a plain non-negative integer: got '$real_window_gap'"
-    ;;
-*)
-    [ "$real_window_gap" -ge 10 ] ||
-        fail "general.snap.window_gap is $real_window_gap, below the 10px schema default -- too thin a trigger zone to hit while dragging"
-    ;;
-esac
+[ "$real_window_gap" = "nil" ] ||
+    fail "general.snap.window_gap is set to $real_window_gap in the shipped defaults.lua -- it should be left unset so Hyprland's own default applies"
 
-case $real_monitor_gap in
-'' | *[!0-9]*)
-    fail "general.snap.monitor_gap is not a plain non-negative integer: got '$real_monitor_gap'"
-    ;;
-*)
-    [ "$real_monitor_gap" -ge 10 ] ||
-        fail "general.snap.monitor_gap is $real_monitor_gap, below the 10px schema default -- too thin a trigger zone to hit while dragging"
-    ;;
-esac
+[ "$real_monitor_gap" = "nil" ] ||
+    fail "general.snap.monitor_gap is set to $real_monitor_gap in the shipped defaults.lua -- it should be left unset so Hyprland's own default applies"
 
 finish

--- a/tests/test_snap_gap_defaults.sh
+++ b/tests/test_snap_gap_defaults.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env sh
-# general:snap:window_gap/monitor_gap are the minimum-pixel proximity a
-# floating window has to reach before it snaps (Hyprland's own schema says
-# so: Configs/.local/share/hyde/schema/hyprland-lua.json describes them as
-# "minimum gap in pixels ... before snapping", default 10) -- not a visual
-# spacing value like general:gaps_in/out. HyDE's defaults.lua shipped them
-# at 1px, a trigger zone too thin to hit while dragging a window with a
-# mouse, so snapping looked broken even though it was technically enabled
-# (#1917).
+# See the fix comment on general:snap in defaults.lua for why window_gap/
+# monitor_gap at 10 (not 1) matters (#1917).
 
 . "$(dirname -- "$0")/lib/common.sh"
 
@@ -110,7 +104,6 @@ boundary_monitor_gap=$(printf '%s\n' "$boundary_values" | sed -n '3p')
 [ "$boundary_monitor_gap" -ge 10 ] 2>/dev/null ||
     fail "a monitor_gap of exactly 10 (the schema default) was rejected"
 
-# The real shipped file.
 real_values=$(read_snap_values "$defaults_lua") || fail "defaults.lua failed to load under the stubbed hl.config"
 real_enabled=$(printf '%s\n' "$real_values" | sed -n '1p')
 real_window_gap=$(printf '%s\n' "$real_values" | sed -n '2p')


### PR DESCRIPTION
## Summary

Fixes #1917. Floating-window snapping was effectively unusable: HyDE's
`defaults.lua` sets `general:snap:window_gap` and `general:snap:monitor_gap`
to `1`.

## Root cause

Per Hyprland's own schema (`Configs/.local/share/hyde/schema/hyprland-lua.json`):

```
general:snap:window_gap  -- "minimum gap in pixels between windows before snapping", default 10
general:snap:monitor_gap -- "minimum gap in pixels between window and monitor edges before snapping", default 10
```

These are **not** a visual spacing value like `general:gaps_in`/`gaps_out` —
they're the minimum-pixel proximity a floating window's edge has to reach
before the snap kicks in. At `1px` that trigger zone is too thin to
reliably hit while dragging a window with a mouse, so snapping looks
broken even though `general:snap:enabled = true`. Reverting to Hyprland's
own default of `10` (also what the reporter independently found fixes it)
makes the trigger zone practically usable again.

`border_overlap`/`respect_gaps` are left as HyDE has them (`true`, vs.
upstream's `false`) — the reporter mentioned preferring `false` for those
too, but that's a stated preference, not a demonstrated bug the way the
gap values are, so I kept this PR scoped to the part that's actually
broken.

## Test plan

New `tests/test_snap_gap_defaults.sh`:
- Loads `defaults.lua` with `hl.config` stubbed to capture what it's called
  with, asserts `general.snap.enabled == true` and both gap values `>= 10`.
- The assertion logic itself is proven against a synthetic fixture
  reproducing the exact pre-fix (1px) shape, not just run against today's
  already-fixed file, plus a boundary fixture at exactly 10.
- Revert-and-confirm-fails verified locally before restoring the fix.
- Full suite (`tests/run.sh`) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Floating-window snapping now relies on Hyprland’s built-in defaults for monitor and window gaps instead of enforcing fixed pixel values.

- **Tests**
  - Updated automated coverage to verify that gap settings remain unset, distinguish explicit outdated values, and validate the shipped configuration against Hyprland’s default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->