### PR TITLE
fix: retire a leftover conf.d/binds.zsh that reintroduces word-jumping arrows

### DIFF
--- a/Scripts/migrations/v26.9.1.sh
+++ b/Scripts/migrations/v26.9.1.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+
+# "$ZDOTDIR/conf.d/binds.zsh" (default $ZDOTDIR: "$HOME/.config/zsh", the same
+# fallback .zshenv itself uses for its conf.d glob) shipped bindkey lines that
+# mapped the plain arrow keys' SS3 form ("^[OC"/"^[OD" -- what a terminal like
+# kitty sends for Left/Right, per its own terminfo kcuf1/kcub1) to
+# forward-word/backward-word instead of char movement. #2036 (d020fde0)
+# already deleted the file from the repo, but .zshenv sources every
+# "*.zsh" file it finds under conf.d/ by a directory glob, regardless of
+# whether the repo still ships it -- an install from before that fix still
+# has the file on disk, keeps sourcing it on every new shell, and silently
+# turns the arrow keys back into word-jumps, the exact bug #2036 already
+# fixed upstream (#1940, #1958).
+#
+# Nothing is deleted. The file is moved into a backup directory, so a user
+# who deliberately repurposed it for their own bindings still has it on disk.
+
+config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
+zdotdir="${ZDOTDIR:-${config_home}/zsh}"
+state_home="${XDG_STATE_HOME:-${HOME}/.local/state}"
+backup_dir="${state_home}/hyde/migration/v26.9.1"
+
+src="${zdotdir}/conf.d/binds.zsh"
+dst="${backup_dir}/binds.zsh"
+
+[ -e "${src}" ] || [ -L "${src}" ] || exit 0
+
+# A rerun after the file was restored would otherwise destroy the copy kept
+# by the first run, so an occupied destination is reported and left alone.
+if [ -e "${dst}" ] || [ -L "${dst}" ]; then
+    echo "  skipped conf.d/binds.zsh, a backup already exists at ${dst}" >&2
+    exit 1
+fi
+
+if ! mkdir -p "${backup_dir}"; then
+    echo "  failed to create ${backup_dir}" >&2
+    exit 1
+fi
+
+if mv "${src}" "${dst}"; then
+    echo "Moved the stale conf.d/binds.zsh (superseded by #2036) to ${backup_dir}"
+    echo "Plain arrow keys move by character in zsh again."
+    exit 0
+fi
+
+echo "  failed to move conf.d/binds.zsh" >&2
+exit 1

