### PR TITLE
fix(waybar): repair macOS preset and restore theme layout selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Waybar: add VSCodium and Chromium icon rules to window module
 
 ### Fixed
+- Waybar: honor an optional `$WAYBAR_LAYOUT` in `hypr.theme` during color/theme updates, selecting the layout and matching stylesheet temporarily. Restore the previous layout and independently selected CSS when leaving themes with a preset, preserving them across repeated updates and preset-to-preset switches. Fix theme setting lookup for names containing spaces such as `Mac OS`.
 - Waybar: repair the macOS preset, remove its blocking wallpaper decoder, use an accessible semantic palette, and restore spacing between HyDE menu icons and labels
 - Hyprland: prevent window borders from being clipped when snapping to monitor edges in 0-gap workflows 
 - Hyprland: windows that cannot join a group, such as pyprland's dropdown terminal, get the same border colors as every other window; `general.col.nogroup_border` and `nogroup_border_active` were never set, so those windows kept Hyprland's magenta and yellow defaults whatever the theme or wallbash mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Waybar: add VSCodium and Chromium icon rules to window module
 
 ### Fixed
+- Waybar: repair the macOS preset, remove its blocking wallpaper decoder, and restore spacing between HyDE menu icons and labels
 - Hyprland: prevent window borders from being clipped when snapping to monitor edges in 0-gap workflows 
 - Hyprland: windows that cannot join a group, such as pyprland's dropdown terminal, get the same border colors as every other window; `general.col.nogroup_border` and `nogroup_border_active` were never set, so those windows kept Hyprland's magenta and yellow defaults whatever the theme or wallbash mode
 - Hyprland: the dropdown terminal (`SUPER + ALT + T`) no longer reappears and fades out after sliding off-screen when an animation preset is active; pyprland's `no_anim` rule for the `pypr_noanim` tag is registered at runtime and was lost on every config reload, so it is now declared in `window_rules.lua`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Waybar: add VSCodium and Chromium icon rules to window module
 
 ### Fixed
-- Waybar: repair the macOS preset, remove its blocking wallpaper decoder, and restore spacing between HyDE menu icons and labels
+- Waybar: repair the macOS preset, remove its blocking wallpaper decoder, use an accessible semantic palette, and restore spacing between HyDE menu icons and labels
 - Hyprland: prevent window borders from being clipped when snapping to monitor edges in 0-gap workflows 
 - Hyprland: windows that cannot join a group, such as pyprland's dropdown terminal, get the same border colors as every other window; `general.col.nogroup_border` and `nogroup_border_active` were never set, so those windows kept Hyprland's magenta and yellow defaults whatever the theme or wallbash mode
 - Hyprland: the dropdown terminal (`SUPER + ALT + T`) no longer reappears and fades out after sliding off-screen when an animation preset is active; pyprland's `no_anim` rule for the `pypr_noanim` tag is registered at runtime and was lost on every config reload, so it is now declared in `window_rules.lua`

--- a/Configs/.local/lib/hyde/waybar.py
+++ b/Configs/.local/lib/hyde/waybar.py
@@ -11,7 +11,6 @@ import time
 import sys
 import hashlib
 import signal
-import shlex
 
 from pathlib import Path
 
@@ -344,6 +343,36 @@ def set_layout(layout):
 
     logger.error(f"Layout {layout} not found")
     sys.exit(1)
+
+
+def apply_theme_layout():
+    """Temporarily apply a theme preset, preserving the user's layout/CSS pair."""
+    theme_layout = get_value_from_hypr_theme("$WAYBAR_LAYOUT")
+    saved_layout = get_state_value("WAYBAR_PRE_THEME_LAYOUT")
+    if theme_layout:
+        # Validate before saving anything; a missing preset must not claim the bar.
+        pair = next((p for p in list_layouts()["layouts"]
+                     if theme_layout in (p["name"], p["layout"]) and p["style"]), None)
+        if not pair:
+            logger.warning(f"Theme Waybar layout not found: {theme_layout}")
+            return
+        if not saved_layout:
+            # Save only on entry, not on wallpaper reloads or preset-to-preset switches.
+            set_state_value("WAYBAR_PRE_THEME_LAYOUT", get_current_layout_from_config())
+            set_state_value("WAYBAR_PRE_THEME_STYLE", get_state_value("WAYBAR_STYLE_PATH") or
+                            resolve_style_path(get_current_layout_from_config()))
+        _apply_layout(pair["layout"], pair["style"], theme_layout)
+    elif saved_layout:
+        if not os.path.isfile(saved_layout):
+            logger.warning(f"Cannot restore missing Waybar layout: {saved_layout}")
+            return
+        saved_style = get_state_value("WAYBAR_PRE_THEME_STYLE")
+        if not saved_style or not os.path.isfile(saved_style):
+            saved_style = resolve_style_path(saved_layout)
+        _apply_layout(saved_layout, saved_style, os.path.basename(saved_layout))
+        # Clear only after restoration succeeds; the next entry saves a fresh pair.
+        set_state_value("WAYBAR_PRE_THEME_LAYOUT", "")
+        set_state_value("WAYBAR_PRE_THEME_STYLE", "")
 
 
 def handle_layout_navigation(option):
@@ -953,7 +982,8 @@ def get_value_from_hypr_theme(variable_name):
     logger.debug(f"Found hypr.theme at {hypr_theme_path}")
 
     try:
-        cmd = ["hyq", shlex.quote(hypr_theme_path), "--query", variable_name]
+        # argv already preserves spaces in theme names such as "Mac OS".
+        cmd = ["hyq", hypr_theme_path, "--query", variable_name]
         logger.debug(f"Running command: {' '.join(cmd)}")
 
         result = subprocess.run(cmd, capture_output=True, text=True)
@@ -1099,6 +1129,11 @@ def update_style(style_path):
         )
 
     if not style_path:
+        # Keep explicitly selected/restored CSS instead of deriving it from the layout.
+        style_path = get_state_value("WAYBAR_STYLE_PATH")
+        if style_path and not os.path.isfile(style_path):
+            style_path = None
+    if not style_path:
         current_layout = get_current_layout_from_config()
         logger.debug(f"Detected current layout: '{current_layout}'")
         if not current_layout:
@@ -1109,6 +1144,8 @@ def update_style(style_path):
         logger.error(f"Cannot reconcile style path: {style_path}")
         sys.exit(1)
     write_style_file(style_filepath, style_path)
+
+    set_state_value("WAYBAR_STYLE_PATH", style_path)
 
 
 def watch_waybar():
@@ -1283,6 +1320,9 @@ def main():
         sys.exit(0)
 
     if args.update:
+        # The color/theme hook uses --update; a theme may opt into a paired
+        # layout and stylesheet (Mac OS: HyDE #2089 / hyde-gallery #127).
+        apply_theme_layout()
         update_icon_size()
         update_border_radius()
         generate_includes()

