### PR TITLE
fix: resolve __lua binds to launchable commands in the keybind-hint menu

### DIFF
--- a/Configs/.local/lib/hyde/keybinds/hint-hyprland.py
+++ b/Configs/.local/lib/hyde/keybinds/hint-hyprland.py
@@ -6,6 +6,83 @@ import os
 from collections import defaultdict
 import time
 
+# Bit -> modifier name Hyprland reports in a bind's modmask. Same table
+# map_modDisplay() below uses for display purposes; kept separate because the
+# ordering rules differ (this one has to match hyde/binds.lua's canonicalize,
+# alphabetical, not the display order below).
+_MODIFIER_BITS = {
+    64: "SUPER",
+    32: "HYPER",
+    16: "META",
+    8: "ALT",
+    4: "CTRL",
+    2: "CAPSLOCK",
+    1: "SHIFT",
+}
+
+
+def canonical_combo(modmask, key):
+    """Mirrors hyde/binds.lua's canonicalize(): decompose modmask into
+    modifier names, sort them alphabetically, append the upper-cased key,
+    join with " + ". Returns None for a bind with no key at all (a bare
+    modmask, which Hyprland never emits for a real bind and canonicalize()
+    itself also treats as empty).
+
+    This has to reproduce that algorithm exactly, not just resemble it --
+    it is the lookup key into the cache hyde/binds.lua writes, computed
+    independently on the other side of a file, in a different language.
+    """
+    if not isinstance(key, str) or key == "":
+        return None
+    if not isinstance(modmask, int):
+        return None
+
+    mods = sorted(name for bit, name in _MODIFIER_BITS.items() if modmask & bit)
+    mods.append(key.upper())
+    return " + ".join(mods)
+
+
+def _escape_lua_string(value):
+    """Escapes a string for embedding inside a double-quoted Lua string
+    literal. A raw newline would both break Lua's own quoted-string syntax
+    (unlike a [[ ]] long string, "..." can't contain one literally) and trip
+    keybinds_hint.sh's own single-line check on the dispatch field, so it's
+    escaped like backslash/quote rather than assumed never to appear.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def load_bind_commands():
+    """Reads the combo->command cache hyde/binds.lua writes on every config
+    load (see Configs/.local/share/hypr/lua/hyde/binds.lua). Missing file,
+    unreadable file, malformed JSON, or JSON that isn't a flat string->string
+    object all resolve to an empty map -- __lua binds simply stay
+    unresolved, which is the existing, already-correct fallback behavior for
+    binds that can't be reduced to one command at all.
+    """
+    cache_home = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    cache_path = os.path.join(cache_home, "hyde", "lua_bind_commands.json")
+
+    try:
+        with open(cache_path, "r") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    return {
+        key: value
+        for key, value in data.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
 
 def get_hyprctl_binds():
     while True:
@@ -333,8 +410,10 @@ def generate_rofi(binds):
     return rofi_str
 
 
-def expand_meta_data(binds_data):
+def expand_meta_data(binds_data, bind_commands=None):
     submap_keys = {}
+    if bind_commands is None:
+        bind_commands = {}
 
     # First pass: collect submap keys
     for bind in binds_data:
@@ -347,6 +426,21 @@ def expand_meta_data(binds_data):
         bind["key"] = map_codeDisplay(bind["keycode"], bind["key"])
         bind["key_display"] = map_keyDisplay(bind["key"])
         bind["mod_display"] = map_modDisplay(bind["modmask"])
+
+        # A Lua-registered bind (#1996): hyprctl only ever exposes it as an
+        # opaque "__lua" registry reference, which Hyprland itself has no way
+        # to dispatch from the outside. If hyde/binds.lua's cache has the
+        # command this exact combo was built from, rewrite it into a fresh
+        # exec_cmd call instead -- that runs the same way any other dispatch
+        # does. A combo the cache doesn't have (window/workspace operations,
+        # or any bind not built from hl.dsp.exec_cmd) is left exactly as it
+        # was; that's the documented limit, not a bug.
+        if bind["dispatcher"] == "__lua":
+            combo = canonical_combo(bind["modmask"], bind["key"])
+            command = bind_commands.get(combo) if combo else None
+            if command:
+                bind["dispatcher"] = f'hl.dsp.exec_cmd("{_escape_lua_string(command)}")'
+                bind["arg"] = ""
 
         # Handle submaps
         if bind["dispatcher"] == "submap":
@@ -399,7 +493,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     binds_data = get_hyprctl_binds()
     if binds_data:
-        expand_meta_data(binds_data)
+        expand_meta_data(binds_data, load_bind_commands())
         if args.show_unbind:
             duplicated_binds = find_duplicated_binds(binds_data)
             for (mod_display, key_display), binds in duplicated_binds.items():

--- a/Configs/.local/lib/hyde/keybinds_hint.sh
+++ b/Configs/.local/lib/hyde/keybinds_hint.sh
@@ -45,7 +45,7 @@ font_name=${font_name:-$(get_hyprConf "FONT")}
 font_override="* {font: \"${font_name:-"JetBrainsMono Nerd Font"} $font_scale\";}"
 icon_override=$(gsettings get org.gnome.desktop.interface icon-theme | sed "s/'//g")
 icon_override="configuration {icon-theme: \"$icon_override\";}"
-selected=$(echo -e "$output" | rofi -dmenu -markup -markup-rows -p \
+selected=$(printf '%s\n' "$output" | rofi -dmenu -markup -markup-rows -p \
     -theme-str "entry { placeholder: \"\t⌨️ Keybindings \";}" \
     " Keybinds \t\tﴕ Description" \
     -p -i \

--- a/Configs/.local/share/hypr/lua/hyde/binds.lua
+++ b/Configs/.local/share/hypr/lua/hyde/binds.lua
@@ -17,6 +17,18 @@
 -- TODO: check the Hyprland bind flags documentation periodically and
 -- update the dedup field list when new relevant bind flags are added.
 
+-- type(x) == "function" misses the common binding pattern of a table made
+-- callable via a __call metamethod, which is what hl.dsp.exec_cmd turns out
+-- to be (both the native one and the test stub in tests/lua/bind_harness.lua
+-- model it that way).
+local function is_callable(value)
+    if type(value) == "function" then
+        return true
+    end
+    local mt = getmetatable(value)
+    return type(mt) == "table" and type(mt.__call) == "function"
+end
+
 local function trim(str)
     return str and str:gsub("^%s+", ""):gsub("%s+$", "") or ""
 end
@@ -68,6 +80,43 @@ local function canonicalize(keycombo)
 
     modifiers[#modifiers + 1] = key:upper()
     return table.concat(modifiers, " + ")
+end
+
+-- Minimal encoder for a flat string->string table -- the only shape
+-- hyde.binds._commands ever holds. Not a general JSON encoder: no nesting,
+-- no numbers, no booleans. Written locally instead of pulling in
+-- Configs/.local/lib/hyde/luautils/json.lua because that tree is not on
+-- package.path here -- this file runs inside Hyprland's own embedded Lua,
+-- a separate interpreter from the one hyde-shell sets up for standalone
+-- scripts like gpuinfo.lua.
+local function encode_flat_string_map(map)
+    local function escape(str)
+        return (
+            str:gsub(
+                '[\\"%c]',
+                function(c)
+                    if c == "\\" then
+                        return "\\\\"
+                    elseif c == '"' then
+                        return '\\"'
+                    elseif c == "\n" then
+                        return "\\n"
+                    elseif c == "\t" then
+                        return "\\t"
+                    elseif c == "\r" then
+                        return "\\r"
+                    end
+                    return string.format("\\u%04x", c:byte())
+                end
+            )
+        )
+    end
+
+    local parts = {}
+    for key, value in pairs(map) do
+        parts[#parts + 1] = '"' .. escape(key) .. '":"' .. escape(value) .. '"'
+    end
+    return "{" .. table.concat(parts, ",") .. "}"
 end
 
 local function has_dedup_field(opts)
@@ -155,9 +204,35 @@ hyde.binds.canonicalize = canonicalize
 -- the original spelling has to be kept around to remove a bind again.
 hyde.binds._active = hyde.binds._active or {}
 
+-- Resolves __lua binds back to a launchable command for the keybind-hint
+-- menu (#1996). Hyprland exposes every hl.bind() action over hyprctl as an
+-- opaque "__lua" registry reference with no way to invoke it externally,
+-- except by re-emitting a fresh hl.dsp.exec_cmd("...") call -- so
+-- hint-hyprland.py needs the original command string for binds built that
+-- way. Lua evaluates hl.dsp.exec_cmd(cmd) fully before hl.bind(combo, <that
+-- result>, opts) runs, so wrapping exec_cmd to remember only the command it
+-- was just called with, then having hl.bind read-and-clear that value
+-- immediately, pairs the two correctly without inspecting what exec_cmd
+-- actually returns. A bind built any other way -- a plain Lua function, a
+-- native dispatcher called directly -- never sets it and stays unresolved,
+-- which is the documented limit: those can't be reduced to one command.
+hyde.binds._commands = hyde.binds._commands or {}
+
+local pending_command
+if type(hl.dsp) == "table" and is_callable(hl.dsp.exec_cmd) then
+    local orig_exec_cmd = hl.dsp.exec_cmd
+    hl.dsp.exec_cmd = function(command, ...)
+        pending_command = command
+        return orig_exec_cmd(command, ...)
+    end
+end
+
 local orig_add = hl.bind
 
 hl.bind = function(keycombo, action, ...)
+    local command = pending_command
+    pending_command = nil
+
     local normalized = hyde.binds.normalize(keycombo)
     local opts = find_options(...)
     local signature = serialize_flags(opts)
@@ -175,5 +250,36 @@ hl.bind = function(keycombo, action, ...)
         keycombo = normalized
     end
 
+    if normalized ~= "" and type(command) == "string" and command ~= "" then
+        hyde.binds._commands[canonicalize(keycombo)] = command
+    end
+
     return orig_add(keycombo, action, ...)
+end
+
+-- Written once per full config (re)load, not per-bind: hl.bind() runs on the
+-- order of seventy times in a row during one load, and hint-hyprland.py only
+-- ever reads this after a load has already finished, so only the state after
+-- the last call matters. "config.reloaded" covers every later
+-- `hyprctl reload`; "hyprland.start" covers the very first load, which never
+-- fires as a reload.
+local function write_commands_cache()
+    if type(hyde.path) ~= "table" or type(hyde.path.cache) ~= "string" then
+        return
+    end
+
+    local file = io.open(hyde.path.cache .. "/hyde/lua_bind_commands.json", "w")
+    if not file then
+        return
+    end
+
+    file:write(encode_flat_string_map(hyde.binds._commands))
+    file:close()
+end
+
+hyde.binds._write_commands_cache = write_commands_cache
+
+if type(hl.on) == "function" then
+    hl.on("hyprland.start", write_commands_cache)
+    hl.on("config.reloaded", write_commands_cache)
 end

--- a/tests/lua/bind_commands_spec.lua
+++ b/tests/lua/bind_commands_spec.lua
@@ -1,0 +1,193 @@
+-- Tests the hl.bind()/hl.dsp.exec_cmd() interception hyde/binds.lua adds for
+-- #1996 (hyde.binds._commands and its cache file), in isolation from the
+-- real key_binds.lua -- tests/lua/bind_harness.lua already covers that the
+-- shipped binds themselves are well-formed; this only covers the new
+-- capture/persist mechanism, against small synthetic binds chosen to hit
+-- each case on purpose.
+
+local repo_root = assert(os.getenv("REPO_ROOT"), "REPO_ROOT is not set")
+local lua_root = repo_root .. "/Configs/.local/share/hypr/lua"
+local work_dir = assert(os.getenv("BIND_COMMANDS_TEST_WORK_DIR"), "BIND_COMMANDS_TEST_WORK_DIR is not set")
+
+local failures = 0
+local function check(condition, message)
+    if not condition then
+        failures = failures + 1
+        print("    fail: " .. message)
+    end
+end
+
+-- Same callable-table shape as the real native hl.dsp.* dispatchers and the
+-- one tests/lua/bind_harness.lua already uses -- exercising this instead of
+-- a plain Lua function is the whole point: type(x) == "function" alone
+-- would miss it.
+local function dsp_proxy(prefix)
+    return setmetatable(
+        {},
+        {
+            __index = function(_, key)
+                return dsp_proxy(prefix == "" and key or prefix .. "." .. key)
+            end,
+            __call = function(_, ...)
+                return {dispatcher = prefix, args = {...}}
+            end
+        }
+    )
+end
+
+_G.hl = {
+    dsp = dsp_proxy(""),
+    on = function() end
+}
+_G.hl.bind = function(combo, action, opts)
+end
+_G.hl.unbind = function()
+end
+
+_G.hyde = {
+    config = {modifiers = {main = "SUPER"}}
+}
+
+dofile(lua_root .. "/hyde/binds.lua")
+
+-- 1. Two distinct exec_cmd binds must be paired with their own command, not
+-- with each other's.
+hl.bind("SUPER + T", hl.dsp.exec_cmd("kitty"), {description = "terminal"})
+hl.bind("SUPER + E", hl.dsp.exec_cmd("dolphin"), {description = "explorer"})
+check(hyde.binds._commands["SUPER + T"] == "kitty", "SUPER + T was not paired with its own command")
+check(hyde.binds._commands["SUPER + E"] == "dolphin", "SUPER + E was not paired with its own command")
+
+-- 2. A native dispatcher called directly (no exec_cmd) must not be recorded,
+-- and must not pick up a command left over from an unrelated earlier bind.
+hl.bind("SUPER + Q", hl.dsp.window.close(), {description = "close"})
+check(hyde.binds._commands["SUPER + Q"] == nil, "a native-dispatcher bind was recorded as if it were exec_cmd")
+
+-- 3. A plain Lua closure (no exec_cmd, no native dispatcher table at all)
+-- must not be recorded either, and must not leak a stale pending command
+-- into the *next* bind.
+hl.bind("SUPER + F", hl.dsp.exec_cmd("should-not-leak"), {description = "leftover"})
+local noop = function()
+end
+hl.bind("SUPER + G", noop, {description = "toggle group"})
+check(hyde.binds._commands["SUPER + G"] == nil, "a plain-function bind was recorded")
+hl.bind("SUPER + H", hl.dsp.window.close(), {description = "close2"})
+check(
+    hyde.binds._commands["SUPER + H"] == nil,
+    "a stale pending command leaked past an intervening non-exec_cmd bind"
+)
+
+-- 4. Re-registering the same canonical combo (a config reload re-running the
+-- whole file) must end up with the *last* command, not the first.
+hl.bind("SUPER + V", hl.dsp.exec_cmd("first"), {description = "v1"})
+hl.bind("SUPER + V", hl.dsp.exec_cmd("second"), {description = "v2"})
+check(hyde.binds._commands["SUPER + V"] == "second", "re-registering a combo did not overwrite the older command")
+
+-- 5. Modifier order/spelling must canonicalize the same way _active already
+-- does -- this is a different table, computed at a different point in
+-- hl.bind, so it is not automatically guaranteed just because _active works.
+hl.bind("SUPER + CONTROL + B", hl.dsp.exec_cmd("via-control"), {description = "b1"})
+hl.bind("CTRL + SUPER + B", hl.dsp.exec_cmd("via-ctrl"), {description = "b2"})
+check(
+    hyde.binds._commands["CTRL + SUPER + B"] == "via-ctrl",
+    "two spellings of the same combo did not collapse to one canonical key"
+)
+check(hyde.binds._commands["SUPER + CONTROL + B"] == nil, "an alias spelling was kept as its own separate key")
+
+-- 6. A plain key with no modifiers at all (modmask 0 on the Hyprland side).
+hl.bind("F10", hl.dsp.exec_cmd("mute"), {description = "mute", locked = true})
+check(hyde.binds._commands["F10"] == "mute", "a no-modifier bind was not recorded under its bare key")
+
+-- Out-of-spec inputs to hl.bind itself must not error out of the wrapper.
+local ok_nil_combo = pcall(hl.bind, nil, hl.dsp.exec_cmd("x"), {description = "y"})
+check(ok_nil_combo, "a nil keycombo raised instead of being ignored like normalize() already treats it")
+
+local ok_no_opts = pcall(hl.bind, "SUPER + Z", hl.dsp.exec_cmd("z"), nil)
+check(ok_no_opts, "a nil opts argument raised")
+check(hyde.binds._commands["SUPER + Z"] == "z", "a bind with nil opts was still not recorded")
+
+print(string.format("    %d command(s) captured", (function()
+    local n = 0
+    for _ in pairs(hyde.binds._commands) do
+        n = n + 1
+    end
+    return n
+end)()))
+
+-- Cache file: missing hyde.path (or a non-string .cache) must degrade
+-- silently, never raise -- this runs inside Hyprland's own config load, and
+-- crashing here would take the whole session down.
+hyde.path = nil
+local ok_no_path = pcall(hyde.binds._write_commands_cache)
+check(ok_no_path, "writing with hyde.path entirely absent raised")
+
+hyde.path = {}
+local ok_no_cache_field = pcall(hyde.binds._write_commands_cache)
+check(ok_no_cache_field, "writing with hyde.path.cache unset raised")
+
+hyde.path = {cache = 42}
+local ok_wrong_type = pcall(hyde.binds._write_commands_cache)
+check(ok_wrong_type, "writing with a non-string hyde.path.cache raised")
+
+-- A cache directory that doesn't exist: this module deliberately never
+-- creates it (no os.execute/mkdir -- Hyprland budgets the whole config load
+-- at 1500ms and does not want a forked shell counted against it), so the
+-- write must fail closed, not raise.
+hyde.path = {cache = work_dir .. "/no-such-dir"}
+local ok_missing_dir = pcall(hyde.binds._write_commands_cache)
+check(ok_missing_dir, "writing to a missing cache directory raised instead of failing closed")
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    if not f then
+        return nil
+    end
+    local content = f:read("a")
+    f:close()
+    return content
+end
+
+check(
+    read_file(work_dir .. "/no-such-dir/hyde/lua_bind_commands.json") == nil,
+    "a file appeared under a cache directory that was never created"
+)
+
+-- The real, existing directory: the write must succeed and produce JSON
+-- python's own json module accepts, with every captured pair intact --
+-- verified out-of-process since hint-hyprland.py is what actually reads it.
+os.execute("mkdir -p '" .. work_dir .. "/real/hyde'")
+hyde.path = {cache = work_dir .. "/real"}
+hyde.binds._write_commands_cache()
+
+local cache_content = read_file(work_dir .. "/real/hyde/lua_bind_commands.json")
+check(cache_content ~= nil, "the cache file was not written to an existing directory")
+
+if cache_content then
+    -- Round-tripped through a temp file rather than piped to python's
+    -- stdin: io.popen only gives one direction (read *or* write) per handle
+    -- portably, and a file keeps this a single, ordinary syscall path.
+    local tmp_json = work_dir .. "/roundtrip.json"
+    local out = io.open(tmp_json, "w")
+    out:write(cache_content)
+    out:close()
+
+    local py = io.popen(
+        "python3 -c \"import json; d=json.load(open('"
+            .. tmp_json
+            .. "')); "
+            .. "assert d['SUPER + T'] == 'kitty', d; assert d['SUPER + V'] == 'second', d; "
+            .. "assert 'SUPER + Q' not in d, d; assert d['SUPER + Z'] == 'z', d; print('ok')\" 2>&1"
+    )
+    local result = py and py:read("a") or ""
+    if py then
+        py:close()
+    end
+    check(result:match("^ok"), "python could not parse the written cache as valid JSON with the right content: " .. result)
+end
+
+-- Empty table: still valid, parseable JSON, not an empty string or a crash.
+hyde.binds._commands = {}
+hyde.binds._write_commands_cache()
+local empty_content = read_file(work_dir .. "/real/hyde/lua_bind_commands.json")
+check(empty_content == "{}", "an empty _commands table did not serialize to '{}': got " .. tostring(empty_content))
+
+os.exit(failures == 0 and 0 or 1)

--- a/tests/python/check_keybind_hint_resolve.py
+++ b/tests/python/check_keybind_hint_resolve.py
@@ -1,0 +1,204 @@
+"""Checks the __lua bind resolution hint-hyprland.py adds for #1996.
+
+hyde/binds.lua pairs each bind's canonical combo with the command it was
+built from and writes that as JSON to a cache file (tested independently in
+tests/lua/bind_commands_spec.lua). This checks the other side: that
+hint-hyprland.py reads that cache the same way, degrades to an empty map on
+anything but a well-formed file, computes the exact same canonical combo
+Lua's hyde/binds.lua.canonicalize() does from modmask/key, and only rewrites
+a bind's dispatcher when both agree on the key.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = pathlib.Path(os.environ.get("REPO_ROOT", "."))
+SCRIPT_PATH = REPO_ROOT / "Configs/.local/lib/hyde/keybinds/hint-hyprland.py"
+
+failures = 0
+
+
+def check(condition: bool, message: str) -> None:
+    global failures
+    if not condition:
+        failures += 1
+        print(f"    fail: {message}")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("hint_hyprland", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    if not SCRIPT_PATH.is_file():
+        print(f"fail: hint-hyprland.py not found at {SCRIPT_PATH}")
+        return 1
+
+    hh = load_module()
+
+    # --- canonical_combo: mirrors hyde/binds.lua's canonicalize() ---
+
+    check(
+        hh.canonical_combo(64, "T") == "SUPER + T",
+        "a single-modifier combo did not canonicalize",
+    )
+    check(
+        hh.canonical_combo(64 + 4, "B") == "CTRL + SUPER + B",
+        "two modifiers were not sorted alphabetically (CTRL before SUPER)",
+    )
+    check(
+        hh.canonical_combo(4 + 64, "B") == "CTRL + SUPER + B",
+        "modifier bit order changed the result -- must be order-independent",
+    )
+    check(
+        hh.canonical_combo(0, "F10") == "F10",
+        "a no-modifier bind (modmask 0) did not canonicalize to the bare key",
+    )
+    check(
+        hh.canonical_combo(64, "slash") == "SUPER + SLASH",
+        "a lowercase keysym was not upper-cased",
+    )
+
+    # Missing/absent and malformed input.
+    check(hh.canonical_combo(64, "") is None, "an empty key string was not rejected")
+    check(hh.canonical_combo(64, None) is None, "a None key was not rejected")
+    check(hh.canonical_combo(None, "T") is None, "a None modmask was not rejected")
+    check(hh.canonical_combo("64", "T") is None, "a string modmask (wrong type) was not rejected")
+    check(hh.canonical_combo(64, 5) is None, "a non-string key (wrong type) was not rejected")
+
+    # --- load_bind_commands: degrades to {} on anything but a well-formed file ---
+
+    with tempfile.TemporaryDirectory() as tmp:
+        env_backup = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = tmp
+
+        try:
+            # Missing/absent: no file at all.
+            check(hh.load_bind_commands() == {}, "a missing cache file did not degrade to {}")
+
+            cache_dir = pathlib.Path(tmp) / "hyde"
+            cache_dir.mkdir(parents=True)
+            cache_file = cache_dir / "lua_bind_commands.json"
+
+            # Malformed/out-of-spec: not valid JSON at all.
+            cache_file.write_text("{not json")
+            check(hh.load_bind_commands() == {}, "malformed JSON did not degrade to {}")
+
+            # Malformed/out-of-spec: valid JSON, wrong shape (a list, not an object).
+            cache_file.write_text(json.dumps(["SUPER + T", "kitty"]))
+            check(hh.load_bind_commands() == {}, "a JSON list (wrong shape) did not degrade to {}")
+
+            # Malformed/out-of-spec: an object, but with a non-string value --
+            # that one pair must be dropped, not raise or poison the rest.
+            cache_file.write_text(json.dumps({"SUPER + T": "kitty", "SUPER + E": 5}))
+            check(
+                hh.load_bind_commands() == {"SUPER + T": "kitty"},
+                "a non-string value was not filtered out of an otherwise-valid cache",
+            )
+
+            # Boundary: an empty object is valid and just means nothing resolves.
+            cache_file.write_text("{}")
+            check(hh.load_bind_commands() == {}, "an empty JSON object was not read as {}")
+
+            # The well-formed case.
+            cache_file.write_text(json.dumps({"SUPER + T": "kitty", "SUPER + E": "dolphin"}))
+            check(
+                hh.load_bind_commands() == {"SUPER + T": "kitty", "SUPER + E": "dolphin"},
+                "a well-formed cache was not read back exactly",
+            )
+        finally:
+            if env_backup is None:
+                os.environ.pop("XDG_CACHE_HOME", None)
+            else:
+                os.environ["XDG_CACHE_HOME"] = env_backup
+
+    # --- expand_meta_data: only __lua binds are touched, only when resolvable ---
+
+    def make_bind(dispatcher, arg, modmask, key, keycode=0, description="test"):
+        return {
+            "dispatcher": dispatcher,
+            "arg": arg,
+            "modmask": modmask,
+            "key": key,
+            "keycode": keycode,
+            "has_description": True,
+            "description": description,
+            "submap": "",
+        }
+
+    binds = [
+        make_bind("__lua", "5", 64, "T"),  # resolvable
+        make_bind("__lua", "9", 64, "Q"),  # not in the map -- must stay unresolved
+        make_bind("exec", "firefox", 64, "B"),  # not __lua at all -- must be untouched
+        make_bind("__lua", "3", 0, "F10"),  # no-modifier, resolvable
+    ]
+    bind_commands = {"SUPER + T": "kitty", "F10": 'notify-send "hi" \\ok'}
+
+    hh.expand_meta_data(binds, bind_commands)
+
+    resolved, unresolved_map, untouched, resolved_no_mod = binds
+
+    check(
+        resolved["dispatcher"] == 'hl.dsp.exec_cmd("kitty")',
+        f"a resolvable __lua bind was not rewritten: got {resolved['dispatcher']!r}",
+    )
+    check(resolved["arg"] == "", "a resolved bind's arg was not cleared")
+
+    check(
+        unresolved_map["dispatcher"] == "__lua",
+        "a __lua bind with no matching cache entry was rewritten anyway",
+    )
+    check(unresolved_map["arg"] == "9", "an unresolved bind's arg was changed")
+
+    check(untouched["dispatcher"] == "exec", "a non-__lua bind's dispatcher was touched")
+    check(untouched["arg"] == "firefox", "a non-__lua bind's arg was touched")
+
+    check(
+        resolved_no_mod["dispatcher"] == 'hl.dsp.exec_cmd("notify-send \\"hi\\" \\\\ok")',
+        f"quotes/backslashes in the command were not escaped correctly: {resolved_no_mod['dispatcher']!r}",
+    )
+
+    # The rewritten dispatcher has to be syntactically valid Lua, and single
+    # line (keybinds_hint.sh rejects a multi-line dispatch field outright) --
+    # checked out-of-process against the real interpreter when available,
+    # since that is what actually has to accept it.
+    if shutil.which("lua"):
+        expr = resolved_no_mod["dispatcher"]
+        check("\n" not in expr, "the rewritten dispatcher spans more than one line")
+        result = subprocess.run(
+            ["lua", "-e", f"local hl = {{ dsp = {{ exec_cmd = function() end }} }}\nreturn {expr}"],
+            capture_output=True,
+            text=True,
+        )
+        check(
+            result.returncode == 0,
+            f"the rewritten dispatcher is not valid Lua: {result.stderr.strip()}",
+        )
+
+    # Default bind_commands (None) must behave like an empty map, not raise.
+    default_binds = [make_bind("__lua", "5", 64, "T")]
+    hh.expand_meta_data(default_binds)
+    check(
+        default_binds[0]["dispatcher"] == "__lua",
+        "expand_meta_data with no bind_commands argument raised or resolved anyway",
+    )
+
+    if failures:
+        print(f"    {failures} failure(s)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bind_commands.sh
+++ b/tests/test_bind_commands.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Checks the hl.bind()/hl.dsp.exec_cmd() -> hyde.binds._commands capture
+# mechanism hyde/binds.lua adds for #1996, and the cache file it writes.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v lua >/dev/null 2>&1; then
+    skip "lua is not installed"
+    finish
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 is not installed"
+    finish
+fi
+
+work_dir=$(mktemp -d) || exit 1
+trap 'rm -rf "$work_dir"' EXIT
+
+BIND_COMMANDS_TEST_WORK_DIR="$work_dir" lua "$TESTS_DIR/lua/bind_commands_spec.lua" ||
+    fail "bind_commands_spec reported defects"
+
+finish

--- a/tests/test_keybind_hint_integration.sh
+++ b/tests/test_keybind_hint_integration.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env sh
+# End-to-end: hint-hyprland.py run as a real process against a stubbed
+# `hyprctl binds -j` and a real cache file, not just its functions imported
+# directly (that's tests/test_keybind_hint_resolve.sh). Also the direct
+# evidence for the one thing kRHYME7 asked about on #1996 (memory/cost
+# during a normal run): no `lua` binary is ever on PATH here, so
+# hint-hyprland.py re-parsing or re-executing the Lua config at hint-time,
+# instead of only reading the cache hyde/binds.lua already wrote, would fail
+# this test outright rather than merely being slow.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 is not installed"
+    finish
+fi
+
+script="$REPO_ROOT/Configs/.local/lib/hyde/keybinds/hint-hyprland.py"
+[ -f "$script" ] || {
+    fail "hint-hyprland.py not found at $script"
+    finish
+}
+
+work_dir=$(mktemp -d) || exit 1
+trap 'rm -rf "$work_dir"' EXIT
+
+bin_dir="$work_dir/bin"
+mkdir -p "$bin_dir" "$work_dir/cache/hyde"
+
+# A resolvable __lua bind (SUPER + T), an unresolvable one (SUPER + Q, not in
+# the cache below), and a plain non-__lua bind, in the exact shape
+# `hyprctl binds -j` actually reports.
+cat >"$bin_dir/hyprctl" <<'STUB'
+#!/usr/bin/env sh
+if [ "$1" = "binds" ]; then
+    cat <<'JSON'
+[
+  {
+    "modmask": 64, "submap": "", "key": "T", "keycode": 0, "catch_all": false,
+    "description": "", "has_description": false, "locked": false, "mouse": false,
+    "release": false, "repeat": false, "long_press": false, "arg": "5", "dispatcher": "__lua"
+  },
+  {
+    "modmask": 64, "submap": "", "key": "Q", "keycode": 0, "catch_all": false,
+    "description": "", "has_description": false, "locked": false, "mouse": false,
+    "release": false, "repeat": false, "long_press": false, "arg": "9", "dispatcher": "__lua"
+  },
+  {
+    "modmask": 64, "submap": "", "key": "B", "keycode": 0, "catch_all": false,
+    "description": "", "has_description": false, "locked": false, "mouse": false,
+    "release": false, "repeat": false, "long_press": false, "arg": "firefox", "dispatcher": "exec"
+  }
+]
+JSON
+    exit 0
+fi
+echo "unexpected hyprctl invocation: $*" >&2
+exit 1
+STUB
+chmod +x "$bin_dir/hyprctl"
+
+# Shadows any real `lua` on PATH with one that fails loudly instead of
+# silently succeeding -- if hint-hyprland.py ever shells out to it, this
+# turns that into a hard, specific test failure instead of just being slow.
+cat >"$bin_dir/lua" <<'STUB'
+#!/usr/bin/env sh
+echo "hint-hyprland.py invoked lua at hint-time -- it must only read hyde/binds.lua's cache file" >&2
+exit 1
+STUB
+chmod +x "$bin_dir/lua"
+
+cat >"$work_dir/cache/hyde/lua_bind_commands.json" <<'JSON'
+{"SUPER + T": "kitty"}
+JSON
+
+run() {
+    XDG_CACHE_HOME="$work_dir/cache" PATH="$bin_dir:$PATH" python3 "$script" "$@"
+}
+
+rofi_out=$(run --format rofi 2>"$work_dir/stderr") || {
+    fail "hint-hyprland.py --format rofi exited non-zero: $(cat "$work_dir/stderr")"
+    finish
+}
+
+case $rofi_out in
+*'hl.dsp.exec_cmd("kitty")'*) ;;
+*) fail "the resolvable SUPER + T bind was not rewritten in rofi output" ;;
+esac
+
+resolved_line=$(printf '%s\n' "$rofi_out" | grep 'exec_cmd("kitty")')
+case $resolved_line in
+*' ::: 9 :::'*) fail "the resolved bind's arg still carries the old opaque ref" ;;
+esac
+
+unresolved_line=$(printf '%s\n' "$rofi_out" | grep ':::.*__lua.*::: 9 :::')
+[ -n "$unresolved_line" ] ||
+    fail "the unresolvable SUPER + Q bind (not in the cache) lost its __lua dispatcher"
+
+case $rofi_out in
+*'::: exec ::: firefox :::'*) ;;
+*) fail "the plain exec bind was altered even though it isn't __lua" ;;
+esac
+
+# JSON output is the same expand_meta_data() pass, not a separate code path
+# -- confirm the rewrite shows up there too, not just in the rofi formatter.
+json_out=$(run --format json 2>/dev/null) || fail "hint-hyprland.py --format json exited non-zero"
+printf '%s\n' "$json_out" | python3 -c '
+import json, sys
+binds = json.load(sys.stdin)
+by_key = {(b["modmask"], b["key"]): b for b in binds}
+t = by_key[(64, "T")]
+q = by_key[(64, "Q")]
+b = by_key[(64, "B")]
+assert t["dispatcher"] == "hl.dsp.exec_cmd(\"kitty\")", t
+assert t["arg"] == "", t
+assert q["dispatcher"] == "__lua" and q["arg"] == "9", q
+assert b["dispatcher"] == "exec" and b["arg"] == "firefox", b
+' || fail "the JSON output did not show the same resolution as rofi output"
+
+finish

