### PR TITLE
fix: restore eval exec so selected games actually launch

### DIFF
--- a/Configs/.local/lib/hyde/gamelauncher.sh
+++ b/Configs/.local/lib/hyde/gamelauncher.sh
@@ -82,4 +82,11 @@ fi
 
 cmd=${selected#*$'\t'}
 
-exec "$cmd"
+# run_command is a full shell command line (e.g. `xdg-open "lutris:rungame/
+# <slug>"`), not a single argv -- a plain, quoted exec would try to run that
+# whole string as one program name and always fail. eval is what actually
+# parses it as shell syntax; the backends (steam.py: a regex-validated
+# numeric appid, lutris.py: a slug checked against ^[a-z0-9-]+$) are
+# responsible for making sure nothing unexpected ends up in this string in
+# the first place.
+eval exec "$cmd"

--- a/Configs/.local/lib/hyde/gamelauncher/lutris.py
+++ b/Configs/.local/lib/hyde/gamelauncher/lutris.py
@@ -22,9 +22,19 @@ Assumptions/notes:
 import argparse
 import json
 import os
+import re
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Dict, List, Optional
+
+# gamelauncher.sh runs run_command with `eval exec` (it has to: the command
+# is a full shell command line, not a single argv), so a slug that isn't
+# what Lutris actually generates -- e.g. one containing a `"` -- could break
+# out of the quotes it's embedded in below and inject arbitrary shell code.
+# Lutris slugs are lowercased, hyphenated ASCII by construction; anything
+# else is treated as untrustworthy rather than assumed safe.
+_SAFE_SLUG = re.compile(r"^[a-z0-9-]+$")
 
 DEFAULT_LOCATIONS = [
     Path(os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")) + "/lutris/pga.db"),
@@ -212,6 +222,15 @@ def main(argv=None):
     games = read_games_from_db(use_db)
     result = []
     for g in games:
+        slug = g.get("slug") or ""
+        if not _SAFE_SLUG.match(slug):
+            print(
+                f"Skipping {g.get('name', '?')!r}: slug {slug!r} is not a plain lowercase-hyphenated "
+                "identifier, refusing to embed it in a shell command",
+                file=sys.stderr,
+            )
+            continue
+
         g2 = g.copy()
         cover = guess_cover_path(g, use_db)
         if cover:

--- a/Configs/.local/lib/hyde/gamelauncher/lutris.py
+++ b/Configs/.local/lib/hyde/gamelauncher/lutris.py
@@ -109,7 +109,13 @@ def read_games_from_db(db_path: Path) -> List[Dict]:
                     "name": r["name"],
                     "slug": r["slug"],
                     "runner": r["runner"],
-                    "path": r.get("prefix") if "prefix" in r.keys() else None,
+                    # sqlite3.Row supports [] and .keys(), not .get() -- and
+                    # the AttributeError from calling it anyway isn't a
+                    # sqlite3.Error, so the try/except around this block
+                    # never caught it: every real Lutris DB (which has a
+                    # "games" table, the primary query this is inside)
+                    # crashed the whole script before this line was reached.
+                    "path": r["prefix"] if "prefix" in r.keys() else None,
                     "icon": r["icon"],
                 }
             )

--- a/Configs/.local/lib/hyde/gamelauncher/lutris.py
+++ b/Configs/.local/lib/hyde/gamelauncher/lutris.py
@@ -229,7 +229,12 @@ def main(argv=None):
     result = []
     for g in games:
         slug = g.get("slug") or ""
-        if not _SAFE_SLUG.match(slug):
+        # fullmatch, not match: "^...$" under match() still accepts one
+        # trailing newline after what the pattern consumed (Python's `$`
+        # matches immediately before a trailing "\n" as well as at the true
+        # end of string) -- a slug ending in "\n<more shell>" would pass and
+        # inject a second statement once eval sees the embedded newline.
+        if not _SAFE_SLUG.fullmatch(slug):
             print(
                 f"Skipping {g.get('name', '?')!r}: slug {slug!r} is not a plain lowercase-hyphenated "
                 "identifier, refusing to embed it in a shell command",

--- a/tests/python/check_lutris_slug_validation.py
+++ b/tests/python/check_lutris_slug_validation.py
@@ -1,0 +1,142 @@
+"""Checks lutris.py's slug validation, added alongside restoring gamelauncher.sh's
+`eval exec "$cmd"` (#2018).
+
+run_command is built as f'xdg-open "lutris:rungame/{slug}"' and later run
+through eval by gamelauncher.sh -- a slug isn't validated by anything upstream
+(it comes straight from Lutris's own SQLite database), so a slug containing a
+stray '"' could break out of that quoted argument and inject arbitrary shell
+code. This checks that only a plain lowercase-hyphenated slug (what Lutris
+actually generates) makes it into run_command at all; anything else is
+dropped rather than passed through.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sqlite3
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = pathlib.Path(os.environ.get("REPO_ROOT", "."))
+SCRIPT_PATH = REPO_ROOT / "Configs/.local/lib/hyde/gamelauncher/lutris.py"
+
+failures = 0
+
+
+def check(condition: bool, message: str) -> None:
+    global failures
+    if not condition:
+        failures += 1
+        print(f"    fail: {message}")
+
+
+def make_db(path: pathlib.Path, games: list[tuple]) -> None:
+    """games: list of (id, name, slug, runner, prefix, icon)."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE games (id INTEGER, name TEXT, slug TEXT, runner TEXT, "
+        "prefix TEXT, icon TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO games (id, name, slug, runner, prefix, icon) VALUES (?, ?, ?, ?, ?, ?)",
+        games,
+    )
+    conn.commit()
+    conn.close()
+
+
+def run_lutris_json(db_path: pathlib.Path):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--json", "--db", str(db_path)],
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+def main() -> int:
+    if not SCRIPT_PATH.is_file():
+        print(f"fail: lutris.py not found at {SCRIPT_PATH}")
+        return 1
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = pathlib.Path(tmp) / "pga.db"
+
+        # A legitimate Lutris slug, an injection attempt (embeds a double
+        # quote to try to break out of run_command's quoting), a slug with a
+        # shell metacharacter that doesn't even need the quote to be
+        # dangerous under eval, an empty slug, and one with an unexpected
+        # uppercase/space shape a real Lutris slug would never have.
+        make_db(
+            db_path,
+            [
+                (1, "Counter-Strike 2", "counter-strike-2", "steam", "", ""),
+                (2, "Evil Game", 'x"; touch /tmp/pwned; echo "', "wine", "", ""),
+                (3, "Semicolon Game", "foo;rm -rf ~", "wine", "", ""),
+                (4, "Empty Slug Game", "", "wine", "", ""),
+                (5, "Weird Case Game", "Some Slug", "wine", "", ""),
+            ],
+        )
+
+        result = run_lutris_json(db_path)
+        check(result.returncode == 0, f"lutris.py --json exited {result.returncode}: {result.stderr}")
+
+        try:
+            games = json.loads(result.stdout)
+        except ValueError:
+            games = []
+            check(False, f"lutris.py --json did not print valid JSON: {result.stdout!r}")
+
+        by_id = {g["id"]: g for g in games} if isinstance(games, list) else {}
+
+        check(1 in by_id, "the legitimate slug (counter-strike-2) was dropped")
+        if 1 in by_id:
+            check(
+                by_id[1]["run_command"] == 'xdg-open "lutris:rungame/counter-strike-2"',
+                f"the legitimate game's run_command is wrong: {by_id[1].get('run_command')!r}",
+            )
+
+        for bad_id, why in [
+            (2, "a slug containing an embedded double-quote was not filtered out"),
+            (3, "a slug containing a shell metacharacter (;) was not filtered out"),
+            (4, "an empty slug was not filtered out"),
+            (5, "a slug with spaces/uppercase (not what Lutris generates) was not filtered out"),
+        ]:
+            check(bad_id not in by_id, why)
+
+        check(result.stderr.strip() != "", "no warning was printed for any of the rejected slugs")
+
+        # Boundary: a single-character slug and a slug that is only digits
+        # are both syntactically valid per Lutris's own convention and must
+        # not be rejected just for being short or numeric-looking. A fresh
+        # DB file: make_db() creates the table, and re-running it against
+        # the same path would just collide with the one already there.
+        db_path = pathlib.Path(tmp) / "pga2.db"
+        make_db(
+            db_path,
+            [
+                (10, "One Char", "a", "wine", "", ""),
+                (11, "Numeric Slug", "12345", "wine", "", ""),
+            ],
+        )
+        result2 = run_lutris_json(db_path)
+        try:
+            games2 = {g["id"]: g for g in json.loads(result2.stdout)}
+        except ValueError:
+            games2 = {}
+            check(False, f"second run did not print valid JSON: {result2.stdout!r}")
+
+        check(10 in games2, "a single-character slug was rejected")
+        check(11 in games2, "a purely numeric slug was rejected")
+
+    if failures:
+        print(f"    {failures} failure(s)")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/python/check_lutris_slug_validation.py
+++ b/tests/python/check_lutris_slug_validation.py
@@ -78,6 +78,14 @@ def main() -> int:
                 (3, "Semicolon Game", "foo;rm -rf ~", "wine", "", ""),
                 (4, "Empty Slug Game", "", "wine", "", ""),
                 (5, "Weird Case Game", "Some Slug", "wine", "", ""),
+                # Nothing after the newline: Python's $ matches immediately
+                # before a single trailing "\n" as well as at the true end
+                # of string, so match() (as opposed to fullmatch()) accepts
+                # this even though the pattern never actually consumes the
+                # newline itself -- a slug with content *after* the
+                # newline (e.g. "foo\nrm -rf ~") is already rejected by
+                # plain match() too, so it wouldn't exercise this gap.
+                (6, "Trailing Newline Game", "foo\n", "wine", "", ""),
             ],
         )
 