--- a/Configs/.local/share/waybar/layouts/macos.jsonc
+++ b/Configs/.local/share/waybar/layouts/macos.jsonc
@@ -1,90 +1,70 @@
 {
-  // General Waybar configuration
   "layer": "top",
-  "margin": 0,
+  "output": ["*"],
   "position": "top",
-  "spacing": 10,
-  "border-size": 1,
-  "padding": 1,
-  "include": ["$XDG_CONFIG_HOME/waybar/includes/includes.json"],
-  // Modules configuration
+  "height": 32,
+  "margin": 0,
+  "spacing": 0,
+  "mode": "dock",
+  "exclusive": true,
+  "passthrough": false,
+  "reload_style_on_change": true,
+  "include": [
+    "modules/*json*", // Resolve relative to this config for stable Waybar releases.
+    "$XDG_DATA_HOME/waybar/modules/*json*" // Also support waybar-git's data modules.
+  ],
+
+  // Mirror the macOS menu bar: application menus left, system status and time right.
   "modules-left": [
     "custom/launcher",
     "hyprland/window",
-    "custom/text#two",
-    "custom/text#three",
-    "custom/text#four",
+    "custom/text#file",
+    "custom/text#edit",
+    "custom/text#view",
     "custom/help#macos"
   ],
-  "modules-right": ["image#wallpaper", "clock#date", "clock"],
-  // Module-specific configurations
-  "clock#12": {
-    "format": "{:%H:%M %p}",
-    "tooltip-format": "{:%A, %B %d, %Y}"
-  },
+  // Do not add image#wallpaper: decoding it can block Waybar during a layout reload.
+  "modules-right": [
+    "privacy",
+    "tray",
+    "bluetooth",
+    "network",
+    "pulseaudio",
+    "battery",
+    "clock"
+  ],
+
   "clock": {
-    "format": "{:%H:%M}",
+    "format": "{:%a %b %d  %H:%M}",
     "tooltip-format": "{:%A, %B %d, %Y}"
-  },
-  "clock#date": {
-    "format": "{:%a %b %d}",
-    "rotate": 0,
-    // "format-alt": "{:%R \udb80\udced %d\u00b7%m\u00b7%y}",
-    "tooltip-format": "<span>{calendar}</span>",
-    "calendar": {
-      "mode": "month",
-      "mode-mon-col": 3,
-      "on-scroll": 1,
-      "on-click-right": "mode",
-      "format": {
-        "months": "<span color='#ffead3'><b>{}</b></span>",
-        "weekdays": "<span color='#ffcc66'><b>{}</b></span>",
-        "today": "<span color='#ff6699'><b>{}</b></span>"
-      }
-    },
-    "actions": {
-      "on-click-right": "mode",
-      "on-click-forward": "tz_up",
-      "on-click-backward": "tz_down",
-      "on-scroll-up": "shift_up",
-      "on-scroll-down": "shift_down"
-    }
   },
   "hyprland/window": {
     "format": "{class}",
-    "max-length": 20,
+    "max-length": 24,
     "rewrite": {
-      // if any window is focused display Finder
-      "^(?!.*\\S).*": "Finder"
+      "^(?!.*\\S).*$": "Finder"
     }
   },
   "custom/launcher": {
-    "format": "",
+    "format": "",
+    "tooltip": false,
     "on-click": "hyde-shell rofilaunch"
   },
-  "custom/text#two": {
+  "custom/text#file": {
     "format": "File",
-    "interval": 60,
-    "return-type": "plain",
-    "on-click": "hyde-shell open --fall dolphin file-manager" //or you favorite Filer Explorer
+    "on-click": "hyde-shell open --fall dolphin file-manager"
   },
-  "custom/text#three": {
+  "custom/text#edit": {
     "format": "Edit",
-    "interval": 60,
-    "return-type": "plain",
-    "on-click": "krita" // or you favorite Image editor
+    "on-click": "krita"
   },
-  "custom/text#four": {
-    "format": "View",
-    "interval": 60,
-    "return-type": "plain"
+  "custom/text#view": {
+    "format": "View"
   },
   "custom/help#macos": {
     "format": "Help",
-    "interval": 60,
     "tooltip": true,
-    "tooltip-format": "Right-click for more HyDE options",
-    "return-type": "plain",
+    "tooltip-format": "Left-click for keybinds; right-click for HyDE options",
     "on-click": "hyde-shell keybinds_hint",
     "menu": "on-click-right",
     "menu-file": "${HYDE_WAYBAR_MENU_DIR:-$XDG_DATA_HOME/waybar/menus}/hyde-menu.xml",
@@ -99,8 +79,9 @@
       "theme-select": "hyde-shell app -t scope -- theme.select.sh",
       "theme-import": "hyde-shell app -T -- hydectl theme import",
       "waybar-restart": "hyde-shell waybar -ubg",
-      "waybar-reload-css": "sed -i '${/^$/d;}'  $XDG_CONFIG_HOME/waybar/style.css",
-      "waybar-layout-select": "hyde-shell waybar --select",
+      "waybar-reload-css": "sed -i '${/^$/d;}' $XDG_CONFIG_HOME/waybar/style.css",
+      "waybar-layout-select": "hyde-shell waybar --select-layout",
+      "waybar-style-select": "hyde-shell waybar --select-style",
       "waybar-layout-next": "hyde-shell waybar --update --next",
       "waybar-layout-previous": "hyde-shell waybar --update --prev",
       "workflows-select": "hyde-shell workflows --select;pkill -RTMIN+19 waybar",

--- a/Configs/.local/share/waybar/menus/hyde-menu.xml
+++ b/Configs/.local/share/waybar/menus/hyde-menu.xml
@@ -5,13 +5,13 @@
 
         <child>
             <object class="GtkMenuItem" id="animation_menu">
-                <property name="label">󰗘 Animations</property>
+                <property name="label">󰗘&#x2002;Animations</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="animations-select">
-                                <property name="label"> Select Animation</property>
+                                <property name="label">&#x2002;Select Animation</property>
                             </object>
                         </child>
 
@@ -24,28 +24,28 @@
 
         <child>
             <object class="GtkMenuItem" id="wallpaper_menu">
-                <property name="label">󰸉 Wallpaper</property>
+                <property name="label">󰸉&#x2002;Wallpaper</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-select">
-                                <property name="label"> Select Wallpaper</property>
+                                <property name="label">&#x2002;Select Wallpaper</property>
                             </object>
                         </child>
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-next">
-                                <property name="label"> Next Wallpaper</property>
+                                <property name="label">&#x2002;Next Wallpaper</property>
                             </object>
                         </child>
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-previous">
-                                <property name="label"> Previous Wallpaper</property>
+                                <property name="label">&#x2002;Previous Wallpaper</property>
                             </object>
                         </child>
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-random">
-                                <property name="label"> Random Wallpaper</property>
+                                <property name="label">&#x2002;Random Wallpaper</property>
                             </object>
                         </child>
 
@@ -58,32 +58,32 @@
 
         <child>
             <object class="GtkMenuItem" id="theme_menu">
-                <property name="label"> Theme</property>
+                <property name="label">&#x2002;Theme</property>
                 <child
                     type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="theme-select">
-                                <property name="label"> Select Theme</property>
+                                <property name="label">&#x2002;Select Theme</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="theme-next">
-                                <property name="label"> Next Theme</property>
+                                <property name="label">&#x2002;Next Theme</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="theme-previous">
-                                <property name="label"> Previous Theme</property>
+                                <property name="label">&#x2002;Previous Theme</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="theme-import">
-                                <property name="label"> More Themes</property>
+                                <property name="label">&#x2002;More Themes</property>
                             </object>
                         </child>
 
@@ -96,13 +96,13 @@
 
         <child>
             <object class="GtkMenuItem" id="layouts_menu">
-                <property name="label"> Layouts</property>
+                <property name="label">&#x2002;Layouts</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="layouts-select">
-                                <property name="label"> Select Layout</property>
+                                <property name="label">&#x2002;Select Layout</property>
                             </object>
                         </child>
 
@@ -114,41 +114,41 @@
 
         <child>
             <object class="GtkMenuItem" id="waybar-menu">
-                <property name="label"> Waybar</property>
+                <property name="label">&#x2002;Waybar</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-layout-select">
-                                <property name="label"> Select Layout</property>
+                                <property name="label">&#x2002;Select Layout</property>
                             </object>
                         </child>
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-style-select">
-                                <property name="label"> Select Style</property>
+                                <property name="label">&#x2002;Select Style</property>
                             </object>
                         </child>
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-layout-next">
-                                <property name="label"> Next Layout</property>
+                                <property name="label">&#x2002;Next Layout</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-layout-prev">
-                                <property name="label"> Previous Layout</property>
+                                <property name="label">&#x2002;Previous Layout</property>
                             </object>
                         </child>
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-reload-css">
-                                <property name="label">󰑓 Reload CSS</property>
+                                <property name="label">󰑓&#x2002;Reload CSS</property>
                             </object>
                         </child>
 
@@ -160,7 +160,7 @@
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-restart">
-                                <property name="label">󰜉 Restart</property>
+                                <property name="label">󰜉&#x2002;Restart</property>
                             </object>
                         </child>
 
@@ -173,13 +173,13 @@
 
         <child>
             <object class="GtkMenuItem" id="workflows_menu">
-                <property name="label"> Workflows</property>
+                <property name="label">&#x2002;Workflows</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="workflows-select">
-                                <property name="label"> Select Workflow</property>
+                                <property name="label">&#x2002;Select Workflow</property>
                             </object>
                         </child>
 
@@ -192,13 +192,13 @@
 
         <child>
             <object class="GtkMenuItem" id="lockscreen_menu">
-                <property name="label"> Lockscreen</property>
+                <property name="label">&#x2002;Lockscreen</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="lockscreen-select">
-                                <property name="label"> Select Lockscreen</property>
+                                <property name="label">&#x2002;Select Lockscreen</property>
                             </object>
                         </child>
 
@@ -211,14 +211,14 @@
 
         <child>
             <object class="GtkMenuItem" id="eyecare_menu">
-                <property name="label">󰛨 Eye Care</property>
+                <property name="label">󰛨&#x2002;Eye Care</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <!-- Hyprsunset submenu -->
                         <child>
                             <object class="GtkMenuItem" id="hyprsunset_menu">
-                                <property name="label"> Hyprsunset</property>
+                                <property name="label">&#x2002;Hyprsunset</property>
                                 <child type="submenu">
                                     <object class="GtkMenu">
 
@@ -236,14 +236,14 @@
                                         <!-- Temperature submenu -->
                                         <child>
                                             <object class="GtkMenuItem" id="temperature_menu">
-                                                <property name="label"> Temperature</property>
+                                                <property name="label">&#x2002;Temperature</property>
                                                 <child type="submenu">
                                                     <object class="GtkMenu">
 
                                                         <child>
                                                             <object class="GtkMenuItem"
                                                                 id="temp-off">
-                                                                <property name="label">󰨙 Default</property>
+                                                                <property name="label">󰨙&#x2002;Default</property>
                                                             </object>
                                                         </child>
 
@@ -310,7 +310,7 @@
                                         <!-- Gamma submenu -->
                                         <child>
                                             <object class="GtkMenuItem" id="gamma_menu">
-                                                <property name="label">󰃝 Gamma</property>
+                                                <property name="label">󰃝&#x2002;Gamma</property>
                                                 <child type="submenu">
                                                     <object class="GtkMenu">
 
@@ -391,7 +391,7 @@
                         <!-- Shaders direct item -->
                         <child>
                             <object class="GtkMenuItem" id="shaders-select">
-                                <property name="label"> Shaders</property>
+                                <property name="label">&#x2002;Shaders</property>
                             </object>
                         </child>
 
@@ -408,13 +408,13 @@
 
         <child>
             <object class="GtkMenuItem" id="keybinds-hint">
-                <property name="label"> Keybinds</property>
+                <property name="label">&#x2002;Keybinds</property>
             </object>
         </child>
 
         <child>
             <object class="GtkMenuItem" id="about-hyde">
-                <property name="label"> About</property>
+                <property name="label">&#x2002;About</property>
             </object>
         </child>
 

--- a/Configs/.local/share/waybar/menus/hyde-menu.xml
+++ b/Configs/.local/share/waybar/menus/hyde-menu.xml
@@ -5,13 +5,13 @@
 
         <child>
             <object class="GtkMenuItem" id="animation_menu">
-                <property name="label">󰗘&#x2002;Animations</property>
+                <property name="label">󰗘&#x2003;Animations</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="animations-select">
-                                <property name="label">&#x2002;Select Animation</property>
+                                <property name="label">&#x2003;Select Animation</property>
                             </object>
                         </child>
 
@@ -24,28 +24,28 @@
 
         <child>
             <object class="GtkMenuItem" id="wallpaper_menu">
-                <property name="label">󰸉&#x2002;Wallpaper</property>
+                <property name="label">󰸉&#x2003;Wallpaper</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-select">
-                                <property name="label">&#x2002;Select Wallpaper</property>
+                                <property name="label">&#x2003;Select Wallpaper</property>
                             </object>
                         </child>
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-next">
-                                <property name="label">&#x2002;Next Wallpaper</property>
+                                <property name="label">&#x2003;Next Wallpaper</property>
                             </object>
                         </child>
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-previous">
-                                <property name="label">&#x2002;Previous Wallpaper</property>
+                                <property name="label">&#x2003;Previous Wallpaper</property>
                             </object>
                         </child>
                         <child>
                             <object class="GtkMenuItem" id="wallpaper-random">
-                                <property name="label">&#x2002;Random Wallpaper</property>
+                                <property name="label">&#x2003;Random Wallpaper</property>
                             </object>
                         </child>
 
@@ -58,32 +58,32 @@
 
         <child>
             <object class="GtkMenuItem" id="theme_menu">
-                <property name="label">&#x2002;Theme</property>
+                <property name="label">&#x2003;Theme</property>
                 <child
                     type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="theme-select">
-                                <property name="label">&#x2002;Select Theme</property>
+                                <property name="label">&#x2003;Select Theme</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="theme-next">
-                                <property name="label">&#x2002;Next Theme</property>
+                                <property name="label">&#x2003;Next Theme</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="theme-previous">
-                                <property name="label">&#x2002;Previous Theme</property>
+                                <property name="label">&#x2003;Previous Theme</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="theme-import">
-                                <property name="label">&#x2002;More Themes</property>
+                                <property name="label">&#x2003;More Themes</property>
                             </object>
                         </child>
 
@@ -96,13 +96,13 @@
 
         <child>
             <object class="GtkMenuItem" id="layouts_menu">
-                <property name="label">&#x2002;Layouts</property>
+                <property name="label">&#x2003;Layouts</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="layouts-select">
-                                <property name="label">&#x2002;Select Layout</property>
+                                <property name="label">&#x2003;Select Layout</property>
                             </object>
                         </child>
 
@@ -114,41 +114,41 @@
 
         <child>
             <object class="GtkMenuItem" id="waybar-menu">
-                <property name="label">&#x2002;Waybar</property>
+                <property name="label">&#x2003;Waybar</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-layout-select">
-                                <property name="label">&#x2002;Select Layout</property>
+                                <property name="label">&#x2003;Select Layout</property>
                             </object>
                         </child>
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-style-select">
-                                <property name="label">&#x2002;Select Style</property>
+                                <property name="label">&#x2003;Select Style</property>
                             </object>
                         </child>
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-layout-next">
-                                <property name="label">&#x2002;Next Layout</property>
+                                <property name="label">&#x2003;Next Layout</property>
                             </object>
                         </child>
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-layout-prev">
-                                <property name="label">&#x2002;Previous Layout</property>
+                                <property name="label">&#x2003;Previous Layout</property>
                             </object>
                         </child>
 
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-reload-css">
-                                <property name="label">󰑓&#x2002;Reload CSS</property>
+                                <property name="label">󰑓&#x2003;Reload CSS</property>
                             </object>
                         </child>
 
@@ -160,7 +160,7 @@
 
                         <child>
                             <object class="GtkMenuItem" id="waybar-restart">
-                                <property name="label">󰜉&#x2002;Restart</property>
+                                <property name="label">󰜉&#x2003;Restart</property>
                             </object>
                         </child>
 
@@ -173,13 +173,13 @@
 
         <child>
             <object class="GtkMenuItem" id="workflows_menu">
-                <property name="label">&#x2002;Workflows</property>
+                <property name="label">&#x2003;Workflows</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="workflows-select">
-                                <property name="label">&#x2002;Select Workflow</property>
+                                <property name="label">&#x2003;Select Workflow</property>
                             </object>
                         </child>
 
@@ -192,13 +192,13 @@
 
         <child>
             <object class="GtkMenuItem" id="lockscreen_menu">
-                <property name="label">&#x2002;Lockscreen</property>
+                <property name="label">&#x2003;Lockscreen</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <child>
                             <object class="GtkMenuItem" id="lockscreen-select">
-                                <property name="label">&#x2002;Select Lockscreen</property>
+                                <property name="label">&#x2003;Select Lockscreen</property>
                             </object>
                         </child>
 
@@ -211,14 +211,14 @@
 
         <child>
             <object class="GtkMenuItem" id="eyecare_menu">
-                <property name="label">󰛨&#x2002;Eye Care</property>
+                <property name="label">󰛨&#x2003;Eye Care</property>
                 <child type="submenu">
                     <object class="GtkMenu">
 
                         <!-- Hyprsunset submenu -->
                         <child>
                             <object class="GtkMenuItem" id="hyprsunset_menu">
-                                <property name="label">&#x2002;Hyprsunset</property>
+                                <property name="label">&#x2003;Hyprsunset</property>
                                 <child type="submenu">
                                     <object class="GtkMenu">
 
@@ -236,14 +236,14 @@
                                         <!-- Temperature submenu -->
                                         <child>
                                             <object class="GtkMenuItem" id="temperature_menu">
-                                                <property name="label">&#x2002;Temperature</property>
+                                                <property name="label">&#x2003;Temperature</property>
                                                 <child type="submenu">
                                                     <object class="GtkMenu">
 
                                                         <child>
                                                             <object class="GtkMenuItem"
                                                                 id="temp-off">
-                                                                <property name="label">󰨙&#x2002;Default</property>
+                                                                <property name="label">󰨙&#x2003;Default</property>
                                                             </object>
                                                         </child>
 
@@ -310,7 +310,7 @@
                                         <!-- Gamma submenu -->
                                         <child>
                                             <object class="GtkMenuItem" id="gamma_menu">
-                                                <property name="label">󰃝&#x2002;Gamma</property>
+                                                <property name="label">󰃝&#x2003;Gamma</property>
                                                 <child type="submenu">
                                                     <object class="GtkMenu">
 
@@ -391,7 +391,7 @@
                         <!-- Shaders direct item -->
                         <child>
                             <object class="GtkMenuItem" id="shaders-select">
-                                <property name="label">&#x2002;Shaders</property>
+                                <property name="label">&#x2003;Shaders</property>
                             </object>
                         </child>
 
@@ -408,13 +408,13 @@
 
         <child>
             <object class="GtkMenuItem" id="keybinds-hint">
-                <property name="label">&#x2002;Keybinds</property>
+                <property name="label">&#x2003;Keybinds</property>
             </object>
         </child>
 
         <child>
             <object class="GtkMenuItem" id="about-hyde">
-                <property name="label">&#x2002;About</property>
+                <property name="label">&#x2003;About</property>
             </object>
         </child>
 

--- a/Configs/.local/share/waybar/styles/macos.css
+++ b/Configs/.local/share/waybar/styles/macos.css
@@ -1,46 +1,56 @@
+/* Waybar cannot adapt labels to wallpaper luminance, so use a neutral regular material. */
+@define-color macos-bar-surface rgba(28, 28, 30, 0.88);
+@define-color macos-elevated-surface rgba(44, 44, 46, 0.98);
+@define-color macos-label #F5F5F7;
+@define-color macos-secondary-label #AEAEB2;
+@define-color macos-separator rgba(255, 255, 255, 0.18);
+@define-color macos-accent #0066CC;
+
 * {
     border: none;
     border-radius: 0;
-    font-family: "SF Pro Text", "SF Pro Display", sans-serif;
+    font-family: "SF Pro Text", "Noto Sans", sans-serif;
     font-size: 13px;
+    font-weight: 400;
     min-height: 0;
 }
 
 window#waybar {
-    background-color: alpha(@wallbash_pry1, 0.88);
-    color: @wallbash_txt1;
+    border-bottom: 1px solid @macos-separator;
+    background-color: @macos-bar-surface;
+    color: @macos-label;
 }
 
 .modules-left,
 .modules-center,
 .modules-right {
-    padding: 0 8px;
+    padding: 0 7px;
 }
 
 .module {
     margin: 0;
-    padding: 0 6px;
-    color: @wallbash_txt1;
+    padding: 0 5px;
+    color: @macos-label;
 }
 
 #custom-launcher {
-    padding: 0 8px 0 4px;
-    font-size: 17px;
+    padding: 0 8px 0 3px;
+    font-size: 16px;
 }
 
 #window {
-    padding: 0 9px 0 4px;
+    padding: 0 8px 0 4px;
     font-weight: 600;
 }
 
 #custom-text,
 #custom-help {
-    padding: 0 7px;
+    padding: 0 6px;
 }
 
 #clock {
-    padding-right: 4px;
-    font-weight: 600;
+    padding-right: 3px;
+    font-weight: 500;
 }
 
 #tray {
