### PR TITLE
fix: accept a wallbash script name with or without .sh

### DIFF
--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -191,7 +191,14 @@ call_wallbashScript() {
         fi
     done
     dirs=("${sanitized_dirs[@]}")
-    script_path=$(find -L "${dirs[@]}" -type f -path "*/scripts/*" -name "${scriptName}.sh" -exec echo {} \; -quit)
+    # A missing or empty name must never reach `find`: an empty scriptName
+    # would search for the literal filename ".sh", which a real wallbash
+    # script directory could legitimately contain -- executing it instead
+    # of showing usage for what is clearly not a real request.
+    script_path=""
+    if [[ -n "$scriptName" ]]; then
+        script_path=$(find -L "${dirs[@]}" -type f -path "*/scripts/*" -name "${scriptName}.sh" -exec echo {} \; -quit)
+    fi
 
     for func in $(compgen -A function); do
         export -f "${func?}"

--- a/Configs/.local/bin/hyde-shell
+++ b/Configs/.local/bin/hyde-shell
@@ -174,7 +174,13 @@ USAGE() {
 }
 
 call_wallbashScript() {
-    local scriptName=$1
+    # Accept a name with or without ".sh": the usage fallback below lists
+    # scripts by their real filename (e.g. "spotify.sh"), which is what a
+    # user copies -- but the -name match further down always appends its
+    # own ".sh", so passing that exact listed name looked for
+    # "spotify.sh.sh", found nothing, and silently fell through to the same
+    # usage/help text instead of running the script (#1801).
+    local scriptName=${1%.sh}
     shift
     local args=("${@}")
     local dirs=("${WALLBASH_DIRS[@]}")

--- a/tests/test_hyde_shell_wallbash.sh
+++ b/tests/test_hyde_shell_wallbash.sh
@@ -27,6 +27,16 @@ echo "ran with args: $*"
 EOF
 chmod +x "$scripts_dir/spotify.sh"
 
+# A script literally named ".sh" -- appending ".sh" to an empty/missing name
+# produces exactly this filename, so this fixture is what makes the
+# missing/empty-name cases below a real test instead of one that would pass
+# just as well with an empty scripts directory.
+cat >"$scripts_dir/.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "DOT-SH SCRIPT RAN UNEXPECTEDLY"
+EOF
+chmod +x "$scripts_dir/.sh"
+
 ##
 # Runs `hyde-shell wallbash "$@"` against the sandboxed HOME/XDG dirs.
 ##
@@ -92,20 +102,26 @@ case $output in
 esac
 
 # Missing/absent: no script-name argument at all -- ${1%.sh} on an unset $1
-# must not error (this file has no `set -u`), and must fall through to the
-# usage text like any other unresolvable name, not crash or hang.
+# must not error (this file has no `set -u`), and appending ".sh" to that
+# empty name must not resolve to (and run) the ".sh" fixture above instead
+# of falling through to the usage text like any other unresolvable name.
 output=$(run_wallbash)
 status=$?
 [ "$status" -eq 0 ] || fail "wallbash with no arguments at all exited $status: $output (stderr: $(cat "$work_dir/stderr"))"
+case $output in
+*'DOT-SH SCRIPT RAN'*) fail "wallbash with no arguments at all ran the '.sh' script instead of showing usage: $output" ;;
+esac
 case $output in
 *'Usage: wallbash'*) ;;
 *) fail "wallbash with no arguments at all did not show the usage text: got '$output' (stderr: $(cat "$work_dir/stderr"))" ;;
 esac
 
 # Boundary: an explicit empty-string name must behave the same as no
-# argument at all, not match every script or explode the -name pattern into
-# just ".sh".
+# argument at all -- same ".sh"-fixture risk as above.
 output=$(run_wallbash "")
+case $output in
+*'DOT-SH SCRIPT RAN'*) fail "wallbash with an empty-string name ran the '.sh' script instead of showing usage: $output" ;;
+esac
 case $output in
 *'Usage: wallbash'*) ;;
 *) fail "wallbash with an empty-string name did not show the usage text: got '$output' (stderr: $(cat "$work_dir/stderr"))" ;;

--- a/tests/test_hyde_shell_wallbash.sh
+++ b/tests/test_hyde_shell_wallbash.sh
@@ -91,4 +91,36 @@ case $output in
     ;;
 esac
 
+# Missing/absent: no script-name argument at all -- ${1%.sh} on an unset $1
+# must not error (this file has no `set -u`), and must fall through to the
+# usage text like any other unresolvable name, not crash or hang.
+output=$(run_wallbash)
+status=$?
+[ "$status" -eq 0 ] || fail "wallbash with no arguments at all exited $status: $output (stderr: $(cat "$work_dir/stderr"))"
+case $output in
+*'Usage: wallbash'*) ;;
+*) fail "wallbash with no arguments at all did not show the usage text: got '$output' (stderr: $(cat "$work_dir/stderr"))" ;;
+esac
+
+# Boundary: an explicit empty-string name must behave the same as no
+# argument at all, not match every script or explode the -name pattern into
+# just ".sh".
+output=$(run_wallbash "")
+case $output in
+*'Usage: wallbash'*) ;;
+*) fail "wallbash with an empty-string name did not show the usage text: got '$output' (stderr: $(cat "$work_dir/stderr"))" ;;
+esac
+
+# Malformed/out-of-spec: a path-traversal-shaped name must not escape the
+# wallbash script directories or otherwise behave differently from any
+# other nonexistent name -- find's -name matches basenames only, so a
+# name containing "/" can never match a real file through it, but that
+# safety property is worth pinning down explicitly rather than trusting
+# incidentally.
+output=$(run_wallbash "../../../etc/passwd")
+case $output in
+*'Usage: wallbash'*) ;;
+*) fail "a path-traversal-shaped name did not fall through to the usage text: got '$output' (stderr: $(cat "$work_dir/stderr"))" ;;
+esac
+
 finish

