### PR TITLE
fix: use freedesktop-standard battery icon names in batterynotify.lua

### DIFF
--- a/Configs/.local/lib/hyde/batterynotify.lua
+++ b/Configs/.local/lib/hyde/batterynotify.lua
@@ -227,7 +227,7 @@ local function start_critical_countdown()
             local mm = math.floor(crit_remaining / 60); local ss = crit_remaining % 60
             notify_send('Battery Critically Low',
                 string.format('%d%% is critically low. Device will execute %s in %d:%02d.', pct, conf.execute_critical,
-                    mm, ss), 'critical', 'xfce4-battery-critical')
+                    mm, ss), 'critical', 'battery-empty-symbolic')
             crit_remaining = crit_remaining - 1
             if crit_remaining <= 0 then
                 run_cmd_shell(conf.execute_critical); crit_source = nil; return false
@@ -245,7 +245,7 @@ local function start_critical_countdown()
             local mm = math.floor(crit_remaining / 60); local ss = crit_remaining % 60
             notify_send('Battery Critically Low',
                 string.format('%d%% is critically low. Device will execute %s in %d:%02d.', pct, conf.execute_critical,
-                    mm, ss), 'critical', 'xfce4-battery-critical')
+                    mm, ss), 'critical', 'battery-empty-symbolic')
             crit_remaining = crit_remaining - 1
             if crit_remaining <= 0 then
                 run_cmd_shell(conf.execute_critical); timer:stop(); timer:close(); crit_source = nil
@@ -292,7 +292,11 @@ local function handle_update()
 
     if percentage >= conf.unplug_charger_threshold and not string.find(tostring(status), 'Discharging') and status ~= 'Full' and (percentage - last_notified_percentage) >= conf.interval then
         local steps = math.floor(((percentage + 5) / 10) + 0.00001) * 10
-        local icon = 'battery-' .. tostring((steps > 0) and steps or 100) .. '-charging'
+        -- Matches the battery-level-N-symbolic pattern already used below for
+        -- the discharging icons: freedesktop's icon-naming spec has no plain
+        -- "battery-N-charging" name, so themes that only ship the level-based
+        -- set (e.g. Tela-circle-dracula) rendered no icon at all (#798).
+        local icon = 'battery-level-' .. tostring((steps > 0) and steps or 100) .. '-charging-symbolic'
         log.debug('Prompt: UNPLUG threshold=%d status=%s percentage=%d steps=%d',
             conf.unplug_charger_threshold, tostring(status), percentage, steps)
         cancel_critical_countdown()
@@ -332,7 +336,11 @@ local function handle_update()
                 prev_status = status
                 local urgency = (percentage >= conf.unplug_charger_threshold) and 'CRITICAL' or 'NORMAL'
                 local steps = math.floor(((percentage + 5) / 10) + 0.00001) * 10
-                local icon = 'battery-' .. tostring((steps > 0) and steps or 100) .. '-charging'
+                -- Matches the battery-level-N-symbolic pattern already used below for
+        -- the discharging icons: freedesktop's icon-naming spec has no plain
+        -- "battery-N-charging" name, so themes that only ship the level-based
+        -- set (e.g. Tela-circle-dracula) rendered no icon at all (#798).
+        local icon = 'battery-level-' .. tostring((steps > 0) and steps or 100) .. '-charging-symbolic'
                 notify_send('Charger Plug In', string.format('Battery is at %d%%.', percentage), urgency, icon)
                 if conf.execute_charging ~= '' then run_cmd_shell(conf.execute_charging) end
             end

--- a/Configs/.local/lib/hyde/batterynotify.lua
+++ b/Configs/.local/lib/hyde/batterynotify.lua
@@ -227,7 +227,7 @@ local function start_critical_countdown()
             local mm = math.floor(crit_remaining / 60); local ss = crit_remaining % 60
             notify_send('Battery Critically Low',
                 string.format('%d%% is critically low. Device will execute %s in %d:%02d.', pct, conf.execute_critical,
-                    mm, ss), 'critical', 'battery-empty-symbolic')
+                    mm, ss), { urgency = 'critical', icon = 'battery-empty-symbolic' })
             crit_remaining = crit_remaining - 1
             if crit_remaining <= 0 then
                 run_cmd_shell(conf.execute_critical); crit_source = nil; return false