@@ -53,6 +63,11 @@ window#waybar {
 
 #tray > .needs-attention {
     -gtk-icon-effect: highlight;
+}
+
+#network.disconnected,
+#pulseaudio.muted {
+    color: @macos-secondary-label;
 }
 
 #workspaces,
@@ -78,31 +93,37 @@ window#waybar {
 button {
     margin: 3px 1px;
     padding: 0 6px;
-    color: @wallbash_txt1;
     background: transparent;
     box-shadow: none;
+    color: @macos-label;
     text-shadow: none;
-    transition: background-color 100ms ease-out;
+    transition: background-color 120ms ease-out;
 }
 
 button:hover,
 .module:hover {
     border-radius: 5px;
-    background-color: alpha(@wallbash_txt1, 0.16);
+    background-color: alpha(@macos-label, 0.14);
+}
+
+button:focus,
+menu menuitem:focus {
+    box-shadow: inset 0 0 0 1px @macos-accent;
 }
 
 #workspaces button.active,
 #taskbar button.active {
     border-radius: 5px;
-    background-color: alpha(@wallbash_txt1, 0.24);
+    background-color: @macos-accent;
+    color: @macos-label;
 }
 
 tooltip,
 menu {
-    border: 1px solid alpha(@main-fg, 0.24);
-    border-radius: 8px;
-    background-color: @main-bg;
-    color: @main-fg;
+    border: 1px solid @macos-separator;
+    border-radius: 10px;
+    background-color: @macos-elevated-surface;
+    color: @macos-label;
 }
 
 tooltip * {
@@ -110,17 +131,21 @@ tooltip * {
 }
 
 menu menuitem {
-    padding: 5px 10px;
-    color: @main-fg;
+    min-height: 20px;
+    padding: 4px 12px;
+    color: @macos-label;
     transition: background-color 100ms ease-out;
 }
 
 menu menuitem:hover {
-    background-color: alpha(@main-fg, 0.16);
+    border-radius: 5px;
+    background-color: @macos-accent;
+    color: @macos-label;
 }
 
 #tray menu separator {
     min-height: 1px;
+    background-color: @macos-separator;
 }
 
 #tray menu menuitem check,