--- a/tests/test_migration_stale_zsh_binds.sh
+++ b/tests/test_migration_stale_zsh_binds.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env sh
+# Scripts/migrations/v26.9.1.sh must move a leftover conf.d/binds.zsh out of
+# the way -- .zshenv sources every *.zsh file it finds under conf.d/ by a
+# directory glob, so a copy left over from before #2036 deleted the file from
+# the repo keeps re-applying its word-jumping arrow-key bindings on every new
+# shell, regardless of what the current checkout ships (#1940, #1958).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+migration="$REPO_ROOT/Scripts/migrations/v26.9.1.sh"
+[ -f "$migration" ] || {
+    fail "migration not found at $migration"
+    finish
+}
+
+work_dir=$(mktemp -d) || exit 1
+trap 'rm -rf "$work_dir"' EXIT
+
+run_migration() {
+    # Every env var the migration reads has to be pinned into the sandbox --
+    # a real XDG_CONFIG_HOME leaking through here once made this test move
+    # (and, via its own EXIT trap, delete) the real conf.d/binds.zsh on the
+    # machine actually running the suite instead of a fixture.
+    HOME="$work_dir/home" \
+        XDG_CONFIG_HOME="$work_dir/home/.config" \
+        XDG_STATE_HOME="$work_dir/state" \
+        ZDOTDIR="${1:-}" \
+        sh "$migration"
+}
+
+reset_sandbox() {
+    rm -rf "$work_dir/home" "$work_dir/state"
+    mkdir -p "$work_dir/home"
+}
+
+# Missing/absent: no such file at all, at the default ZDOTDIR location.
+reset_sandbox
+run_migration >"$work_dir/out" 2>&1
+status=$?
+[ "$status" -eq 0 ] || fail "a missing conf.d/binds.zsh made the migration exit $status"
+[ -s "$work_dir/out" ] && fail "a missing conf.d/binds.zsh still produced output: $(cat "$work_dir/out")"
+[ -d "$work_dir/state" ] && fail "a missing conf.d/binds.zsh still created a state/backup directory"
+
+# Default ZDOTDIR ($HOME/.config/zsh, same fallback .zshenv itself uses):
+# the file must be moved, its content preserved exactly, and the original
+# location left empty.
+reset_sandbox
+mkdir -p "$work_dir/home/.config/zsh/conf.d"
+original_content='bindkey "^[OC" forward-word
+bindkey "^[OD" backward-word
+'
+printf '%s' "$original_content" >"$work_dir/home/.config/zsh/conf.d/binds.zsh"
+
+run_migration >"$work_dir/out" 2>&1
+status=$?
+[ "$status" -eq 0 ] || fail "moving a present conf.d/binds.zsh exited $status: $(cat "$work_dir/out")"
+[ -e "$work_dir/home/.config/zsh/conf.d/binds.zsh" ] &&
+    fail "conf.d/binds.zsh is still at the original location after the migration ran"
+
+backup="$work_dir/state/hyde/migration/v26.9.1/binds.zsh"
+[ -f "$backup" ] || fail "no backup copy was created at $backup"
+if [ -f "$backup" ]; then
+    backup_content=$(cat "$backup")
+    [ "$backup_content" = "$(printf '%s' "$original_content")" ] ||
+        fail "the backed-up file's content does not match the original byte-for-byte"
+fi
+
+# A custom ZDOTDIR must be respected, not just the default fallback.
+reset_sandbox
+mkdir -p "$work_dir/home/custom-zdotdir/conf.d"
+printf 'bindkey "^[OC" forward-word\n' >"$work_dir/home/custom-zdotdir/conf.d/binds.zsh"
+
+run_migration "$work_dir/home/custom-zdotdir" >"$work_dir/out" 2>&1
+[ -e "$work_dir/home/custom-zdotdir/conf.d/binds.zsh" ] &&
+    fail "a custom ZDOTDIR's conf.d/binds.zsh was not moved"
+[ -f "$work_dir/state/hyde/migration/v26.9.1/binds.zsh" ] ||
+    fail "a custom ZDOTDIR's conf.d/binds.zsh was not backed up to the expected path"
+
+# Idempotency: running again after a successful move must be a silent no-op,
+# not an error and not a second backup attempt.
+run_migration "$work_dir/home/custom-zdotdir" >"$work_dir/out2" 2>&1
+status=$?
+[ "$status" -eq 0 ] || fail "re-running after a successful move exited $status"
+[ -s "$work_dir/out2" ] && fail "re-running after a successful move produced output: $(cat "$work_dir/out2")"
+
+# Out-of-spec: the file comes back (e.g. a user restored it, or a stray sync)
+# while a backup from an earlier run already exists -- the existing backup
+# must survive untouched, not get silently overwritten or lost.
+mkdir -p "$work_dir/home/custom-zdotdir/conf.d"
+printf 'a different, user-restored version\n' >"$work_dir/home/custom-zdotdir/conf.d/binds.zsh"
+run_migration "$work_dir/home/custom-zdotdir" >"$work_dir/out3" 2>&1
+status=$?
+[ "$status" -eq 0 ] && fail "a re-appeared file with an existing backup did not report a conflict"
+[ -e "$work_dir/home/custom-zdotdir/conf.d/binds.zsh" ] ||
+    fail "a re-appeared file was silently consumed instead of being left in place on conflict"
+backup_after=$(cat "$work_dir/state/hyde/migration/v26.9.1/binds.zsh" 2>/dev/null)
+case $backup_after in
+*"forward-word"*) ;;
+*) fail "the original backup was overwritten by the conflicting re-run" ;;
+esac
+
+# Out-of-spec: a broken symlink at the source path (present via -L, absent
+# via -e) must still be treated as present and moved, not silently ignored.
+reset_sandbox
+mkdir -p "$work_dir/home/.config/zsh/conf.d"
+ln -s "$work_dir/home/.config/zsh/conf.d/does-not-exist-target" "$work_dir/home/.config/zsh/conf.d/binds.zsh"
+run_migration >"$work_dir/out4" 2>&1
+status=$?
+[ "$status" -eq 0 ] || fail "a broken-symlink source exited $status: $(cat "$work_dir/out4")"
+[ -e "$work_dir/home/.config/zsh/conf.d/binds.zsh" ] || [ -L "$work_dir/home/.config/zsh/conf.d/binds.zsh" ] &&
+    fail "a broken-symlink source was left in place instead of being moved"
+
+# Not run through run_pending_migrations against the real Scripts/migrations
+# directory: that would execute every other shipped migration too, each with
+# whatever env vars *they* read, not just the ones this file's own sandbox
+# happens to cover -- tests/test_migrations.sh already proves the generic
+# runner mechanics (order, skip-if-applied, recording) against synthetic
+# fixtures; nothing here suggests v26.9.1.sh needs its own copy of that.
+
+finish

