### PR TITLE
fix(theme): accept compatible optional archives

### DIFF
--- a/Configs/.local/lib/hyde/theme.patch.sh
+++ b/Configs/.local/lib/hyde/theme.patch.sh
@@ -176,11 +176,34 @@ check_tars() {
         if [[ $gsVal =~ ^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$ ]]; then
             print_log -warn "Variable $gsVal detected! " "be sure $gsVal is set as a different name or on a different file, skipping check"
         else
+            # Theme authors commonly put a font style/size in the archive
+            # directory name while hypr.theme contains only the family (for
+            # example `SF Pro Rounded` vs `SF Pro Rounded Regular 10.5`).
+            # Compare trimmed names and accept an archive whose top-level
+            # directory starts with the configured value.
+            gsVal="${gsVal##+([[:space:]])}"
+            gsVal="${gsVal%%+([[:space:]])}"
             print_log -g "[pass]  " "hypr.theme :: [$gsLow]" -b " $gsVal"
             trArc="$(echo "$all_tar_files" | grep "/${inVal}_")"
-            [ -f "$trArc" ] && [ "$(echo "$trArc" | wc -l)" -eq 1 ] && trVal="$(basename "$(tar -tf "$trArc" | cut -d '/' -f1 | sort -u)")" && trVal="$(echo "$trVal" | grep -w "$gsVal")"
+            trVal=""
+            if [ -f "$trArc" ] && [ "$(echo "$trArc" | wc -l)" -eq 1 ]; then
+                while IFS= read -r candidate; do
+                    candidate="${candidate%/}"
+                    if [[ "$candidate" == "$gsVal" || "$candidate" == "$gsVal "* || "$candidate" == "$gsVal-"* ]]; then
+                        trVal="$candidate"
+                        break
+                    fi
+                done < <(tar -tf "$trArc" | cut -d '/' -f1 | sort -u)
+            fi
             print_log -g "[pass]  " "../*.tar.* :: [$gsLow]" -b " $trVal"
-            [ "$trVal" != "$gsVal" ] && print_log -r "[ERROR] " "$gsLow set in hypr.theme does not exist in ${inVal}_*.tar.*" && exit_flag=true
+            if [ -z "$trVal" ]; then
+                if [ "$2" == "--mandatory" ]; then
+                    print_log -r "[ERROR] " "$gsLow set in hypr.theme does not exist in ${inVal}_*.tar.*"
+                    exit_flag=true
+                else
+                    print_log -y "[note] " "$gsLow package for '$gsVal' is missing, continuing..."
+                fi
+            fi
         fi
     else
         [ "$2" == "--mandatory" ] && print_log -r "[ERROR] " "hypr.theme :: [$gsLow]" -r " Not Found" && exit_flag=true && return 0

--- a/Configs/.local/lib/hyde/theme.patch.sh
+++ b/Configs/.local/lib/hyde/theme.patch.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+shopt -s extglob
 script_dir=$(dirname "$(realpath "$0")")
 if ! source "$script_dir/globalcontrol.sh"; then
     echo "Error: unable to source globalcontrol.sh..."


### PR DESCRIPTION
## Summary

- accept compatible archive directory names such as `SF Pro Rounded` and `SF Pro Rounded Regular 10.5`
- treat missing non-GTK font, cursor, icon, and other optional packages as warnings so the theme can still be imported
- keep the GTK archive requirement mandatory

## Root cause

The theme patcher required an exact match between the value in `hypr.theme` and the top-level directory inside an archive. It also marked every declared but missing non-GTK package as fatal. Several valid community themes use a family name in `hypr.theme`, a family-plus-style archive directory, or omit optional packages entirely.

## Validation

- `bash -n Configs/.local/lib/hyde/theme.patch.sh`: passed
- isolated Monterey Frost import: archive validation passed; missing optional font variants reported as warnings
- isolated Electra import: missing optional Noto Sans package reported as a warning; import continued
- `git diff --check`: passed

## Risk

Low. GTK remains mandatory. Optional resources are still extracted when present; only validation of absent optional resources changes from an error to a warning.

Closes #2077


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package archive validation by correctly handling package directory names containing spaces or dashes.
  - Prevented false validation failures caused by surrounding whitespace in package values.
  - Optional package mismatches now generate a note and allow processing to continue, while mandatory mismatches continue to stop processing as required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->