--- a/Configs/.local/share/waybar/styles/macos.css
+++ b/Configs/.local/share/waybar/styles/macos.css
@@ -1,88 +1,130 @@
 * {
-    font-family: "SF Pro Display", sans-serif;
-    /* background: transparent; */
-    /* background-color: transparent; */
+    border: none;
+    border-radius: 0;
+    font-family: "SF Pro Text", "SF Pro Display", sans-serif;
+    font-size: 13px;
+    min-height: 0;
 }
 
-#waybar {
-    background-color: @bar-bg;
-    /* border-bottom: 0.01 solid #000000; */
-    padding: 0em;
-    margin: 0em;
-    background: rgba(0, 0, 0, 0.4);
+window#waybar {
+    background-color: alpha(@wallbash_pry1, 0.88);
+    color: @wallbash_txt1;
 }
 
-#clock,
-#network,
-#pulseaudio,
-#cpu,
-#memory,
-#temperature {
-    padding: 1em;
-    color: white;
+.modules-left,
+.modules-center,
+.modules-right {
+    padding: 0 8px;
 }
 
-#network,
-#pulseaudio,
-#memory,
-#temperature {
-    border-right: 0.01 solid #444444;
-}
-
-#clock {
-    /* font-weight: 700; */
-    /* font-size: 1em; */
-}
-
-#window {
-    padding: 0 0.5em;
-    /* font-weight: 600; */
-}
-
-#battery {
-    color: white;
-    background: white;
-    border-radius: 10.5em;
-    margin: 0.5em;
-    padding: 0.21 1em;
+.module {
+    margin: 0;
+    padding: 0 6px;
+    color: @wallbash_txt1;
 }
 
 #custom-launcher {
