### PR TITLE
fix(waybar): resolve module includes on stable Waybar

### DIFF
--- a/Configs/.config/waybar/config.jsonc
+++ b/Configs/.config/waybar/config.jsonc
@@ -7,9 +7,9 @@
   "passthrough": false,
   "reload_style_on_change": true,
   "include": [
-    "$XDG_CONFIG_HOME/waybar/modules/*json*", // This can be used on waybar-git
-    "$XDG_DATA_HOME/waybar/modules/*json*" // This can be used on waybar-git
-    // "$XDG_CONFIG_HOME/waybar/includes/includes.json" // This will be deprecated if waybar 0.12.0 is released on debian
+    "modules/*json*", // Resolve relative to this config for stable Waybar releases.
+    "$XDG_DATA_HOME/waybar/modules/*json*" // Also support waybar-git's data modules.
+    // "$XDG_CONFIG_HOME/waybar/includes/includes.json" // Deprecated on newer Waybar releases.
   ],
   // ? Groups per side
   "modules-left": ["group/leaf-inverse"],

--- a/Scripts/dots/waybar.toml
+++ b/Scripts/dots/waybar.toml
@@ -4,10 +4,11 @@ pre_command = "echo 'Pre commands '"
 post_command = "echo 'HyDE backed up!'"
 
 [[waybar.dependency]]
-pacman = ["waybar"]
-yay = ["waybar"]
-paru = ["waybar"]
-dnf = ["waybar"]
+# Config-relative glob includes require Waybar 0.15.0 or newer.
+pacman = ["waybar>=0.15.0"]
+yay = ["waybar>=0.15.0"]
+paru = ["waybar>=0.15.0"]
+dnf = ["waybar>=0.15.0"]
 
 [[waybar.files]]
 action = "preserve"

--- a/Scripts/dots/waybar.toml
+++ b/Scripts/dots/waybar.toml
@@ -4,11 +4,12 @@ pre_command = "echo 'Pre commands '"
 post_command = "echo 'HyDE backed up!'"
 
 [[waybar.dependency]]
-# Config-relative glob includes require Waybar 0.15.0 or newer.
-pacman = ["waybar>=0.15.0"]
-yay = ["waybar>=0.15.0"]
-paru = ["waybar>=0.15.0"]
-dnf = ["waybar>=0.15.0"]
+# Escape the comparison operator because deez-dots executes package commands
+# through a shell; the package manager receives `waybar>=0.15.0`.
+pacman = ["waybar\\>=0.15.0"]
+yay = ["waybar\\>=0.15.0"]
+paru = ["waybar\\>=0.15.0"]
+dnf = ["waybar\\>=0.15.0"]
 
 [[waybar.files]]
 action = "preserve"


### PR DESCRIPTION
## Problem
The Waybar configuration uses `$XDG_CONFIG_HOME/waybar/modules/*json*` in the `include` list. Stable Waybar releases do not expand this environment variable there, so the module files are not loaded and the bar can appear blank after installation or an update.

## Fix
Use the config-relative `modules/*json*` glob for the modules shipped beside `config.jsonc`. Keep the data-directory include for waybar-git installations.

## Validation
- `git diff --check`
- Reviewed the deployed Waybar module layout and current include generation path

Closes #1600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Waybar module discovery using relative paths and modules stored in the user data directory.
  * Corrected Waybar version constraints for supported package managers by escaping comparison operators.
* **Compatibility**
  * Retained the deprecated configuration path as a commented reference for existing setups.
  * Updated package manager dependency declarations to correctly recognize Waybar 0.15.0 and later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->