### PR TITLE
fix(notifications): install only Dunst by default

### DIFF
--- a/Scripts/dots-groups/extra.toml
+++ b/Scripts/dots-groups/extra.toml
@@ -21,6 +21,7 @@
         "../dots/hypridle.toml",
         "../dots/hyprsunset.toml",
         "../dots/fastfetch.toml",
+        "../dots/swaync-config.toml",
     ]
 
 # Loads an array of package manager commands

--- a/Scripts/dots-groups/extra.toml
+++ b/Scripts/dots-groups/extra.toml
@@ -21,7 +21,6 @@
         "../dots/hypridle.toml",
         "../dots/hyprsunset.toml",
         "../dots/fastfetch.toml",
-        "../dots/swaync.toml",
     ]
 
 # Loads an array of package manager commands

--- a/Scripts/dots-groups/notification-daemon.toml
+++ b/Scripts/dots-groups/notification-daemon.toml
@@ -1,5 +1,7 @@
 [global]
-    description = "Choose a notification daemon. Only choose 1"
-    include     = [ "../dots/dunst.toml", "../dots/swaync.toml" ]
+    description = "Default notification daemon (Dunst)"
+    # Dunst is HyDE's supported default. SwayNC is an optional alternative;
+    # never deploy both daemons because they claim the same D-Bus service.
+    include     = [ "../dots/dunst.toml" ]
     owner       = "The HyDE Project"
     version     = "latest"

--- a/Scripts/dots/swaync-config.toml
+++ b/Scripts/dots/swaync-config.toml
@@ -5,7 +5,10 @@
     action      = "sync"
     source_root = "Configs/.config"
     target_root = "${XDG_CONFIG_HOME}"
-    paths       = [
-        "swaync",
-        "waybar/menus/swaync.xml",
-    ]
+    paths       = ["swaync"]
+
+[[swaync_config.files]]
+    action      = "sync"
+    source_root = "Configs/.local/share/waybar"
+    target_root = "${XDG_DATA_HOME}/waybar"
+    paths       = ["menus/swaync.xml"]

--- a/Scripts/dots/swaync-config.toml
+++ b/Scripts/dots/swaync-config.toml
@@ -1,0 +1,11 @@
+[swaync_config]
+    description = "SwayNC configuration (daemon installation is opt-in)"
+
+[[swaync_config.files]]
+    action      = "sync"
+    source_root = "Configs/.config"
+    target_root = "${XDG_CONFIG_HOME}"
+    paths       = [
+        "swaync",
+        "waybar/menus/swaync.xml",
+    ]

--- a/Scripts/dots/swaync.toml
+++ b/Scripts/dots/swaync.toml
@@ -1,6 +1,6 @@
 
 [swaync]
-    description = " A simple notification daemon with a GTK panel for checking previous notifications like other DEs"
+    description = "Optional SwayNC notification daemon (alternative to Dunst)"
 [[swaync.dependency]]
     pacman = [ "swaync" ]
 


### PR DESCRIPTION
## Description

A clean HyDE installation currently installs both Dunst and SwayNC. Both daemons claim `org.freedesktop.Notifications`, so whichever process acquires the D-Bus name receives all notifications. This can make SwayNC take over after Dunst fails and leaves the notification behavior inconsistent.

This change keeps Dunst as HyDE's single default notification daemon:

- the standard extra group deploys SwayNC's configuration files without installing or starting the SwayNC daemon;
- the explicit notification-daemon group selects Dunst only;
- the full SwayNC dot remains available as an opt-in alternative for users who deliberately choose it.

Dunst is the correct default because HyDE's startup configuration launches it, the notification helper targets it, and the Waybar integration uses `dunstctl` for pause, history, and clearing notifications. SwayNC provides a richer notification center, but it does not provide a missing function that requires both daemons to run; it can remain an explicitly selected alternative.

Closes #2030.

## Validation

- Parsed all `Scripts/dots/*.toml` files with Python `tomllib`.
- Ran `sh tests/test_wallbash_targets.sh` successfully.
- Ran `git diff --check`.
- The full test suite still reports unrelated environment-dependent failures in GPUInfo fixtures and the Pyprland socket permission check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * The default notification daemon configuration now deploys Dunst only.
  * SwayNC is available as an optional alternative through a separate configuration bundle.
  * The optional SwayNC setup synchronizes its configuration and Waybar integration files.
  * Documentation clarifies that Dunst and SwayNC should not be deployed together because they provide the same notification service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->