@@ -104,6 +112,11 @@ def main() -> int:
             (3, "a slug containing a shell metacharacter (;) was not filtered out"),
             (4, "an empty slug was not filtered out"),
             (5, "a slug with spaces/uppercase (not what Lutris generates) was not filtered out"),
+            (
+                6,
+                "a slug that is just 'foo\\n' was not filtered out -- match() would accept it "
+                "(Python's $ matches before a trailing newline too), only fullmatch() rejects it",
+            ),
         ]:
             check(bad_id not in by_id, why)
 

--- a/tests/test_gamelauncher_exec.sh
+++ b/tests/test_gamelauncher_exec.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+# gamelauncher.sh must actually run a selected game, not just try to and
+# silently fail. run_command (from steam.py/lutris.py/catalog.py) is a full
+# shell command line, e.g. `xdg-open "lutris:rungame/some-slug"` -- quoted
+# `exec "$cmd"` treats that whole string as a single program name and always
+# fails, which is exactly what #2018 reports ("select a game, nothing
+# happens"), introduced by b87c44b8 replacing the working `eval exec "$cmd"`.
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+script="$REPO_ROOT/Configs/.local/lib/hyde/gamelauncher.sh"
+[ -f "$script" ] || {
+    fail "gamelauncher.sh not found at $script"
+    finish
+}
+
+work_dir=$(mktemp -d) || exit 1
+trap 'rm -rf "$work_dir"' EXIT
+
+bin_dir="$work_dir/bin"
+python_dir="$work_dir/hyde/python_env/bin"
+mkdir -p "$bin_dir" "$python_dir"
+
+# Stands in for steam.py/lutris.py/catalog.py: gamelauncher.sh hardcodes the
+# interpreter path via XDG_STATE_HOME rather than looking one up on PATH, so
+# pointing XDG_STATE_HOME here is what actually substitutes it. Always
+# emits one fixture line shaped like lutris.py's real run_command, but with
+# a deliberate space *inside* the quoted argument -- naive word-splitting
+# (as opposed to real shell-quote-aware parsing) would wrongly cut this into
+# three argv pieces with stray literal quote characters, so this fails
+# either the old bug (single mangled argv) or a half-fix (unquoted
+# splitting) the same way, not just the one this repo happened to ship.
+cat >"$python_dir/python" <<'STUB'
+#!/usr/bin/env sh
+printf 'Test Game\txdg-open "lutris:rungame/my slug"\n'
+STUB
+chmod +x "$python_dir/python"
+
+# Stands in for the real interactive rofi: -dmenu mode reads candidate lines
+# on stdin and prints the one line the user picked back out unchanged: this
+# always "picks" the first one, deterministically.
+cat >"$bin_dir/rofi" <<'STUB'
+#!/usr/bin/env sh
+sed -n '1p'
+STUB
+chmod +x "$bin_dir/rofi"
+
+# The command gamelauncher.sh is ultimately supposed to run -- records
+# exactly the argv it was invoked with, one argument per line, so the test
+# can tell a correctly-split multi-word invocation from a mangled one.
+cat >"$bin_dir/xdg-open" <<STUB
+#!/usr/bin/env sh
+for arg in "\$@"; do printf '%s\n' "\$arg"; done >"$work_dir/xdg-open.args"
+STUB
+chmod +x "$bin_dir/xdg-open"
+
+run_gamelauncher() {
+    HYDE_SHELL_INIT=1 \
+        LIB_DIR="$REPO_ROOT/Configs/.local/lib" \
+        XDG_STATE_HOME="$work_dir" \
+        PATH="$bin_dir:$PATH" \
+        bash "$script" --style catalog_dummy --backend lutris
+}
+
+# --style anything-non-numeric-and-not-steam_deck skips the steam_deck
+# branch entirely (hyprctl/jq/magick, none of which this test stubs -- it
+# isn't what's under test here).
+run_gamelauncher >"$work_dir/out" 2>"$work_dir/err"
+status=$?
+
+[ "$status" -eq 0 ] || fail "gamelauncher.sh exited $status: $(cat "$work_dir/err")"
+
+[ -f "$work_dir/xdg-open.args" ] ||
+    fail "xdg-open was never invoked -- the selected game did not launch at all: $(cat "$work_dir/err")"
+
+if [ -f "$work_dir/xdg-open.args" ]; then
+    argv=$(cat "$work_dir/xdg-open.args")
+    expected='lutris:rungame/my slug'
+    [ "$argv" = "$expected" ] ||
+        fail "xdg-open received $(wc -l <"$work_dir/xdg-open.args") argument(s) reading '$argv', expected exactly one: '$expected'"
+fi
+
+finish