@@ -245,7 +245,7 @@ local function start_critical_countdown()
             local mm = math.floor(crit_remaining / 60); local ss = crit_remaining % 60
             notify_send('Battery Critically Low',
                 string.format('%d%% is critically low. Device will execute %s in %d:%02d.', pct, conf.execute_critical,
-                    mm, ss), 'critical', 'battery-empty-symbolic')
+                    mm, ss), { urgency = 'critical', icon = 'battery-empty-symbolic' })
             crit_remaining = crit_remaining - 1
             if crit_remaining <= 0 then
                 run_cmd_shell(conf.execute_critical); timer:stop(); timer:close(); crit_source = nil
@@ -299,6 +299,13 @@ local function handle_update()
         local icon = 'battery-level-' .. tostring((steps > 0) and steps or 100) .. '-charging-symbolic'
         log.debug('Prompt: UNPLUG threshold=%d status=%s percentage=%d steps=%d',
             conf.unplug_charger_threshold, tostring(status), percentage, steps)
+        -- The computed icon went unused here -- this branch mirrors the
+        -- Battery Low block above (same interval-throttle condition) but was
+        -- missing the actual notify_send call and the last_notified_percentage
+        -- update needed to make that throttle work.
+        notify_send('Unplug Charger', string.format('Battery is at %d%%. You can unplug the charger.', percentage),
+            { urgency = 'normal', icon = icon })
+        last_notified_percentage = percentage
         cancel_critical_countdown()
     end
 
@@ -317,7 +324,8 @@ local function handle_update()
         local icon = 'battery-level-' .. tostring((steps > 0) and steps or 10) .. '-symbolic'
         log.debug('Prompt: LOW threshold=%d status=%s percentage=%d',
             conf.battery_low_threshold, tostring(status), percentage)
-        notify_send('Battery Low', string.format('Battery is at %d%%. Connect the charger.', percentage), 'critical', icon)
+        notify_send('Battery Low', string.format('Battery is at %d%%. Connect the charger.', percentage),
+            { urgency = 'critical', icon = icon })
         last_notified_percentage = percentage
     end
 
@@ -328,7 +336,8 @@ local function handle_update()
                 local urgency = (percentage <= conf.battery_low_threshold) and 'CRITICAL' or 'NORMAL'
                 local steps = math.floor(((percentage + 5) / 10) + 0.00001) * 10
                 local icon = 'battery-level-' .. tostring((steps > 0) and steps or 10) .. '-symbolic'
-                notify_send('Charger Plug Out', string.format('Battery is at %d%%.', percentage), urgency, icon)
+                notify_send('Charger Plug Out', string.format('Battery is at %d%%.', percentage),
+                    { urgency = urgency, icon = icon })
                 if conf.execute_discharging ~= '' then run_cmd_shell(conf.execute_discharging) end
             end
         elseif starts_with(tostring(status), 'Not') or starts_with(tostring(status), 'Charging') then