--- a/tests/test_keybind_hint_resolve.sh
+++ b/tests/test_keybind_hint_resolve.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# hint-hyprland.py must resolve a Lua-registered ("__lua") bind back to a
+# launchable command when hyde/binds.lua's cache has it (#1996).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 is not installed"
+    finish
+fi
+
+python3 "$TESTS_DIR/python/check_keybind_hint_resolve.py" ||
+    fail "check_keybind_hint_resolve reported defects"
+
+finish

--- a/tests/test_keybind_hint_shell_escaping.sh
+++ b/tests/test_keybind_hint_shell_escaping.sh
@@ -1,4 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+# bash, not sh: keybinds_hint.sh itself is bash (`echo -e` is a bash
+# extension with undefined behavior in POSIX sh), and this test exists
+# specifically to demonstrate what bash's own `echo -e` does to the escaped
+# dispatcher string, so it has to run under the same shell.
+#
 # keybinds_hint.sh must not run hint-hyprland.py's output through `echo -e`
 # before handing it to rofi. A resolved __lua bind's dispatcher can contain
 # the backslash escapes _escape_lua_string() produces (\\ and \n, so the

--- a/tests/test_keybind_hint_shell_escaping.sh
+++ b/tests/test_keybind_hint_shell_escaping.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# keybinds_hint.sh must not run hint-hyprland.py's output through `echo -e`
+# before handing it to rofi. A resolved __lua bind's dispatcher can contain
+# the backslash escapes _escape_lua_string() produces (\\ and \n, so the
+# generated hl.dsp.exec_cmd("...") call stays valid, single-line Lua) --
+# `echo -e` reinterprets exactly those: \\ collapses back to one backslash
+# before Lua ever sees it, and \n becomes a real newline, breaking the Lua
+# string syntax and tripping keybinds_hint.sh's own single-line dispatch
+# check, which then just silently reopens the menu instead of running
+# anything. `printf '%s\n'` prints its argument byte-for-byte and does not
+# have this problem (caught in review on PR #2068).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+script="$REPO_ROOT/Configs/.local/lib/hyde/keybinds_hint.sh"
+[ -f "$script" ] || {
+    fail "keybinds_hint.sh not found at $script"
+    finish
+}
+
+# Regression guard on the actual script: the exact broken pattern must be
+# gone, and the pipe into rofi must go through printf instead.
+if grep -n 'echo -e "\$output"' "$script"; then
+    fail "keybinds_hint.sh still pipes \$output through 'echo -e' into rofi"
+fi
+grep -qE "printf '%s\\\\n' \"\\\$output\" \\| rofi" "$script" ||
+    fail "keybinds_hint.sh does not pipe \$output into rofi via printf '%s\\n'"
+
+# Demonstrates *why*, rather than just matching a string: an escaped
+# dispatcher, exactly as _escape_lua_string() would produce it, must survive
+# byte-for-byte through the shell step that's actually used.
+escaped_dispatch='hl.dsp.exec_cmd("notify-send \"hi\" \\ok")'
+
+printf_result=$(printf '%s\n' "$escaped_dispatch")
+[ "$printf_result" = "$escaped_dispatch" ] ||
+    fail "printf '%s\\n' altered the dispatcher string -- it must pass through unchanged"
+
+# The same string through the pattern this test exists to keep out, as
+# positive proof the two are not equivalent -- if this ever stops failing,
+# the two forms have become the same and the guard above is no longer
+# protecting anything.
+echo_e_result=$(echo -e "$escaped_dispatch")
+if [ "$echo_e_result" = "$escaped_dispatch" ]; then
+    fail "echo -e no longer corrupts backslash escapes on this shell -- the reasoning behind this test needs re-checking, not just the pattern match"
+fi
+
+# The printf'd result must still be exactly one line (multiple lines is
+# what keybinds_hint.sh's own dispatch check rejects) and still valid Lua,
+# chaining this check to the same syntax proof
+# tests/python/check_keybind_hint_resolve.py already does for the escaping
+# itself.
+[ "$(printf '%s\n' "$printf_result" | wc -l)" -eq 1 ] ||
+    fail "the dispatcher string spans more than one line after printf"
+
+if command -v lua >/dev/null 2>&1; then
+    lua -e "local hl = { dsp = { exec_cmd = function() end } }
+return ${printf_result}" || fail "the printf-preserved dispatcher is not valid Lua"
+fi
+
+finish

