### PR TITLE
fix: give swaync's notification window a transparent GTK background

### DIFF
--- a/Configs/.local/share/wallbash/theme/swaync.dcol
+++ b/Configs/.local/share/wallbash/theme/swaync.dcol
@@ -11,6 +11,15 @@ ${confDir}/swaync/theme.css|${WALLBASH_SCRIPTS}/swaync.sh
 @define-color text-color #FFFFFF;
 @define-color text-color-disabled #070707;
 
+/* swaync's layer-shell surface spans the full monitor height (fit-to-screen
+ * in config.json), so its GTK window node has to be transparent -- without
+ * this, GTK's default dark window background paints across that whole area,
+ * not just the notification popup itself (#1611). */
+notificationwindow, blankwindow {
+  background: transparent;
+  background-color: transparent;
+}
+
 /*
  *
  * control center

--- a/tests/test_swaync_notification_transparency.sh
+++ b/tests/test_swaync_notification_transparency.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+# swaync's layer-shell surface spans the full monitor height (fit-to-screen
+# in config.json), so without an explicit transparent background on its GTK
+# window node, GTK's default dark background paints across that whole area
+# -- a black rectangle next to every notification, not just the popup (#1611).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+dcol="$REPO_ROOT/Configs/.local/share/wallbash/theme/swaync.dcol"
+[ -f "$dcol" ] || {
+    fail "swaync.dcol not found at $dcol"
+    finish
+}
+
+grep -Eq 'notificationwindow,[[:space:]]*blankwindow[[:space:]]*\{' "$dcol" ||
+    fail "swaync.dcol has no rule for the notificationwindow/blankwindow GTK nodes"
+
+awk '/notificationwindow,[ \t]*blankwindow[ \t]*\{/,/\}/' "$dcol" | grep -q 'background:[[:space:]]*transparent' ||
+    fail "the notificationwindow/blankwindow rule does not set a transparent background"
+
+finish


### PR DESCRIPTION
swaync's layer-shell surface spans the full monitor height (`fit-to-screen: true` in `config.json`), but the generated `theme.css` had no transparent background rule for swaync's GTK window node (`notificationwindow`/`blankwindow`). GTK's own dark default background then painted across that entire area, so every notification showed a black rectangle next to the popup — worst on portrait monitors, where the surface is even taller.

## Fix

Adds the missing rule to `Configs/.local/share/wallbash/theme/swaync.dcol` (the wallbash template that generates `theme.css`):

```css
notificationwindow, blankwindow {
  background: transparent;
  background-color: transparent;
}
```

## Deliberately not included

The issue also suggested raising `ignore_alpha` from `0` to `0.5` on the shared `swaync-notification-window` blur layer rule. That rule is shared with rofi/waybar/selection, and the change is speculative (the reporter themselves framed it as "should be ... at minimum"). The transparent-background fix alone accounts for a full-width black rectangle, not just thin blur edges, so I left the shared alpha threshold untouched rather than adjusting it without being able to verify visually.

## Test plan

- [x] `tests/test_swaync_notification_transparency.sh` (new): asserts the GTK transparency rule is present in `swaync.dcol`
- [x] Revert-and-confirm: reverting the fix makes the new test fail with the expected message; restoring it passes again
- [x] Full suite (`sh tests/run.sh`): 44/44 passing

Fixes #1611.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification windows now remain transparent, preventing an unwanted dark background from covering the monitor.

* **Tests**
  * Added coverage to verify the notification transparency styling is present and correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->