-    color: white;
-    padding: 0 0.20em 0 1.31em;
-    /* font-size: 0.23em; */
+    padding: 0 8px 0 4px;
+    font-size: 17px;
 }
 
-#custom-text {
-
-    padding-left: 0.01;
-    /* font-weight: 600; */
+#window {
+    padding: 0 9px 0 4px;
+    font-weight: 600;
 }
 
-#custom-text {
-    /* font-size: 1.31em; */
-    padding-left: 0.20em;
-    color: white;
+#custom-text,
+#custom-help {
+    padding: 0 7px;
 }
 
-#image.ethernetart {
-    color: white;
+#clock {
+    padding-right: 4px;
+    font-weight: 600;
 }
 
-#custom-date {
-    color: white;
-    /* font-size: 1.31em; */
-    /* font-weight: 700; */
+#tray {
+    padding: 0 4px;
 }
 
-tooltip {
+#tray > .passive {
+    -gtk-icon-effect: dim;
+}
+
+#tray > .needs-attention {
+    -gtk-icon-effect: highlight;
+}
+
+#workspaces,
+#taskbar,
+#leaf,
+#leaf-inverse,
+#leaf-up,
+#leaf-down,
+#leaf-right,
+#leaf-left,
+#pill,
+#pill-right,
+#pill-left,
+#pill-down,
+#pill-up,
+#pill-in,
+#pill-out {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+}
+
+button {
+    margin: 3px 1px;
+    padding: 0 6px;
+    color: @wallbash_txt1;
+    background: transparent;
+    box-shadow: none;
+    text-shadow: none;
+    transition: background-color 100ms ease-out;
+}
+
+button:hover,
+.module:hover {
+    border-radius: 5px;
+    background-color: alpha(@wallbash_txt1, 0.16);
+}
+
+#workspaces button.active,
+#taskbar button.active {
+    border-radius: 5px;
+    background-color: alpha(@wallbash_txt1, 0.24);
+}
+
+tooltip,
+menu {
+    border: 1px solid alpha(@main-fg, 0.24);
+    border-radius: 8px;
     background-color: @main-bg;
     color: @main-fg;
-    border-radius: 0.5em;
-    padding: 0.5em;
-    /* font-size: 1.21em; */
 }
 
