### PR TITLE
fix(hyprland): pass opacity as a string

### DIFF
--- a/Configs/.local/share/hypr/lua/window_rules.lua
+++ b/Configs/.local/share/hypr/lua/window_rules.lua
@@ -126,7 +126,7 @@ hl.window_rule(
     move = "(monitor_w*0.73) (monitor_h*0.72)",
     size = "(monitor_w*0.25) (monitor_h*0.25)",
     pin = true,
-	opacity = true
+	opacity = "1.0"
   }
 )
 


### PR DESCRIPTION
## Problem
The pinned window rule sets `opacity = true`, but the Lua window-rule API requires `opacity` to be a string. Hyprland reports a type error while loading `window_rules.lua`.

## Fix
Use the valid string value `opacity = "1.0"` for the PIP rule.

## Validation
- `lua -e 'assert(loadfile("Configs/.local/share/hypr/lua/window_rules.lua"))'`
- `hyprctl reload`
- `git diff --check`

This keeps the existing fully opaque PIP behavior while satisfying the API type requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pinned picture-in-picture windows now remain fully opaque with an explicit opacity setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->