--- a/tests/test_migration_stale_zsh_binds.sh
+++ b/tests/test_migration_stale_zsh_binds.sh
@@ -60,8 +60,12 @@ status=$?
 backup="$work_dir/state/hyde/migration/v26.9.1/binds.zsh"
 [ -f "$backup" ] || fail "no backup copy was created at $backup"
 if [ -f "$backup" ]; then
-    backup_content=$(cat "$backup")
-    [ "$backup_content" = "$(printf '%s' "$original_content")" ] ||
+    # cmp, not a $(...)-captured string compare: command substitution strips
+    # trailing newlines from both sides, which would hide exactly the kind
+    # of difference this check exists to catch.
+    original="$work_dir/original-for-compare"
+    printf '%s' "$original_content" >"$original"
+    cmp -s "$original" "$backup" ||
         fail "the backed-up file's content does not match the original byte-for-byte"
 fi
 

--- a/tests/test_migration_stale_zsh_binds.sh
+++ b/tests/test_migration_stale_zsh_binds.sh
@@ -72,7 +72,9 @@ fi
 # A custom ZDOTDIR must be respected, not just the default fallback.
 reset_sandbox
 mkdir -p "$work_dir/home/custom-zdotdir/conf.d"
-printf 'bindkey "^[OC" forward-word\n' >"$work_dir/home/custom-zdotdir/conf.d/binds.zsh"
+custom_zdotdir_fixture="$work_dir/custom-zdotdir-fixture"
+printf 'bindkey "^[OC" forward-word\n' >"$custom_zdotdir_fixture"
+cp "$custom_zdotdir_fixture" "$work_dir/home/custom-zdotdir/conf.d/binds.zsh"
 
 run_migration "$work_dir/home/custom-zdotdir" >"$work_dir/out" 2>&1
 [ -e "$work_dir/home/custom-zdotdir/conf.d/binds.zsh" ] &&
@@ -97,22 +99,30 @@ status=$?
 [ "$status" -eq 0 ] && fail "a re-appeared file with an existing backup did not report a conflict"
 [ -e "$work_dir/home/custom-zdotdir/conf.d/binds.zsh" ] ||
     fail "a re-appeared file was silently consumed instead of being left in place on conflict"
-backup_after=$(cat "$work_dir/state/hyde/migration/v26.9.1/binds.zsh" 2>/dev/null)
-case $backup_after in
-*"forward-word"*) ;;
-*) fail "the original backup was overwritten by the conflicting re-run" ;;
-esac
+cmp -s "$custom_zdotdir_fixture" "$work_dir/state/hyde/migration/v26.9.1/binds.zsh" ||
+    fail "the original backup was overwritten by the conflicting re-run (mismatches the fixture it was created from)"
 
 # Out-of-spec: a broken symlink at the source path (present via -L, absent
-# via -e) must still be treated as present and moved, not silently ignored.
+# via -e) must still be treated as present and *moved* -- not silently
+# ignored, and not just deleted in place (which would also make the source
+# disappear, so that alone isn't proof of anything).
 reset_sandbox
 mkdir -p "$work_dir/home/.config/zsh/conf.d"
-ln -s "$work_dir/home/.config/zsh/conf.d/does-not-exist-target" "$work_dir/home/.config/zsh/conf.d/binds.zsh"
+dangling_target="$work_dir/home/.config/zsh/conf.d/does-not-exist-target"
+ln -s "$dangling_target" "$work_dir/home/.config/zsh/conf.d/binds.zsh"
 run_migration >"$work_dir/out4" 2>&1
 status=$?
 [ "$status" -eq 0 ] || fail "a broken-symlink source exited $status: $(cat "$work_dir/out4")"
 [ -e "$work_dir/home/.config/zsh/conf.d/binds.zsh" ] || [ -L "$work_dir/home/.config/zsh/conf.d/binds.zsh" ] &&
     fail "a broken-symlink source was left in place instead of being moved"