@@ -341,7 +350,8 @@ local function handle_update()
         -- "battery-N-charging" name, so themes that only ship the level-based
         -- set (e.g. Tela-circle-dracula) rendered no icon at all (#798).
         local icon = 'battery-level-' .. tostring((steps > 0) and steps or 100) .. '-charging-symbolic'
-                notify_send('Charger Plug In', string.format('Battery is at %d%%.', percentage), urgency, icon)
+                notify_send('Charger Plug In', string.format('Battery is at %d%%.', percentage),
+                    { urgency = urgency, icon = icon })
                 if conf.execute_charging ~= '' then run_cmd_shell(conf.execute_charging) end
             end
         elseif status == 'Full' then
@@ -351,8 +361,8 @@ local function handle_update()
                 if prev_status and string.find(prev_status, 'harging') then do_notify = true end
                 if not do_notify and (now - lt) >= (conf.notify * 60) then do_notify = true end
                 if do_notify then
-                    notify_send('Battery Full', 'Please unplug your Charger', 'critical',
-                        'battery-full-charging-symbolic')
+                    notify_send('Battery Full', 'Please unplug your Charger',
+                        { urgency = 'critical', icon = 'battery-full-charging-symbolic' })
                     prev_status = status
                     lt = now
                     if conf.execute_charging ~= '' then run_cmd_shell(conf.execute_charging) end

--- a/tests/python/check_batterynotify_notify_calls.py
+++ b/tests/python/check_batterynotify_notify_calls.py
@@ -14,6 +14,24 @@ import sys
 from pathlib import Path
 
 
+def _skip_lua_string(text, i):
+    """i points at a ' or " that opens a Lua string; returns the index just
+    past its matching close, honouring \\-escapes -- a stray ')' or '(' a
+    battery-percentage message happens to contain (e.g. "Battery at 20%)")
+    must not be mistaken for call syntax.
+    """
+    quote = text[i]
+    i += 1
+    while i < len(text):
+        if text[i] == "\\":
+            i += 2
+            continue
+        if text[i] == quote:
+            return i + 1
+        i += 1
+    return i  # unterminated string -- stop where the text does
+
+
 def extract_calls(text, name="notify_send"):
     """Every "name(...)" call in text, matched by tracking paren depth
     rather than a fixed-nesting-depth regex -- a regex like
@@ -23,6 +41,13 @@ def extract_calls(text, name="notify_send"):
     dropped from the result, so a missing { urgency/icon } table on that
     call would never be checked -- not "no calls found" (which the caller
     below already fails loudly on), just fewer calls than actually exist.
+
+    Parens and quote characters inside a Lua string literal or a `--` line
+    comment are skipped rather than counted, so a message like "Battery at
+    20%)" can't be mistaken for the call's own closing paren. Lua's
+    `--[[ ]]` long-bracket comments are not handled -- batterynotify.lua
+    doesn't use them and a notify_send call sitting inside one would be dead
+    code anyway, so it's not worth the extra complexity here.
     """
     calls = []
     start = 0
@@ -34,9 +59,17 @@ def extract_calls(text, name="notify_send"):
         i = idx + len(name)
         end = None
         while i < len(text):
-            if text[i] == "(":
+            ch = text[i]
+            if ch in ("'", '"'):
+                i = _skip_lua_string(text, i)
+                continue
+            if ch == "-" and text[i:i + 2] == "--":
+                nl = text.find("\n", i)
+                i = len(text) if nl == -1 else nl
+                continue
+            if ch == "(":
                 depth += 1
-            elif text[i] == ")":
+            elif ch == ")":
                 depth -= 1
                 if depth == 0:
                     end = i + 1

--- a/tests/python/check_batterynotify_notify_calls.py
+++ b/tests/python/check_batterynotify_notify_calls.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Every notify_send(...) call in batterynotify.lua must pass its third
+argument as an { urgency = ..., icon = ... } table.
+
+notify_mod.send(summary, body, opts) reads opts.urgency/opts.icon -- passing
+urgency as a bare string (and icon as an unused fourth positional argument,
+which Lua silently drops) makes opts a string, and indexing a string with
+.urgency/.icon in Lua returns nil rather than erroring, so both silently fell
+back to their defaults ('normal', no icon) for every notification in this
+file, regardless of what was actually passed.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1] if len(sys.argv) > 1 else
+              "Configs/.local/lib/hyde/batterynotify.lua")
+if not script.is_file():
+    print(f"batterynotify.lua not found at {script}")
+    sys.exit(1)
+
+text = script.read_text()
+
+# Matches notify_send(...) allowing one level of nested parens, which is
+# enough for the string.format(...) calls used as the body argument here --
+# a genuinely unbalanced call (parens nested deeper) would fail to match at
+# all, which the "no calls found" check below turns into a loud failure
+# rather than a silent false pass.
+call_re = re.compile(r"notify_send\((?:[^()]|\([^()]*\))*\)", re.DOTALL)
+calls = call_re.findall(text)
+
+if not calls:
+    print("no notify_send(...) calls found -- the extraction pattern above may be stale")
+    sys.exit(1)
+
+failures = []
+for call in calls:
+    if "{ urgency" not in call and "{urgency" not in call:
+        failures.append(call)
+
+if failures:
+    print(f"{len(failures)} of {len(calls)} notify_send(...) call(s) do not pass "
+          "an { urgency = ... } options table:")
+    for call in failures:
+        print("  " + " ".join(call.split()))
+    sys.exit(1)
+
+print(f"{len(calls)} notify_send(...) call(s) checked")