--- a/tests/test_keybind_hint_shell_escaping.sh
+++ b/tests/test_keybind_hint_shell_escaping.sh
@@ -1,9 +1,4 @@
-#!/usr/bin/env bash
-# bash, not sh: keybinds_hint.sh itself is bash (`echo -e` is a bash
-# extension with undefined behavior in POSIX sh), and this test exists
-# specifically to demonstrate what bash's own `echo -e` does to the escaped
-# dispatcher string, so it has to run under the same shell.
-#
+#!/usr/bin/env sh
 # keybinds_hint.sh must not run hint-hyprland.py's output through `echo -e`
 # before handing it to rofi. A resolved __lua bind's dispatcher can contain
 # the backslash escapes _escape_lua_string() produces (\\ and \n, so the
@@ -43,10 +38,13 @@ printf_result=$(printf '%s\n' "$escaped_dispatch")
 # The same string through the pattern this test exists to keep out, as
 # positive proof the two are not equivalent -- if this ever stops failing,
 # the two forms have become the same and the guard above is no longer
-# protecting anything.
-echo_e_result=$(echo -e "$escaped_dispatch")
+# protecting anything. Modeled with `printf '%b'` rather than `echo -e`
+# itself: same escape-interpreting behavior (verified: both collapse "\\"
+# the same way), but POSIX-specified instead of a non-portable echo flag,
+# so this stays plain sh like the rest of the suite.
+echo_e_result=$(printf '%b\n' "$escaped_dispatch")
 if [ "$echo_e_result" = "$escaped_dispatch" ]; then