--- a/tests/test_lutris_slug_validation.sh
+++ b/tests/test_lutris_slug_validation.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# lutris.py must not embed an unvalidated slug into run_command --
+# gamelauncher.sh runs it through eval, so a slug containing a stray quote
+# or shell metacharacter would be an injection vector (#2018).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 is not installed"
+    finish
+fi
+
+python3 "$TESTS_DIR/python/check_lutris_slug_validation.py" ||
+    fail "check_lutris_slug_validation reported defects"
+
+finish


### PR DESCRIPTION
## Summary

Fixes #2018. Selecting a game in the gamelauncher does nothing — reported as
a regression from v26.08.21.

## Root cause

`gamelauncher.sh:85` does `exec "$cmd"`, but `$cmd` (from `steam.py`/
`lutris.py`/`catalog.py`'s `--rofi-string` output) is always a full shell
command line, not a single argv, e.g.:

```
xdg-open steam://rungameid/12345
xdg-open "lutris:rungame/some-slug"
```

Quoted `exec "$cmd"` tries to run that entire string as one program name and
always fails — there's no executable literally named `xdg-open steam://...`.

Confirmed with git history: this was `eval exec "$cmd"` (correctly parsing
the string as shell syntax) since October 2025. `b87c44b8` ("fix: eval an
injection vector if command string contains shell metacharacters") replaced
it with the plain quoted form on 2026-08-20 — a real security concern,
correctly identified, but the fix breaks every launch rather than closing
the actual hole.

## What it does

**`gamelauncher.sh`**: restores `eval exec "$cmd"`.

**Closes the actual injection surface instead of just reopening it**:
- `steam.py`'s `appid` was already safe — parsed via `re.search(r'"appid"\s*"(\d+)"', ...)` then `int(...)`, so it can only ever be digits.
- `lutris.py`'s `slug` came straight from Lutris's own SQLite database with
  **no validation at all**, and gets embedded inside a quoted argument
  (`f'xdg-open "lutris:rungame/{slug}"'`) that a slug containing a stray `"`
  could break out of under `eval`. Entries whose slug isn't a plain
  lowercase-hyphenated identifier (`^[a-z0-9-]+$`, what Lutris actually
  generates) are now skipped, with a warning on stderr, rather than passed
  through.

**Also fixes an unrelated crash found while testing**: `sqlite3.Row` has no
`.get()` (only `[]` and `.keys()`). The `AttributeError` from calling it
anyway isn't a `sqlite3.Error`, so the `try/except` around that block never
caught it — every real Lutris DB (which has a `games` table, the primary
query this line is inside) crashed `lutris.py` outright, before ever
reaching the fallback schema-detection path below it. This is independent
of the `exec`/`eval` bug and would have kept Lutris games from appearing at
all even with that fixed.

## Test plan

- `tests/test_gamelauncher_exec.sh` (new): runs the real script end-to-end
  with `xdg-open`, `rofi`, and the backend interpreter stubbed. The fixture
  command has a space *inside* the quoted argument specifically so naive
  unquoted word-splitting (not just the literal bug this repo shipped) would
  also fail it — asserts `xdg-open` receives exactly the one correctly
  parsed argument.
- `tests/test_lutris_slug_validation.sh` (new): a legitimate slug, an
  embedded-quote injection attempt, a shell-metacharacter slug, an empty
  slug, and a wrong-shaped slug are all exercised against a real (fixture)
  SQLite DB via the actual `--json` CLI path; boundary cases (single-char,
  purely-numeric slug) confirmed *not* rejected.
- Revert-and-confirm-fails verified locally for both the `eval` fix and the
  `sqlite3.Row` fix before restoring them.
- Full suite (`tests/run.sh`) green, 42/42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Game launcher commands containing arguments or quoted values now execute correctly.
  - Lutris game listings load reliably from supported databases.
  - Invalid or unsafe game identifiers are skipped with a warning instead of being used to build launch commands.

- **Tests**
  - Added coverage for command execution, database handling, valid and invalid game identifiers, and shell-safety scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->