--- a/tests/test_hyde_shell_wallbash.sh
+++ b/tests/test_hyde_shell_wallbash.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# `hyde-shell wallbash <name>` looks up the script by appending ".sh" to
+# whatever name it's given -- but its own usage/help fallback lists scripts
+# by their real filename (e.g. "spotify.sh"), inviting a user to pass that
+# exact name back in. Doing so looked for "spotify.sh.sh", found nothing,
+# and silently fell through to the same usage text instead of running the
+# script (#1801).
+
+. "$(dirname -- "$0")/lib/common.sh"
+
+hyde_shell="$REPO_ROOT/Configs/.local/bin/hyde-shell"
+[ -f "$hyde_shell" ] || {
+    fail "hyde-shell not found at $hyde_shell"
+    finish
+}
+
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+home_dir="$work_dir/home"
+scripts_dir="$home_dir/.local/share/wallbash/scripts"
+mkdir -p "$home_dir/.config" "$scripts_dir" "$home_dir/.local/state" "$home_dir/.cache"
+
+cat >"$scripts_dir/spotify.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "ran with args: $*"
+EOF
+chmod +x "$scripts_dir/spotify.sh"
+
+##
+# Runs `hyde-shell wallbash "$@"` against the sandboxed HOME/XDG dirs.
+##
+run_wallbash() {
+    env -i \
+        HOME="$home_dir" \
+        XDG_CONFIG_HOME="$home_dir/.config" \
+        XDG_DATA_HOME="$home_dir/.local/share" \
+        XDG_CACHE_HOME="$home_dir/.cache" \
+        XDG_STATE_HOME="$home_dir/.local/state" \
+        XDG_RUNTIME_DIR="$home_dir/run" \
+        PATH="/usr/bin:/bin" \
+        bash "$hyde_shell" wallbash "$@" 2>"$work_dir/stderr"
+}
+
+# The reported shape: the name copied verbatim from the help listing, ".sh"
+# and all.
+output=$(run_wallbash spotify.sh foo)
+case $output in
+*'ran with args: foo'*) ;;
+*)
+    fail "wallbash spotify.sh (with the extension, as the help text lists it) did not run the script: got '$output' (stderr: $(cat "$work_dir/stderr"))"
+    ;;
+esac
+
+# The name without the extension must keep working exactly as before --
+# regression guard for the case this always handled correctly.
+output=$(run_wallbash spotify bar)
+case $output in
+*'ran with args: bar'*) ;;
+*)
+    fail "wallbash spotify (no extension) did not run the script: got '$output' (stderr: $(cat "$work_dir/stderr"))"
+    ;;
+esac
+
+# Out-of-spec: a name that isn't a script at all, with or without ".sh",
+# must still fall through to the usage/help text -- not be silently
+# swallowed, and not crash.
+for missing in "nonexistent" "nonexistent.sh"; do
+    output=$(run_wallbash "$missing")
+    case $output in
+    *'Usage: wallbash'*) ;;
+    *)
+        fail "wallbash $missing (which does not exist) did not show the usage text: got '$output' (stderr: $(cat "$work_dir/stderr"))"
+        ;;
+    esac
+done
+
+# Boundary: a script literally named "x.sh.sh" (unusual, but the glob
+# doesn't forbid it) must still be reachable by its exact real name -- the
+# fix must strip at most one trailing ".sh", not repeatedly.
+cat >"$scripts_dir/oddname.sh.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "odd script ran"
+EOF
+chmod +x "$scripts_dir/oddname.sh.sh"
+output=$(run_wallbash oddname.sh.sh)
+case $output in
+*'odd script ran'*) ;;
+*)
+    fail "wallbash oddname.sh.sh (its exact real filename) did not run: got '$output' (stderr: $(cat "$work_dir/stderr"))"
+    ;;
+esac
+
+finish


### PR DESCRIPTION
call_wallbashScript()'s usage fallback lists available scripts by their real filename (e.g. "spotify.sh"), inviting a user to pass that exact name back in -- but the `-name` match always appends its own ".sh", so `hyde-shell wallbash spotify.sh` looked for a nonexistent "spotify.sh.sh" and silently fell through to the same usage text instead of running the script.

## Fix

Strip at most one trailing ".sh" from the given name before appending it back, so both `spotify` and `spotify.sh` resolve to the same script.

## Test plan

- [x] `tests/test_hyde_shell_wallbash.sh` (new): the reported shape (name with `.sh`), the regression case (name without it), a script literally named `x.sh.sh` (single-strip boundary), and missing/empty/path-traversal-shaped names (verified these were already safe before the fix and are now pinned down by a test)
- [x] Revert-and-confirm: reverting the fix reproduces the exact reported symptom for both the `.sh`-suffix and `x.sh.sh` cases
- [x] Full suite (`sh tests/run.sh`): 48/48 passing

Fixes the wallbash half of #1801 -- the reported `eval $(hyde-shell init)` / `export: invalid option(s)` error doesn't reproduce on `dev` and looks specific to the reporter's own (self-described as previously edited) shell config, not a code bug here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `wallbash` script execution when script names include the `.sh` extension shown in usage information.
  * Preserved support for script names without the extension and names containing repeated extensions.
  * Improved handling of invalid, empty, and unsafe script names by consistently displaying usage information instead of attempting unintended lookups.

* **Tests**
  * Added coverage for valid script execution, invalid inputs, edge cases, empty arguments, and path-traversal-shaped names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->