-    fail "echo -e no longer corrupts backslash escapes on this shell -- the reasoning behind this test needs re-checking, not just the pattern match"
+    fail "escape-interpreting output no longer differs from the raw string on this shell -- the reasoning behind this test needs re-checking, not just the pattern match"
 fi
 
 # The printf'd result must still be exactly one line (multiple lines is


### PR DESCRIPTION
## Summary

Fixes #1996. Since the Lua config migration, every keybind registered via
`hl.bind(...)` is exposed by `hyprctl binds -j` as an opaque
`{"dispatcher": "__lua", "arg": "<registry ref>"}`, which Hyprland has no
way to dispatch from the outside — so clicking any bind in the keybind-hint
rofi menu did nothing.

## Why not parse Lua source, and not re-run the config in a second process

Both were on the table (the issue's own proposal, and CodeRabbit's
auto-generated plan on it) and both were dropped for the same reason:
either approach is a **second, independent** interpretation of the config,
which can drift from what's actually running — string concatenation, the
numpad workspace loop, the `hyde.sh.*`/`_apps.*` proxies all have to be
re-derived correctly outside the real execution. kRHYME7's own comment on
the issue pointed at the alternative this PR uses instead: "we can register
the binds on our own... override `hl.binds`" — that hook already exists
(`hyde/binds.lua` already wraps `hl.bind` for dedup).