+
+symlink_backup="$work_dir/state/hyde/migration/v26.9.1/binds.zsh"
+if [ -L "$symlink_backup" ]; then
+    [ "$(readlink "$symlink_backup")" = "$dangling_target" ] ||
+        fail "the symlink was recreated pointing somewhere else instead of moved with its original target"
+else
+    fail "the broken symlink was not preserved as a symlink at the backup path (deleted rather than moved?)"
+fi
 
 # Not run through run_pending_migrations against the real Scripts/migrations
 # directory: that would execute every other shipped migration too, each with


### PR DESCRIPTION
## Summary

Fixes #1940 (and the same underlying issue reported in #1958). Plain Left/Right
arrow keys move by whole words in zsh instead of by character, on installs
that predate #2036.

## Root cause

Confirmed live, not just from the report: this repo's own `zsh -x` startup
trace shows

```
+/home/<user>/.config/zsh/conf.d/binds.zsh:5> bindkey '^[OC' forward-word
+/home/<user>/.config/zsh/conf.d/binds.zsh:6> bindkey '^[OD' backward-word
```

`^[OC`/`^[OD` is the **SS3** form of the arrow keys — what a terminal like
kitty actually sends for plain Left/Right, per its own terminfo
(`kcuf1=\EOC`, `kcub1=\EOD` for `xterm-kitty`). zsh's own built-in default
(verified with `zsh -f`, no rc files at all) already binds these correctly to
`forward-char`/`backward-char`; `conf.d/binds.zsh` overrode that with
word-jump instead.

#2036 (`d020fde0`) already recognized this and deleted the file from the
repo. But `.zshenv` sources every `*.zsh` file it finds under `conf.d/` by a
directory glob:

```
for file in "${ZDOTDIR:-$HOME/.config/zsh}/conf.d/"*.zsh; do
```

— regardless of whether the current checkout still ships it. An install from
before #2036 still has the file physically on disk, so every new shell keeps
re-applying the bug that was already fixed upstream. Deleting a file from the
repo doesn't remove it from an existing installation; nothing else in this
repo does either.

## What it does

New `Scripts/migrations/v26.9.1.sh`, following the exact pattern
`v26.8.4.sh` already established for this same class of bug (a superseded
file left over from an old install shadowing/reintroducing behavior that was
already fixed): moves `$ZDOTDIR/conf.d/binds.zsh` into
`$XDG_STATE_HOME/hyde/migration/v26.9.1/` if present, rather than deleting
it, in case someone repurposed the file for their own bindings. No-op if the
file was never there or was already moved by an earlier run. (Exact version
number is a guess at the next release tag — happy to rename if you'd prefer
a different one.)

## Test plan

New `tests/test_migration_stale_zsh_binds.sh`, run in an isolated sandbox
(every env var the migration reads is pinned — `HOME`, `XDG_CONFIG_HOME`,
`XDG_STATE_HOME`, `ZDOTDIR`):

- Missing file → no-op, no output, no state directory created.
- Present file (default `$ZDOTDIR`) → moved, content verified byte-for-byte
  with `cmp` against the original.
- A custom `$ZDOTDIR` is respected, not just the default fallback.
- Idempotent: running again after a successful move is a silent no-op.
- Out-of-spec: the file reappears while a backup from an earlier run already
  exists — the existing backup survives untouched, the conflict is reported
  rather than silently overwriting or dropping either copy.
- Out-of-spec: a broken symlink at the source path (`-L` true, `-e` false)
  is still treated as present and moved.
- Revert-and-confirm-fails verified locally (10 targeted failures without
  the fix) before restoring it.

Full suite (`tests/run.sh`) green, 41/41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale zsh keybinding configuration that caused plain arrow keys to move by words instead of characters.
  - Stale configuration files are safely moved to backups before correction, including files in custom zsh configuration locations.
  - Migration handling avoids overwriting existing backups and reports clear errors when backup operations fail.

- **Tests**
  - Expanded coverage for missing files, repeat runs, backup conflicts, symlinks, and custom configuration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
