### PR TITLE
fix: give windows that cannot join a group the normal border colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Waybar: add VSCodium and Chromium icon rules to window module
 
 ### Fixed
+- Hyprland: windows that cannot join a group, such as pyprland's dropdown terminal, get the same border colors as every other window; `general.col.nogroup_border` and `nogroup_border_active` were never set, so those windows kept Hyprland's magenta and yellow defaults whatever the theme or wallbash mode
 - Hyprland: the dropdown terminal (`SUPER + ALT + T`) no longer reappears and fades out after sliding off-screen when an animation preset is active; pyprland's `no_anim` rule for the `pypr_noanim` tag is registered at runtime and was lost on every config reload, so it is now declared in `window_rules.lua`
 - Waybar, wlogout: fix logout button behavior
 - Waybar: resolve visual collision between privacy and tray modules by adding margins

--- a/Configs/.local/share/hypr/lua/dynamic.lua
+++ b/Configs/.local/share/hypr/lua/dynamic.lua
@@ -1,13 +1,24 @@
 local color = check_require("lua_state.colors") or {}
 
+-- `group deny` windows (pyprland scratchpads) use the nogroup border colors,
+-- so keep those equal to the normal ones.
+local function border_colors(active, inactive)
+	return {
+		active_border = active,
+		inactive_border = inactive,
+		nogroup_border_active = active,
+		nogroup_border = inactive
+	}
+end
+
 if next(color) then
 	hl.config(
 		{
 			general = {
-				col = {
-					active_border = {colors = {color._pry4_rgba, color._4xa1_rgba}, angle = 45},
-					inactive_border = {colors = {color._pry1_rgba, color._pry2_rgba}, angle = 45}
-				}
+				col = border_colors(
+					{colors = {color._pry4_rgba, color._4xa1_rgba}, angle = 45},
+					{colors = {color._pry1_rgba, color._pry2_rgba}, angle = 45}
+				)
 			},
 			group = {
 				groupbar = {
@@ -51,7 +62,13 @@ end
 -- Note this is translated by hyprquery from hyprlang to lua
 local theme_config = check_require("lua_state.hypr_theme") or {}
 if type(theme_config) == "table" then
-    hl.config(theme_config)
+	-- Derive the nogroup border colors unless the theme sets them.
+	local col = theme_config.general and theme_config.general.col
+	if type(col) == "table" and col.active_border then
+		col.nogroup_border_active = col.nogroup_border_active or col.active_border
+		col.nogroup_border = col.nogroup_border or col.inactive_border or col.active_border
+	end
+	hl.config(theme_config)
 end
 
 -- Load the HyDE's ui config
@@ -95,10 +112,10 @@ if wallbash_mode ~= "theme" and next(color) then
 	hl.config(
 		{
 			general = {
-				col = {
-					active_border = {colors = {color._pry4_rgba, color._4xa1_rgba}, angle = 45},
-					inactive_border = {colors = {color._pry1_rgba, color._pry2_rgba}, angle = 45}
-				}
+				col = border_colors(
+					{colors = {color._pry4_rgba, color._4xa1_rgba}, angle = 45},
+					{colors = {color._pry1_rgba, color._pry2_rgba}, angle = 45}
+				)
 			},
 			group = {
 				groupbar = {


### PR DESCRIPTION
## Description

The dropdown terminal (`SUPER + ALT + T`) always shows a bright magenta border when focused and a yellowish one when not, whatever theme is active and whatever the wallbash mode. Every other window follows the theme.

**Cause.** pyprland applies the `group deny` window rule to its scratchpads. Hyprland draws such windows with `general.col.nogroup_border_active` / `general.col.nogroup_border` instead of the normal `active_border` / `inactive_border`. Nothing in HyDE sets those two options: `dynamic.lua` only sets the normal pair from wallbash, and the themes' `hypr.theme` only set the normal pair too. So those windows keep Hyprland's defaults (`0xffff00ff` active, `0xffffaaff` inactive).

**Fix.** Mirror the normal border colors into the nogroup ones wherever the normal ones are set:

- a small `border_colors(active, inactive)` helper used by both wallbash blocks in `dynamic.lua`;
- when applying the theme dump, derive `nogroup_border_active` / `nogroup_border` from the theme's own `active_border` / `inactive_border`, unless the theme already defines them.

The precedence between theme colors and wallbash colors is unchanged, since the nogroup values are set in the same places and in the same order as the normal ones.

**Verification.** Hyprland 0.56.2, theme Monokai, wallbash mode "theme". Before: `hyprctl getoption general:col.nogroup_border_active` → `ffff00ff`. After a reload with this patch (and no user overrides):

```
active_border            ffca9ee6 fff2d5cf 45deg
nogroup_border_active    ffca9ee6 fff2d5cf 45deg
inactive_border          ccb4befe cc6c7086 45deg
nogroup_border           ccb4befe cc6c7086 45deg
```

The dropdown terminal now has the same border as any other focused window, and it follows theme switches.

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/HyDE-Project/HyDE/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/HyDE-Project/HyDE/blob/master/COMMIT_MESSAGE_GUIDELINES.md).
- [x] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [x] I have tested my code locally and it works as expected.

## Additional context

Related to #2063 (same scratchpad, different symptom). Tested on Arch Linux, Hyprland 0.56.2, pyprland 3.4.3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed border colors for windows that cannot join a group, such as dropdown terminals.
  - These windows now follow the active and inactive border colors from the selected theme, including wallbash-generated themes, instead of using Hyprland’s default magenta and yellow colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->