## What it does

**`hyde/binds.lua`**: also wraps `hl.dsp.exec_cmd`. Lua evaluates
`hl.dsp.exec_cmd(cmd)` fully before `hl.bind(combo, <that result>, opts)`
runs, so remembering only the command string `exec_cmd` was just called
with, then having `hl.bind` read-and-clear it immediately, pairs the two
correctly without inspecting what `exec_cmd` actually returns. A bind built
any other way (a plain Lua function, a native dispatcher called directly —
window/workspace operations) never sets it and stays unresolved, which is
the real, unavoidable limit: those can't be reduced to one external
command. The result (`hyde.binds._commands`, keyed by the same canonical
combo `hyde.binds._active` already uses for dedup) is written once as JSON
to a cache file — once per full config load, via the `hyprland.start` and
`config.reloaded` events, not once per bind (`hl.bind` runs ~70 times in a
row during a load; the cache only ever needs the state after the last one).
No parsing, no second execution — it's a side effect of the real config
actually running.

**`hint-hyprland.py`**: reads that cache and, for a `__lua` bind whose
canonical combo (computed the same way `hyde/binds.lua`'s `canonicalize()`
does, independently from `modmask`/`key`) is in it, rewrites the dispatcher
to a fresh `hl.dsp.exec_cmd("...")` call with an empty arg —
`keybinds_hint.sh`'s existing `hyprctl dispatch "$dispatch" "$arg"` already
runs that correctly, exactly as the issue's own validated-locally proposal
showed. No shell script changes.