-#language {
-    min-width: 1.11em;
+tooltip * {
+    background: transparent;
+}
+
+menu menuitem {
+    padding: 5px 10px;
+    color: @main-fg;
+    transition: background-color 100ms ease-out;
+}
+
+menu menuitem:hover {
+    background-color: alpha(@main-fg, 0.16);
+}
+
+#tray menu separator {
+    min-height: 1px;
+}
+
+#tray menu menuitem check,
+#tray menu menuitem radio {
+    min-width: 14px;
+    min-height: 14px;
 }

--- a/tests/test_waybar_theme_layout.sh
+++ b/tests/test_waybar_theme_layout.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env sh
+# Exercise theme lookup, layout selection and CSS generation without a desktop.
+set -eu
+REPO_ROOT=${REPO_ROOT:-$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)}
+export REPO_ROOT
+python3 - <<'PY'
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from unittest.mock import patch
+
+root = Path(os.environ["REPO_ROOT"])
+lib = root / "Configs/.local/lib/hyde"
+sys.path.insert(0, str(lib))
+
+with tempfile.TemporaryDirectory() as tmp:
+    base = Path(tmp)
+    for kind in ("CONFIG", "STATE", "CACHE", "RUNTIME", "DATA"):
+        os.environ[f"XDG_{kind}_HOME" if kind != "RUNTIME" else "XDG_RUNTIME_DIR"] = str(base / kind)
+    config = base / "CONFIG/waybar"
+    config.mkdir(parents=True)
+    themes = base / "CONFIG/hyde/themes"
+    theme = themes / "Mac OS/hypr.theme"
+    theme.parent.mkdir(parents=True)
+    theme.write_text("$WAYBAR_LAYOUT = macos\n")
+    layouts = config / "layouts"
+    styles = config / "styles"
+    layouts.mkdir()
+    styles.mkdir()
+    for name in ("default", "macos", "other"):
+        (layouts / f"{name}.jsonc").write_text('{"name": "' + name + '"}\n')
+        (styles / f"{name}.css").write_text(f"/* {name} */\n")
+    (styles / "custom.css").write_text("/* separately selected style */\n")
+    (config / "theme.css").touch()
+
+    spec = importlib.util.spec_from_file_location("waybar", lib / "waybar.py")
+    waybar = importlib.util.module_from_spec(spec)
+    with patch("shutil.which", return_value="/usr/bin/waybar"):
+        spec.loader.exec_module(waybar)
+
+    def hyq(args, **kwargs):
+        # A quoted argv path would not exist: regression for "Mac OS".
+        assert args[0] == "hyq", args
+        content = Path(args[1]).read_text()
+        value = content.partition("=")[2].strip() if args[-1] == "$WAYBAR_LAYOUT" else ""
+        return subprocess.CompletedProcess(args, 0, value, "")
+
+    def select(name):
+        waybar.set_state_value("WAYBAR_LAYOUT_PATH", layouts / f"{name}.jsonc")
+        waybar.set_state_value("WAYBAR_LAYOUT_NAME", name)
+        waybar.set_state_value("WAYBAR_STYLE_PATH", styles / f"{name}.css")
+        (config / "config.jsonc").write_text((layouts / f"{name}.jsonc").read_text())
+
+    # Stub desktop effects, retaining actual state, layout lookup and CSS writes.
+    with patch.object(waybar, "source_env_file"), \
+         patch.object(waybar, "update_icon_size"), \
+         patch.object(waybar, "update_border_radius"), \
+         patch.object(waybar, "update_global_css"), \
+         patch.object(waybar, "restart_waybar"), \
+         patch.object(waybar.notify, "send"), \
+         patch.object(waybar.subprocess, "run", side_effect=hyq), \
+         patch.object(sys, "argv", ["waybar.py", "--update"]):
+        select("default")
+        waybar.set_state_value("WAYBAR_STYLE_PATH", styles / "custom.css")
+        waybar.set_state_value("HYDE_THEME", "Mac OS")
+        waybar.main()
+        assert waybar.get_state_value("WAYBAR_LAYOUT_NAME") == "macos"
+        assert (config / "config.jsonc").read_text() == (layouts / "macos.jsonc").read_text()
+        assert f'@import "{styles / "macos.css"}";' in (config / "style.css").read_text()
+        waybar.main()  # Reapplying the theme must keep the same pair.
+        assert waybar.get_state_value("WAYBAR_LAYOUT_NAME") == "macos"
+
+        # A second theme preset must not overwrite the original saved pair.
+        theme.write_text("$WAYBAR_LAYOUT = other\n")
+        waybar.main()
+        assert waybar.get_state_value("WAYBAR_LAYOUT_NAME") == "other"
+        theme.write_text("# No preferred layout\n")
+        waybar.main()
+        assert waybar.get_state_value("WAYBAR_LAYOUT_NAME") == "default"
+        assert (config / "config.jsonc").read_text() == (layouts / "default.jsonc").read_text()
+        assert f'@import "{styles / "custom.css"}";' in (config / "style.css").read_text()
+        assert not waybar.get_state_value("WAYBAR_PRE_THEME_LAYOUT")
+        waybar.main()
+        assert f'@import "{styles / "custom.css"}";' in (config / "style.css").read_text()
+
+        # A new visit saves the user's new selection; unavailable presets leave it alone.
+        select("other")
+        theme.write_text("$WAYBAR_LAYOUT = missing\n")
+        waybar.main()
+        assert not waybar.get_state_value("WAYBAR_PRE_THEME_LAYOUT")
+        assert waybar.get_state_value("WAYBAR_LAYOUT_NAME") == "other"
+        theme.write_text("$WAYBAR_LAYOUT = macos\n")
+        waybar.main()
+        theme.write_text("# No preferred layout\n")
+        waybar.main()
+        assert waybar.get_state_value("WAYBAR_LAYOUT_NAME") == "other"
+        assert f'@import "{styles / "other.css"}";' in (config / "style.css").read_text()
+
+print("Theme round trips, custom CSS, repeated updates, preset chains and missing presets passed.")
+PY