--- a/tests/python/check_batterynotify_notify_calls.py
+++ b/tests/python/check_batterynotify_notify_calls.py
@@ -10,9 +10,44 @@ back to their defaults ('normal', no icon) for every notification in this
 file, regardless of what was actually passed.
 """
 
-import re
 import sys
 from pathlib import Path
+
+
+def extract_calls(text, name="notify_send"):
+    """Every "name(...)" call in text, matched by tracking paren depth
+    rather than a fixed-nesting-depth regex -- a regex like
+    notify_send\\((?:[^()]|\\([^()]*\\))*\\) only handles exactly one level
+    of nested parens; a call with two (e.g. a nested function call inside
+    string.format's arguments) would fail to match at all and be silently
+    dropped from the result, so a missing { urgency/icon } table on that
+    call would never be checked -- not "no calls found" (which the caller
+    below already fails loudly on), just fewer calls than actually exist.
+    """
+    calls = []
+    start = 0
+    while True:
+        idx = text.find(name + "(", start)
+        if idx == -1:
+            break
+        depth = 0
+        i = idx + len(name)
+        end = None
+        while i < len(text):
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+            i += 1
+        if end is None:
+            break  # unterminated call -- nothing sane left to scan
+        calls.append(text[idx:end])
+        start = end
+    return calls
+
 
 script = Path(sys.argv[1] if len(sys.argv) > 1 else
               "Configs/.local/lib/hyde/batterynotify.lua")
@@ -20,30 +55,29 @@ if not script.is_file():
     print(f"batterynotify.lua not found at {script}")
     sys.exit(1)
 
-text = script.read_text()
-
-# Matches notify_send(...) allowing one level of nested parens, which is
-# enough for the string.format(...) calls used as the body argument here --
-# a genuinely unbalanced call (parens nested deeper) would fail to match at
-# all, which the "no calls found" check below turns into a loud failure
-# rather than a silent false pass.
-call_re = re.compile(r"notify_send\((?:[^()]|\([^()]*\))*\)", re.DOTALL)
-calls = call_re.findall(text)
+calls = extract_calls(script.read_text())
 
 if not calls:
-    print("no notify_send(...) calls found -- the extraction pattern above may be stale")
+    print("no notify_send(...) calls found -- extract_calls() may be stale")
     sys.exit(1)
 
 failures = []
 for call in calls:
-    if "{ urgency" not in call and "{urgency" not in call:
-        failures.append(call)
+    has_urgency = "urgency" in call
+    has_icon = "icon" in call
+    if not (has_urgency and has_icon):
+        missing = []
+        if not has_urgency:
+            missing.append("urgency")
+        if not has_icon:
+            missing.append("icon")
+        failures.append((call, missing))
 
 if failures:
-    print(f"{len(failures)} of {len(calls)} notify_send(...) call(s) do not pass "
-          "an { urgency = ... } options table:")
-    for call in failures:
-        print("  " + " ".join(call.split()))
+    print(f"{len(failures)} of {len(calls)} notify_send(...) call(s) are missing "
+          f"required options table key(s):")
+    for call, missing in failures:
+        print(f"  missing {', '.join(missing)}: " + " ".join(call.split()))
     sys.exit(1)
 
 print(f"{len(calls)} notify_send(...) call(s) checked")

--- a/tests/test_batterynotify_icons.sh
+++ b/tests/test_batterynotify_icons.sh
@@ -25,6 +25,33 @@ grep -q "xfce4-battery-critical" "$script" &&
 if command -v python3 >/dev/null 2>&1; then
     python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$script" ||
         fail "a notify_send(...) call does not pass an { urgency = ... } options table -- notify_mod.send reads opts.urgency/opts.icon, so a bare string/positional 4th arg silently loses both"
+
+    work_dir=$(mktemp -d) || exit 1
+    trap 'rm -rf "$work_dir"' EXIT
+
+    # Out-of-spec: a call nested three function-calls deep (well past what
+    # any real call in this file needs) must still be found and checked --
+    # a fixed-one-level-of-parens regex would silently drop it from the
+    # results instead of failing loudly, so a missing options table on a
+    # deeply-nested call would never be caught.
+    cat >"$work_dir/deep-ok.lua" <<'LUA'
+notify_send('Deep', string.format('%s', tostring(compute(x, y))), { urgency = 'critical', icon = 'battery-full-symbolic' })
+LUA
+    python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$work_dir/deep-ok.lua" ||
+        fail "a deeply-nested notify_send call with both urgency and icon was rejected"
+
+    cat >"$work_dir/deep-missing-icon.lua" <<'LUA'
+notify_send('Deep', string.format('%s', tostring(compute(x, y))), { urgency = 'critical' })
+LUA
+    python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$work_dir/deep-missing-icon.lua" >/dev/null 2>&1 &&
+        fail "a deeply-nested notify_send call missing icon was accepted -- the balanced-paren scanner may have silently dropped it instead of checking it"
+
+    # Missing icon on an otherwise well-formed (unnested) call.
+    cat >"$work_dir/urgency-only.lua" <<'LUA'
+notify_send('X', 'Y', { urgency = 'critical' })
+LUA
+    python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$work_dir/urgency-only.lua" >/dev/null 2>&1 &&
+        fail "a notify_send call with urgency but no icon was accepted"
 else
     skip "python3 is not installed"
 fi

--- a/tests/test_batterynotify_icons.sh
+++ b/tests/test_batterynotify_icons.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+# batterynotify.lua's icon names must be valid freedesktop icon-naming-spec
+# battery icons -- driving the full notification pipeline (GLib/luv timers,
+# /sys/class/power_supply reads, D-Bus) just to observe one string is more
+# than this bug needs, so this checks the source text directly, the same way
+# tests/test_monitor_scale.sh checks for a leftover pattern rather than
+# running the function it's guarding against every possible input.
+#
+# "battery-N-charging" and "xfce4-battery-critical" aren't freedesktop names
+# at all -- icon themes that only ship the spec's battery-level-N[-charging]
+# -symbolic set (e.g. Tela-circle-dracula, per the report) resolved neither,
+# so the notification showed with no icon (#798).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+script="$REPO_ROOT/Configs/.local/lib/hyde/batterynotify.lua"
+[ -f "$script" ] || {
+    fail "batterynotify.lua not found at $script"
+    finish
+}
+
+grep -q "xfce4-battery-critical" "$script" &&
+    fail "batterynotify.lua still requests the non-standard 'xfce4-battery-critical' icon"
+
+grep -qE "'battery-' \.\. tostring\(\(steps > 0\) and steps or [0-9]+\) \.\. '-charging'" "$script" &&
+    fail "batterynotify.lua still builds a plain 'battery-N-charging' icon name, not the freedesktop battery-level-N-charging-symbolic form"
+
+for name in "battery-empty-symbolic" "battery-level-.*-charging-symbolic"; do
+    grep -qE "$name" "$script" ||
+        fail "batterynotify.lua no longer requests an icon matching '$name'"
+done
+
+# Every icon name actually passed to notify_send must match the freedesktop
+# battery icon pattern -- catches a typo'd or malformed replacement, not just
+# the two specific strings above.
+icons=$(grep -oE "'(battery-[a-z0-9-]*-symbolic|xfce4[a-z0-9-]*)'" "$script" | tr -d "'" | sort -u)
+[ -n "$icons" ] || fail "no battery icon names found in batterynotify.lua at all -- the patterns above may be stale"
+while IFS= read -r icon; do
+    case "$icon" in
+    battery-empty-symbolic | battery-full-symbolic | battery-good-symbolic | \
+        battery-low-symbolic | battery-caution-symbolic | battery-missing-symbolic | \
+        battery-full-charging-symbolic | battery-level-[0-9]*-symbolic | \
+        battery-level-[0-9]*-charging-symbolic) ;;
+    *) fail "'$icon' does not look like a freedesktop battery icon name" ;;
+    esac
+done <<EOF
+$icons
+EOF
+
+finish

--- a/tests/test_batterynotify_icons.sh
+++ b/tests/test_batterynotify_icons.sh
@@ -22,6 +22,19 @@ script="$REPO_ROOT/Configs/.local/lib/hyde/batterynotify.lua"
 grep -q "xfce4-battery-critical" "$script" &&
     fail "batterynotify.lua still requests the non-standard 'xfce4-battery-critical' icon"
 
+if command -v python3 >/dev/null 2>&1; then
+    python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$script" ||
+        fail "a notify_send(...) call does not pass an { urgency = ... } options table -- notify_mod.send reads opts.urgency/opts.icon, so a bare string/positional 4th arg silently loses both"
+else
+    skip "python3 is not installed"
+fi
+
+# The UNPLUG-threshold notification (mirrors the Battery Low block below it,
+# same interval throttle) used to compute an icon and never call
+# notify_send at all.
+awk '/unplug_charger_threshold and not string\.find/,/^    end$/' "$script" | grep -q "notify_send" ||
+    fail "the UNPLUG-threshold block still never calls notify_send"
+
 grep -qE "'battery-' \.\. tostring\(\(steps > 0\) and steps or [0-9]+\) \.\. '-charging'" "$script" &&
     fail "batterynotify.lua still builds a plain 'battery-N-charging' icon name, not the freedesktop battery-level-N-charging-symbolic form"
 
@@ -32,10 +45,30 @@ done
 
 # Every icon name actually passed to notify_send must match the freedesktop
 # battery icon pattern -- catches a typo'd or malformed replacement, not just
-# the two specific strings above.
+# the two specific strings above. Fully-literal names are pulled directly;
+# the dynamic ones ('prefix' .. tostring(...) .. 'suffix') are reconstructed
+# with a representative steps value AND the expression's own fallback value,
+# so a typo in either the literal parts or the fallback number is caught --
+# grep alone can't do this, since it never sees the concatenated result.
 icons=$(grep -oE "'(battery-[a-z0-9-]*-symbolic|xfce4[a-z0-9-]*)'" "$script" | tr -d "'" | sort -u)
+
+dynamic=$(grep -oE "local icon = '[a-z-]+' \.\. tostring\(\(steps > 0\) and steps or [0-9]+\) \.\. '[a-z-]+'" "$script")
+[ -n "$dynamic" ] || fail "no dynamically-built icon expressions found -- the extraction pattern below may be stale"
+while IFS= read -r expr; do
+    prefix=$(printf '%s\n' "$expr" | sed -E "s/^local icon = '([a-z-]+)'.*/\1/")
+    fallback=$(printf '%s\n' "$expr" | sed -E "s/.*or ([0-9]+)\).*/\1/")
+    suffix=$(printf '%s\n' "$expr" | sed -E "s/.*\.\. '([a-z-]+)'\$/\1/")
+    icons="${icons}
+${prefix}50${suffix}
+${prefix}${fallback}${suffix}"
+done <<EOF
+$dynamic
+EOF
+
+icons=$(printf '%s\n' "$icons" | sort -u)
 [ -n "$icons" ] || fail "no battery icon names found in batterynotify.lua at all -- the patterns above may be stale"
 while IFS= read -r icon; do
+    [ -n "$icon" ] || continue
     case "$icon" in
     battery-empty-symbolic | battery-full-symbolic | battery-good-symbolic | \
         battery-low-symbolic | battery-caution-symbolic | battery-missing-symbolic | \

--- a/tests/test_batterynotify_icons.sh
+++ b/tests/test_batterynotify_icons.sh
@@ -52,6 +52,16 @@ notify_send('X', 'Y', { urgency = 'critical' })
 LUA
     python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$work_dir/urgency-only.lua" >/dev/null 2>&1 &&
         fail "a notify_send call with urgency but no icon was accepted"
+
+    # Out-of-spec: a literal ')' inside a Lua string argument (a battery
+    # percentage message can legitimately contain one) must not be mistaken
+    # for the call's own closing paren -- a naive char-by-char depth counter
+    # would truncate the call there and report a false "missing" failure.
+    cat >"$work_dir/paren-in-string.lua" <<'LUA'
+notify_send('Battery at 20%)', 'body', { urgency = 'critical', icon = 'battery-full-symbolic' })
+LUA
+    python3 "$TESTS_DIR/python/check_batterynotify_notify_calls.py" "$work_dir/paren-in-string.lua" ||
+        fail "a ')' inside a string argument made a well-formed notify_send call fail"
 else
     skip "python3 is not installed"
 fi


### PR DESCRIPTION
'battery-N-charging' and 'xfce4-battery-critical' aren't freedesktop icon-naming-spec names. Icon themes that only ship the spec's `battery-level-N[-charging]-symbolic` set (e.g. Tela-circle-dracula, per the report) resolve neither, so the charger-plug-in and critically-low-battery notifications showed with no icon at all.

## Fix

Switches to the same `battery-level-N-charging-symbolic` pattern the file already uses correctly for the discharging icons, and `battery-empty-symbolic` for the critical countdown.

## Also fixed while addressing CodeRabbit's review

Two more real bugs in the same file, in the exact notification path this PR already touches:

- **`notify_send`'s options were never actually reaching it.** `notify_mod.send(summary, body, opts)` reads `opts.urgency`/`opts.icon`. Every call in this file passed urgency as a bare string third argument and icon as an unused fourth positional argument (Lua silently drops extra args). Indexing a string with `.urgency`/`.icon` in Lua returns `nil` rather than erroring, so both silently fell back to their defaults (`'normal'`, no icon) for *every* battery notification -- meaning the icon-name fix above never actually reached `notify-send` on its own. Fixed by passing `{ urgency = ..., icon = ... }` at all 6 original call sites.
- **The UNPLUG-threshold notification was silently missing entirely.** That block computed an icon and logged a debug line but never called `notify_send`, despite mirroring the Battery Low block's interval-throttle condition right below it. Added the missing call ("Unplug Charger" / "Battery is at N%. You can unplug the charger.", `urgency = 'normal'`) and the `last_notified_percentage` update the throttle condition depends on.

## Test plan

- [x] `tests/test_batterynotify_icons.sh` (new): checks the source text and the dynamically-built icon names (evaluated with representative values, not just grepped as literals) against the freedesktop battery icon pattern
- [x] `tests/python/check_batterynotify_notify_calls.py` (new): parses every `notify_send(...)` call and asserts it passes an `{ urgency = ... }` table
- [x] A structural check that the UNPLUG block actually calls `notify_send`
- [x] Revert-and-confirm for all three fixes: each reproduces its exact failure (5 icon-name messages; all 6 calls flagged for the missing options table; the UNPLUG block flagged for no `notify_send` at all) before the corresponding fix, and passes after
- [x] Full suite (`sh tests/run.sh`): 46/46 passing

Fixes #798.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed battery notifications so icons display correctly for critical, charging, and unplugged states.
  * Improved charging-level icon selection, including fallback handling for consistent display.
  * Restored unplugged-state notifications and ensured notification frequency limits work as intended.
  * Ensured critical battery countdown alerts use the appropriate empty-battery icon.

* **Tests**
  * Added validation for supported battery icons, notification settings, unplugged-state alerts, and notification message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->