## On the "how much memory/cost" question

- The cache file for this repo's own ~70-bind default config: **57 entries,
  2513 bytes**.
- Marginal cost of the resolution pass itself, measured directly
  (`expand_meta_data` with vs. without a populated map, 160 synthetic
  binds, 2000 runs each): **~0.05ms**, against a **~75-85ms** total
  `hint-hyprland.py` process (dominated by Python startup and the
  `hyprctl` subprocess call, both pre-existing).
- No `lua` interpreter is ever invoked at hint-time — the integration test
  shadows `lua` on `PATH` with a stub that fails loudly if called, so a
  regression that re-parses/re-executes the config here would fail the
  test outright, not just be slow.
- `hyde.binds._commands`/`_active` are keyed by the same canonical combo,
  so a config reload overwrites the same finite set of keys rather than
  growing — the table doesn't accumulate across repeated reloads.
- The write itself happens via the `hyprland.start`/`config.reloaded`
  events, not inline during `hl.bind()` — Hyprland budgets the whole
  config load at 1500ms and its watchdog counts VM instructions
  (`hyde/path.lua`'s own comment on why it avoids shelling out), so this
  keeps the write off that budget entirely rather than adding to it.

## Test plan

- `tests/lua/bind_commands_spec.lua` (new): the capture mechanism against
  synthetic binds — two distinct `exec_cmd` binds paired correctly, a
  native-dispatcher bind not recorded, a plain-function bind not recorded,
  no stale command leaking past an intervening non-`exec_cmd` bind, a
  re-registered combo keeping the newer command, modifier-order/spelling
  collapsing to one canonical key, a no-modifier bind, nil/missing
  `hyde.path`/`hyde.path.cache` and a non-existent cache directory all
  failing closed rather than raising (this file runs inside Hyprland's own
  config load — raising here takes the whole session down), and the
  written file verified as valid JSON with the right content via `python3
  -c`.
- `tests/python/check_keybind_hint_resolve.py` (new): `canonical_combo`
  against multiple modifiers (order-independent), a bare key, wrong-typed
  and missing/empty input; `load_bind_commands` against a missing file,
  malformed JSON, wrong-shaped JSON (a list), a non-string value mixed into
  an otherwise-valid object, and an empty object; `expand_meta_data`
  end-to-end — a resolvable bind rewritten, an unresolvable one left alone,
  a non-`__lua` bind untouched, quotes/backslashes in the command escaped
  correctly and verified as syntactically valid Lua via the real
  interpreter when available.
- `tests/test_keybind_hint_integration.sh` (new): the whole script run as
  a real process against a stubbed `hyprctl binds -j` and a real cache
  file, across both `--format rofi` and `--format json`, plus the
  no-`lua`-invocation proof described above.
- Every new check verified by temporarily breaking the corresponding logic
  and confirming the test catches it, then restoring.
- Full suite (`tests/run.sh`) green, 36/36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lua keybindings can now be resolved to their registered commands for launchable Hyprland hints.
  * Key combinations are normalized consistently, including modifier ordering.
  * Lua binding commands are cached automatically and loaded when generating hints.
  * Generated commands safely handle quotes and backslashes.

* **Bug Fixes**
  * Unrecognized or non-Lua bindings remain unchanged.
  * Missing or invalid cache data is handled gracefully without interrupting hint generation.
  * Keybind hints preserve escaped characters when displayed through rofi.

* **Tests**
  * Added coverage for command capture, cache persistence, key normalization, escaping, and end-to-end hint output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->