### PR DESCRIPTION
## Description

Repair the macOS Waybar preset with a neutral translucent surface, accessible colors, visible hover/focus states, and wider icon-to-label spacing. Remove the wallpaper image module that can block reloads and the non-functional Go and Window labels.

Theme/color updates now honor an optional `$WAYBAR_LAYOUT` in `hypr.theme`. Selecting a theme preset applies its layout and matching CSS; leaving it restores the previous layout and independently selected stylesheet. Repeated updates and switches between presets preserve the original pair. Fix `hyq` argument handling for theme names containing spaces.

Companion PR: https://github.com/HyDE-Project/hyde-gallery/pull/128 declares `macos` for Mac OS; themes without a preset retain their existing selection.

## Type of change

- [x] Bug fix

## Testing

- `sh tests/run.sh waybar_theme_layout`: passed, including custom CSS restoration, repeated updates, preset chains and unavailable presets.
- Live-tested Code Garden → Mac OS → Code Garden; verified saved/restored state, generated layout and CSS imports.
- `git diff --check`: passed.
- Full suite: 50 cases, 2 failed in the sandbox. Pyprland socket test passes outside the sandbox. The unchanged gpuinfo test still fails, using host NVIDIA readings for simulated AMD cases outside the sandbox.
- `pre-commit` is not installed; its check could not run. Shellcheck is also unavailable.
- Previous preset validation: XML validated with xmllint; primary label contrast at least 10.91:1 over black/white wallpaper extremes.

Code comments, changelog and regression coverage are included. Screenshots have not been uploaded.
